### PR TITLE
Make sure hex are 0x prefixed before using toBuffer

### DIFF
--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -1,5 +1,5 @@
 import Web3 from 'web3'
-import { toBuffer } from 'ethereumjs-util'
+import { toBuffer, addHexPrefix } from 'ethereumjs-util'
 import { waterfall } from 'async'
 import { EventEmitter } from 'events'
 import { ExecutionContext } from './execution-context'
@@ -479,7 +479,7 @@ class Blockchain {
         execResult = await this.web3().eth.getExecutionResultFromSimulator(txResult.transactionHash)
         if (execResult) {
           // if it's not the VM, we don't have return value. We only have the transaction, and it does not contain the return value.
-          returnValue = execResult ? execResult.returnValue : toBuffer(txResult.result || '0x0000000000000000000000000000000000000000000000000000000000000000')
+          returnValue = execResult ? execResult.returnValue : toBuffer(addHexPrefix(txResult.result) || '0x0000000000000000000000000000000000000000000000000000000000000000')
           const vmError = txExecution.checkVMError(execResult, args.data.contractABI)
           if (vmError.error) {
             return cb(vmError.message)
@@ -488,7 +488,7 @@ class Blockchain {
       }
 
       if (!isVM && tx && tx.useCall) {
-        returnValue = toBuffer(txResult.result)
+        returnValue = toBuffer(addHexPrefix(txResult.result))
       }
 
       let address = null

--- a/libs/remix-debug/src/solidity-decoder/types/Mapping.ts
+++ b/libs/remix-debug/src/solidity-decoder/types/Mapping.ts
@@ -1,7 +1,7 @@
 'use strict'
 import { RefType } from './RefType'
 import { normalizeHex } from './util'
-import { toBuffer, setLengthLeft, keccak, BN, bufferToHex } from 'ethereumjs-util'
+import { toBuffer, setLengthLeft, keccak, BN, bufferToHex, addHexPrefix } from 'ethereumjs-util'
 
 export class Mapping extends RefType {
   keyType
@@ -64,8 +64,8 @@ function getMappingLocation (key, position) {
   // > the value corresponding to a mapping key k is located at keccak256(k . p) where . is concatenation.
 
   // key should be a hex string, and position an int
-  const mappingK = toBuffer('0x' + key)
-  let mappingP = toBuffer(position)
+  const mappingK = toBuffer(addHexPrefix(key))
+  let mappingP = toBuffer(addHexPrefix(position))
   mappingP = setLengthLeft(mappingP, 32)
   const mappingKeyBuf = concatTypedArrays(mappingK, mappingP)
   const mappingStorageLocation: Buffer = keccak(mappingKeyBuf)

--- a/libs/remix-lib/src/execution/txListener.ts
+++ b/libs/remix-lib/src/execution/txListener.ts
@@ -1,7 +1,7 @@
 'use strict'
 import { each } from 'async'
 import { ethers } from 'ethers'
-import { toBuffer } from 'ethereumjs-util'
+import { toBuffer, addHexPrefix } from 'ethereumjs-util'
 import { EventManager } from '../eventManager'
 import { compareByteCode } from '../util'
 import { decodeResponse } from './txFormat'
@@ -68,7 +68,7 @@ export class TxListener {
         execResult = await this.executionContext.web3().eth.getExecutionResultFromSimulator(txResult.transactionHash)
         returnValue = execResult.returnValue
       } else {
-        returnValue = toBuffer(txResult.result)
+        returnValue = toBuffer(addHexPrefix(txResult.result))
       }
       const call = {
         from: from,
@@ -358,7 +358,7 @@ export class TxListener {
   }
 
   _decodeInputParams (data, abi) {
-    data = toBuffer('0x' + data)
+    data = toBuffer(addHexPrefix(data))
     if (!data.length) data = new Uint8Array(32 * abi.inputs.length) // ensuring the data is at least filled by 0 cause `AbiCoder` throws if there's not engouh data
 
     const inputTypes = []

--- a/libs/remix-lib/src/util.ts
+++ b/libs/remix-lib/src/util.ts
@@ -1,5 +1,5 @@
 'use strict'
-import { BN, bufferToHex, keccak, setLengthLeft, toBuffer } from 'ethereumjs-util'
+import { BN, bufferToHex, keccak, setLengthLeft, toBuffer, addHexPrefix } from 'ethereumjs-util'
 
 /*
  contains misc util: @TODO should be splitted
@@ -142,7 +142,7 @@ export function buildCallPath (index, rootCall) {
   */
 // eslint-disable-next-line camelcase
 export function sha3_256 (value) {
-  value = toBuffer(value)
+  value = toBuffer(addHexPrefix(value))
   const retInBuffer: Buffer = keccak(setLengthLeft(value, 32))
   return bufferToHex(retInBuffer)
 }


### PR DESCRIPTION
This issue was introduced during the update which led to using the latest ethereumjs-vm version.
`addHexPrefix` only modifies the input if it's a string, it is defined there: https://github.com/ethereumjs/ethereumjs-util/blob/ebf40a0fba8b00ba9acae58405bca4415e383a0d/src/bytes.ts#L204