### PR TITLE
nx deps updated

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -32,7 +32,7 @@
     },
     "remix-debug": {
       "tags": [],
-      "implicitDependencies": ["remix-lib"]
+      "implicitDependencies": ["remix-astwalker", "remix-lib"]
     },
     "remix-simulator": {
       "tags": [],
@@ -57,7 +57,9 @@
         "remix-lib",
         "remix-simulator",
         "remix-solidity",
-        "remix-tests"
+        "remix-tests",
+        "remix-astwalker",
+        "remix-url-resolver"
       ]
     },
     "remix-ide-e2e": {


### PR DESCRIPTION
This should be merged after https://github.com/ethereum/remix-project/pull/690 as `remix-url-resolver` becomes dep of `remix-ide` in that PR