### PR TITLE
fixes for deactivating hardhat

### DIFF
--- a/apps/remix-ide/src/app/files/remixd-handle.js
+++ b/apps/remix-ide/src/app/files/remixd-handle.js
@@ -31,9 +31,9 @@ const profile = {
 }
 
 export class RemixdHandle extends WebsocketPlugin {
-  constructor (locahostProvider, appManager) {
+  constructor (localhostProvider, appManager) {
     super(profile)
-    this.locahostProvider = locahostProvider
+    this.localhostProvider = localhostProvider
     this.appManager = appManager
   }
 
@@ -41,7 +41,7 @@ export class RemixdHandle extends WebsocketPlugin {
     if (super.socket) super.deactivate()
     // this.appManager.deactivatePlugin('git') // plugin call doesn't work.. see issue https://github.com/ethereum/remix-plugin/issues/342
     if (this.appManager.actives.includes('hardhat')) this.appManager.deactivatePlugin('hardhat')
-    this.locahostProvider.close((error) => {
+    this.localhostProvider.close((error) => {
       if (error) console.log(error)
     })
   }
@@ -82,11 +82,11 @@ export class RemixdHandle extends WebsocketPlugin {
             this.canceled()
           }
         }, 3000)
-        this.locahostProvider.init(() => {})
+        this.localhostProvider.init(() => {})
         this.call('manager', 'activatePlugin', 'hardhat')
       }
     }
-    if (this.locahostProvider.isConnected()) {
+    if (this.localhostProvider.isConnected()) {
       this.deactivate()
     } else if (!isElectron()) {
       // warn the user only if he/she is in the browser context
@@ -97,7 +97,7 @@ export class RemixdHandle extends WebsocketPlugin {
           label: 'Connect',
           fn: () => {
             try {
-              this.locahostProvider.preInit()
+              this.localhostProvider.preInit()
               super.activate()
               setTimeout(() => {
                 if (!this.socket || (this.socket && this.socket.readyState === 3)) { // 3 means connection closed

--- a/apps/remix-ide/src/app/files/remixd-handle.js
+++ b/apps/remix-ide/src/app/files/remixd-handle.js
@@ -40,7 +40,7 @@ export class RemixdHandle extends WebsocketPlugin {
   deactivate () {
     if (super.socket) super.deactivate()
     // this.appManager.deactivatePlugin('git') // plugin call doesn't work.. see issue https://github.com/ethereum/remix-plugin/issues/342
-    this.appManager.deactivatePlugin('hardhat')
+    if (this.appManager.actives.includes('hardhat')) this.appManager.deactivatePlugin('hardhat')
     this.locahostProvider.close((error) => {
       if (error) console.log(error)
     })

--- a/apps/remix-ide/src/app/files/remixd-handle.js
+++ b/apps/remix-ide/src/app/files/remixd-handle.js
@@ -53,7 +53,6 @@ export class RemixdHandle extends WebsocketPlugin {
   async canceled () {
     // await this.appManager.deactivatePlugin('git') // plugin call doesn't work.. see issue https://github.com/ethereum/remix-plugin/issues/342
     await this.appManager.deactivatePlugin('remixd')
-    await this.appManager.deactivatePlugin('hardhat')
   }
 
   /**

--- a/apps/remix-ide/src/remixAppManager.js
+++ b/apps/remix-ide/src/remixAppManager.js
@@ -53,6 +53,8 @@ export class RemixAppManager extends PluginManager {
   }
 
   async deactivatePlugin (name) {
+    const isActive = await this.isActive(name)
+    if (!isActive) return
     const [to, from] = [
       await this.getProfile(name),
       await this.getProfile(this.requestFrom)

--- a/apps/remix-ide/src/remixAppManager.js
+++ b/apps/remix-ide/src/remixAppManager.js
@@ -53,8 +53,6 @@ export class RemixAppManager extends PluginManager {
   }
 
   async deactivatePlugin (name) {
-    const isActive = await this.isActive(name)
-    if (!isActive) return
     const [to, from] = [
       await this.getProfile(name),
       await this.getProfile(this.requestFrom)


### PR DESCRIPTION
unnecessary call to deactivate hardhat. it can cause overlapping calls and that can cause hardhat to be reactivated because internally engine calls toggleActive on activate & deactivate. The extra check in Appmanager is also needed.

fixes #1225 