### PR TITLE
Listen to the optimism compiler

### DIFF
--- a/apps/remix-ide/src/app/compiler/compiler-artefacts.js
+++ b/apps/remix-ide/src/app/compiler/compiler-artefacts.js
@@ -46,6 +46,11 @@ module.exports = class CompilerArtefacts extends Plugin {
       this.compilersArtefacts.__last = new CompilerAbstract(languageVersion, data, source)
       saveCompilationPerFileResult(file, source, languageVersion, data)
     })
+
+    this.on('optimism-compiler', 'compilationFinished', (file, source, languageVersion, data) => {
+      this.compilersArtefacts.__last = new CompilerAbstract(languageVersion, data, source)
+      saveCompilationPerFileResult(file, source, languageVersion, data)
+    })
   }
 
   getAllContractDatas () {

--- a/apps/remix-ide/src/app/tabs/runTab/model/dropdownlogic.js
+++ b/apps/remix-ide/src/app/tabs/runTab/model/dropdownlogic.js
@@ -37,6 +37,9 @@ class DropdownLogic {
     this.runView.on('yulp', 'compilationFinished', (file, source, languageVersion, data) =>
       broadcastCompilationResult(file, source, languageVersion, data)
     )
+    this.runView.on('optimism-compiler', 'compilationFinished', (file, source, languageVersion, data) =>
+      broadcastCompilationResult(file, source, languageVersion, data)
+    )
   }
 
   loadContractFromAddress (address, confirmCb, cb) {


### PR DESCRIPTION
Allow to listen on the optimism compiler plugin , which should be added soon to the directory https://github.com/ethereum/remix-plugins-directory/pull/183
So we can display the contract and deploy it from the run tab