### PR TITLE
Keccak the string and not directly the object

### DIFF
--- a/apps/remix-ide/src/app/tabs/runTab/model/recorder.js
+++ b/apps/remix-ide/src/app/tabs/runTab/model/recorder.js
@@ -26,7 +26,7 @@ class Recorder {
         var record = { value, parameters: payLoad.funArgs }
         if (!to) {
           var abi = payLoad.contractABI
-          var keccak = ethutil.bufferToHex(ethutil.keccak(abi))
+          var keccak = ethutil.bufferToHex(ethutil.keccak(JSON.stringify(abi)))
           record.abi = keccak
           record.contractName = payLoad.contractName
           record.bytecode = payLoad.contractBytecode


### PR DESCRIPTION
When doing `var keccak = ethutil.bufferToHex(ethutil.keccak(abi))`, `keccak` keep being the same even though abis were different.

e2e test track: https://github.com/ethereum/remix-project/issues/524