### PR TITLE
Allow multiple pasting of files and folders with non-clashing names.

### DIFF
--- a/apps/remix-ide-e2e/src/tests/fileManager_api.spec.ts
+++ b/apps/remix-ide-e2e/src/tests/fileManager_api.spec.ts
@@ -147,8 +147,8 @@ const executeReadFile = `
 
 const executeCopyFile = `
   const run = async () => {
-    await remix.call('fileManager', 'copyFile', 'contracts/3_Ballot.sol', '/', 'new_contract.sol')
-    const result = await remix.call('fileManager', 'readFile', 'new_contract.sol')
+    await remix.call('fileManager', 'copyFile', 'contracts/3_Ballot.sol', '/', 'copy_contract.sol')
+    const result = await remix.call('fileManager', 'readFile', 'copy_contract.sol')
 
     console.log(result)
   }

--- a/apps/remix-ide/src/app/files/fileManager.js
+++ b/apps/remix-ide/src/app/files/fileManager.js
@@ -222,9 +222,10 @@ class FileManager extends Plugin {
       await this._handleExists(dest, `Cannot paste content into ${dest}. Path does not exist.`)
       await this._handleIsDir(dest, `Cannot paste content into ${dest}. Path is not directory.`)
       const content = await this.readFile(src)
-      const copiedFileName = customName ? '/' + customName : '/' + `Copy_${helper.extractNameFromKey(src)}`
+      let copiedFilePath = dest + (customName ? '/' + customName : '/' + `Copy_${helper.extractNameFromKey(src)}`)
+      copiedFilePath = await helper.createNonClashingNameAsync(copiedFilePath, this)
 
-      await this.writeFile(dest + copiedFileName, content)
+      await this.writeFile(copiedFilePath, content)
     } catch (e) {
       throw new Error(e)
     }
@@ -252,7 +253,8 @@ class FileManager extends Plugin {
 
   async inDepthCopy (src, dest, count = 0) {
     const content = await this.readdir(src)
-    const copiedFolderPath = count === 0 ? dest + '/' + `Copy_${helper.extractNameFromKey(src)}` : dest + '/' + helper.extractNameFromKey(src)
+    let copiedFolderPath = count === 0 ? dest + '/' + `Copy_${helper.extractNameFromKey(src)}` : dest + '/' + helper.extractNameFromKey(src)
+    copiedFolderPath = await helper.createNonClashingDirNameAsync(copiedFolderPath, this)
 
     await this.mkdir(copiedFolderPath)
 

--- a/apps/remix-ide/src/lib/helper.js
+++ b/apps/remix-ide/src/lib/helper.js
@@ -71,6 +71,20 @@ module.exports = {
 
     return name + counter + prefix + '.' + ext
   },
+  async createNonClashingDirNameAsync (name, fileManager) {
+    if (!name) name = 'Undefined'
+    let counter = ''
+    let exist = true
+
+    do {
+      const isDuplicate = await fileManager.exists(name + counter)
+
+      if (isDuplicate) counter = (counter | 0) + 1
+      else exist = false
+    } while (exist)
+
+    return name + counter
+  },
   checkSpecialChars (name) {
     return name.match(/[:*?"<>\\'|]/) != null
   },

--- a/libs/remix-ui/file-explorer/src/lib/file-explorer.tsx
+++ b/libs/remix-ui/file-explorer/src/lib/file-explorer.tsx
@@ -763,10 +763,6 @@ export const FileExplorer = (props: FileExplorerProps) => {
     state.copyElement.map(({ key, type }) => {
       type === 'file' ? copyFile(key, dest) : copyFolder(key, dest)
     })
-    setState(prevState => {
-      return { ...prevState, copyElement: [] }
-    })
-    setCanPaste(false)
   }
 
   const label = (file: File) => {


### PR DESCRIPTION
Fixes https://github.com/ethereum/remix-project/issues/1221