### PR TITLE
Capitalize

### DIFF
--- a/apps/remix-ide/src/app/components/plugin-manager-component.js
+++ b/apps/remix-ide/src/app/components/plugin-manager-component.js
@@ -39,7 +39,6 @@ const css = csjs`
   .description {
     font-size: 13px;
     line-height: 18px;
-    text-transform: capitalize;
   }
   .row {
     display: flex;


### PR DESCRIPTION
Capitalization in plugin descriptions leads to weird results like 'Checks The Contract Code For Security Vulnerabilities And Bad Practices.' Maybe it's better just to keep the profiles up to date?