### PR TITLE
Use binaries.soliditylang.org instead of solc-bin

### DIFF
--- a/apps/remix-ide/manifest.json
+++ b/apps/remix-ide/manifest.json
@@ -27,5 +27,5 @@
     "<all_urls>"
   ],
 
-  "content_security_policy": "script-src 'self' https://solc-bin.ethereum.org/; object-src 'self'"
+  "content_security_policy": "script-src 'self' https://binaries.soliditylang.org/; object-src 'self'"
 }

--- a/apps/remix-ide/src/app/compiler/compiler-utils.js
+++ b/apps/remix-ide/src/app/compiler/compiler-utils.js
@@ -2,8 +2,8 @@ const semver = require('semver')
 const minixhr = require('minixhr')
 /* global Worker */
 
-export const baseURLBin = 'https://solc-bin.ethereum.org/bin'
-export const baseURLWasm = 'https://solc-bin.ethereum.org/wasm'
+export const baseURLBin = 'https://binaries.soliditylang.org/bin'
+export const baseURLWasm = 'https://binaries.soliditylang.org/wasm'
 
 export const pathToURL = {}
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "bumpVersion:libs": "gulp & gulp syncLibVersions;",
     "browsertest": "sleep 5 && npm run nightwatch_local",
     "csslint": "csslint --ignore=order-alphabetical --errors='errors,duplicate-properties,empty-rules' --exclude-list='apps/remix-ide/src/assets/css/font-awesome.min.css' apps/remix-ide/src/assets/css/",
-    "downloadsolc_assets": "wget --no-check-certificate https://solc-bin.ethereum.org/bin/soljson-v0.8.1+commit.df193b15.js -O ./apps/remix-ide/src/assets/js/soljson.js",
+    "downloadsolc_assets": "wget --no-check-certificate https://binaries.soliditylang.org/bin/soljson-v0.8.1+commit.df193b15.js -O ./apps/remix-ide/src/assets/js/soljson.js",
     "make-mock-compiler": "node apps/remix-ide/ci/makeMockCompiler.js",
     "minify": "uglifyjs --in-source-map inline --source-map-inline -c warnings=false",
     "nightwatch_parallel": "npm run build:e2e && nightwatch --config dist/apps/remix-ide-e2e/nightwatch.js --env=chrome,firefox",


### PR DESCRIPTION
While solc-bin.ethereum.org should continue working, binaries.soliditylang.org is the preferred URL.

It also seems that `ethereum.github.io` is still used, which should not be as it is not updated. It is present in some seemingly generated code:
```
./apps/remix-ide/src/assets/js/0.7.7/app.js:      var url = 'https://ethereum.github.io/solc-bin/bin/soljson-' + versionString + '.js';
./apps/remix-ide/src/assets/js/0.7.7/app.js:      baseurl: 'https://solc-bin.ethereum.org/bin'
```

I am not sure what is the source of these.