### PR TITLE
Do not shorten hex data when it's exactly the same length

### DIFF
--- a/apps/remix-ide/src/lib/helper.js
+++ b/apps/remix-ide/src/lib/helper.js
@@ -18,9 +18,10 @@ export default  {
   },
   shortenHexData: function (data) {
     if (!data) return ''
-    if (data.length < 5) return data
+    var sliceLen = 5
     var len = data.length
-    return data.slice(0, 5) + '...' + data.slice(len - 5, len)
+    if (len < sliceLen * 2) return data
+    return data.slice(0, sliceLen) + '...' + data.slice(len - sliceLen, len)
   },
   createNonClashingNameWithPrefix (name, fileProvider, prefix, cb) {
     if (!name) name = 'Undefined'


### PR DESCRIPTION
Right now when `shortenHexData` receives `0xb8368615` it trims that to `0xb83...68615` that's kinda misleading.

![image](https://user-images.githubusercontent.com/7031578/106394103-24300500-63fb-11eb-95a4-9fc5b112570b.png)
 