### PR TITLE
feat(remix-tests): add optimization flag to CLI

### DIFF
--- a/libs/remix-tests/src/compiler.ts
+++ b/libs/remix-tests/src/compiler.ts
@@ -85,7 +85,7 @@ const isBrowser = !(typeof (window) === 'undefined' || userAgent.indexOf(' elect
  * TODO: replace this with remix's own compiler code
  */
 
-export function compileFileOrFiles(filename: string, isDirectory: boolean, opts: any, cb): void {
+export function compileFileOrFiles(filename: string, isDirectory: boolean, opts: any, compilerConfig: CompilerConfiguration, cb): void {
     let compiler: any
     const accounts: string[] = opts.accounts || []
     const sources: SrcIfc = {
@@ -125,7 +125,11 @@ export function compileFileOrFiles(filename: string, isDirectory: boolean, opts:
     } finally {
         async.waterfall([
             function loadCompiler(next) {
+                const {currentCompilerUrl, evmVersion, optimize, usingWorker} = compilerConfig
                 compiler = new RemixCompiler()
+                compiler.set('evmVersion', evmVersion)
+                compiler.set('optimize', optimize)
+                // compiler.loadVersion(usingWorker, currentCompilerUrl)
                 compiler.onInternalCompilerLoaded()
                 // compiler.event.register('compilerLoaded', this, function (version) {
                 next()

--- a/libs/remix-tests/src/run.ts
+++ b/libs/remix-tests/src/run.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import { runTestFiles } from './runTestFiles'
 import fs from './fileSystem'
 import { Provider } from '@remix-project/remix-simulator'
+import { CompilerConfiguration } from './types'
 import Log from './logger'
 const logger = new Log()
 const log = logger.logger
@@ -21,6 +22,15 @@ function mapVerbosity (v: number) {
     }
     return levels[v]
 }
+
+function mapOptimize (v: string) {
+        const optimize = {
+                'true': true,
+                'false': false
+        }
+        return optimize[v];
+}
+
 const version = require('../package.json').version
 
 commander.version(version)
@@ -36,6 +46,7 @@ commander.command('help').description('output usage information').action(functio
 // get current version
 commander
     .option('-v, --verbose <level>', 'run with verbosity', mapVerbosity)
+    .option('-o, --optimize <bool>', 'run compiler optimization', mapOptimize)
     .action(async (testsPath) => {
 
         // Check if path exists
@@ -67,7 +78,13 @@ commander
         await provider.init()
         web3.setProvider(provider)
 
-        runTestFiles(path.resolve(testsPath), isDirectory, web3)
+        const compilerConfig = {} as CompilerConfiguration
+        if (commander.optimize) {
+                compilerConfig.optimize = commander.optimize
+                log.info('compiler optimization set to ' + compilerConfig.optimize)
+        }
+
+        runTestFiles(path.resolve(testsPath), isDirectory, web3, compilerConfig)
     })
 
 if (!process.argv.slice(2).length) {

--- a/libs/remix-tests/src/runTestFiles.ts
+++ b/libs/remix-tests/src/runTestFiles.ts
@@ -1,7 +1,7 @@
 import async from 'async'
 import fs from './fileSystem'
 import { runTest } from './testRunner'
-import { TestResultInterface, ResultsInterface, compilationInterface, ASTInterface, Options, AstNode } from './types'
+import { TestResultInterface, ResultsInterface, CompilerConfiguration, compilationInterface, ASTInterface, Options, AstNode } from './types'
 import colors from 'colors'
 import Web3 from 'web3';
 
@@ -18,8 +18,9 @@ import { deployAll } from './deployer'
  */
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-export function runTestFiles(filepath: string, isDirectory: boolean, web3: Web3, finalCallback: any = () => {}, opts?: Options) {
+export function runTestFiles(filepath: string, isDirectory: boolean, web3: Web3, compilerConfig: CompilerConfiguration, finalCallback: any = () => {}, opts?: Options) {
     opts = opts || {}
+    compilerConfig = compilerConfig || {} as CompilerConfiguration
     const sourceASTs: any = {}
     const { Signale } = require('signale')
     // signale configuration
@@ -53,7 +54,7 @@ export function runTestFiles(filepath: string, isDirectory: boolean, web3: Web3,
             })
         },
         function compile(next) {
-            compileFileOrFiles(filepath, isDirectory, { accounts }, next)
+            compileFileOrFiles(filepath, isDirectory, { accounts }, compilerConfig, next)
         },
         function deployAllContracts (compilationResult: compilationInterface, asts: ASTInterface, next) {
             // Extract AST of test contract file source


### PR DESCRIPTION
Adds an optimize flag to the commander CLI config which generates a
CompilerConfiguration object and passes it down the line to the
compiler optionally.

Running tests on a larger contract without optimization causes it to complain about gas and fail.

running without optimize:
```
$ remix-tests /tests/test  

        👁       :: Running remix-tests - Unit testing for solidity ::   👁

[18:59:41] info: 1 Solidity test file found
'creation of library remix_accounts.sol:TestsAccounts pending...'
'creation of library remix_tests.sol:Assert pending...'
Error: The contract code couldn't be stored, please check your gas limit.
...
```

running with optimize:
```
$ remix-tests --optimize true /tests/test

        👁       :: Running remix-tests - Unit testing for solidity ::   👁

[18:54:48] info: compiler optimization set to undefined
[18:54:48] info: 1 Solidity test file found
'creation of library remix_accounts.sol:TestsAccounts pending...'
'creation of library remix_tests.sol:Assert pending...'

        ◼  Test
        ✓  Test yy owner
        ✓  Test xx roles


2 passing (0.762s)

```

Fixes #540 