### PR TITLE
current folder changed

### DIFF
--- a/apps/remix-ide/src/app.js
+++ b/apps/remix-ide/src/app.js
@@ -391,6 +391,10 @@ Please make a backup of your contracts and start using http://remix.ethereum.org
     filePanel.gitHandle
   ])
 
+  if (isElectron()) {
+    appManager.activatePlugin('remixd')
+  }
+
   try {
     engine.register(await appManager.registeredPlugins())
   } catch (e) {
@@ -453,10 +457,6 @@ Please make a backup of your contracts and start using http://remix.ethereum.org
         }
       }
     })
-  }
-
-  if (isElectron()) {
-    appManager.activatePlugin('remixd')
   }
 
   if (params.embed) framingService.embed()

--- a/apps/remix-ide/src/app/files/remixDProvider.js
+++ b/apps/remix-ide/src/app/files/remixDProvider.js
@@ -41,6 +41,10 @@ module.exports = class RemixDProvider {
     this._appManager.on('remixd', 'fileRenamed', (oldPath, newPath) => {
       this.event.trigger('fileRemoved', [this.addPrefix(oldPath), this.addPrefix(newPath)])
     })
+
+    this._appManager.on('remixd', 'rootFolderChanged', () => {
+      this.event.trigger('rootFolderChanged', [])
+    })
   }
 
   isConnected () {

--- a/libs/remix-ui/file-explorer/src/lib/file-explorer.tsx
+++ b/libs/remix-ui/file-explorer/src/lib/file-explorer.tsx
@@ -127,6 +127,7 @@ export const FileExplorer = (props: FileExplorerProps) => {
     if (state.fileManager) {
       filesProvider.event.register('fileExternallyChanged', fileExternallyChanged)
       filesProvider.event.register('fileRenamedError', fileRenamedError)
+      filesProvider.event.register('rootFolderChanged', rootFolderChanged)
     }
   }, [state.fileManager])
 
@@ -480,6 +481,15 @@ export const FileExplorer = (props: FileExplorerProps) => {
       label: 'Close',
       fn: () => {}
     }, null)
+  }
+
+  // register to event of the file provider
+  // files.event.register('rootFolderChanged', rootFolderChanged)
+  const rootFolderChanged = async () => {
+    const files = await fetchDirectoryContent(name)
+    setState(prevState => {
+      return { ...prevState, files }
+    })
   }
 
   const uploadFile = (target) => {

--- a/libs/remixd/src/index.ts
+++ b/libs/remixd/src/index.ts
@@ -1,5 +1,6 @@
 'use strict'
 import { RemixdClient as sharedFolder } from './services/remixdClient'
+import { GitClient } from './services/gitClient'
 import Websocket from './websocket'
 import * as utils from './utils'
 
@@ -7,6 +8,7 @@ module.exports = {
   Websocket,
   utils,
   services: {
-    sharedFolder
+    sharedFolder,
+    GitClient
   }
 }

--- a/libs/remixd/src/services/remixdClient.ts
+++ b/libs/remixd/src/services/remixdClient.ts
@@ -20,6 +20,7 @@ export class RemixdClient extends PluginClient {
   sharedFolder (currentSharedFolder: string, readOnly: boolean): void {
     this.currentSharedFolder = currentSharedFolder
     this.readOnly = readOnly
+    if (this.isLoaded) this.emit('rootFolderChanged')
   }
 
   list (): Filelist {


### PR DESCRIPTION
This fix remix-desktop working with remixd.
remixd should trigger an event when the shared folder has been changed (allowed by remix-desktop), so the UI can adapt.
see remix-desktop PR: https://github.com/ethereum/remix-desktop/pull/35