### PR TITLE
alert user when full while migrating

### DIFF
--- a/apps/remix-ide/src/migrateFileSystem.js
+++ b/apps/remix-ide/src/migrateFileSystem.js
@@ -1,6 +1,6 @@
 import { Storage } from '@remix-project/remix-lib'
 import { joinPath } from './lib/helper'
-
+var modalDialogCustom = require('./app/ui/modal-dialog-custom')
 /*
   Migrating the files to the BrowserFS storage instead or raw localstorage
 */
@@ -53,7 +53,11 @@ const populateWorkspace = async (workspace, json, browserProvider) => {
       browserProvider.createDir(joinPath(workspace, item))
       await populateWorkspace(workspace, json[item].children, browserProvider)
     } else {
-      await browserProvider.set(joinPath(workspace, item), json[item].content)
+      await browserProvider.set(joinPath(workspace, item), json[item].content, (err) => {
+        if (err && err.message) {
+          modalDialogCustom.alert(`There was an error migrating your files: ${err.message}`)
+        }
+      })
     }
   }
 }

--- a/apps/remix-ide/src/migrateFileSystem.js
+++ b/apps/remix-ide/src/migrateFileSystem.js
@@ -1,6 +1,6 @@
 import { Storage } from '@remix-project/remix-lib'
 import { joinPath } from './lib/helper'
-var modalDialogCustom = require('./app/ui/modal-dialog-custom')
+const modalDialogCustom = require('./app/ui/modal-dialog-custom')
 /*
   Migrating the files to the BrowserFS storage instead or raw localstorage
 */


### PR DESCRIPTION
test it by doing this a couple of times in your console
```
  let r = await fetch('https://raw.githubusercontent.com/ethereum/remix-project/179c9634fb7469d9799a93de6b7dfa4aabc982ed/package-lock.json')
  window.remixFileSystem.writeFileSync(`${Date.now()}.json`, await r.text())
```

it will fill up the storage, after 2 times or so. then run the migration.

this will give you how much is used, after 9mb it starts to fail

```
var _lsTotal=0,_xLen,_x;for(_x in localStorage){ if(!localStorage.hasOwnProperty(_x)){continue;} _xLen= ((localStorage[_x].length + _x.length)* 2);_lsTotal+=_xLen; console.log(_x.substr(0,50)+" = "+ (_xLen/1024).toFixed(2)+" KB")};console.log("Total = " + (_lsTotal / 1024).toFixed(2) + " KB");

```
