### PR TITLE
the file removed event is blocked

### DIFF
--- a/apps/remix-ide/src/app/files/fileManager.js
+++ b/apps/remix-ide/src/app/files/fileManager.js
@@ -424,15 +424,15 @@ class FileManager extends Plugin {
   }
 
   fileRemovedEvent (path) {
+    // TODO: Only keep `this.emit` (issue#2210)
+    this.emit('fileRemoved', path)
+    this.events.emit('fileRemoved', path)
     if (!this.openedFiles[path]) return
     if (path === this._deps.config.get('currentFile')) {
       this._deps.config.set('currentFile', '')
     }
     this.editor.discard(path)
     delete this.openedFiles[path]
-    // TODO: Only keep `this.emit` (issue#2210)
-    this.emit('fileRemoved', path)
-    this.events.emit('fileRemoved', path)
     this.openFile()
   }
 


### PR DESCRIPTION
The file removed event will not be emitted if the file is deleted when it is not opened. This happens for example when you right click on the file without first openening it.