### PR TITLE
docker-compose build fix

### DIFF
--- a/apps/remix-ide/ci/build_and_publish_docker_images.sh
+++ b/apps/remix-ide/ci/build_and_publish_docker_images.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 
-export TAG="$CIRCLE_BRANCH"
-
-if [ "$CIRCLE_BRANCH" == "master" ]; then
+if [ "$CIRCLE_BRANCH" == "master" ]; 
+then
     export TAG="latest";
+else
+    export TAG=$(sed 's/#/-/g' <<< $CIRCLE_BRANCH)
 fi
 
 docker login --username $DOCKER_USER --password $DOCKER_PASS


### PR DESCRIPTION
This small change fixes those failed docker-compose builds that have happened for branches that included character "#" in their name which is illegal character when tagging docker image.

This change will replace every "#" character with dash character and solve the issue.
https://github.com/ethereum/remix-project/issues/515