### PR TITLE
remove double getworkspace call

### DIFF
--- a/apps/remix-ide-e2e/src/helpers/init.ts
+++ b/apps/remix-ide-e2e/src/helpers/init.ts
@@ -2,7 +2,7 @@ import { NightwatchBrowser } from 'nightwatch'
 
 require('dotenv').config()
 
-export default function (browser: NightwatchBrowser, callback: VoidFunction, url?: string, preloadPlugins = true, closeWorkspaceAlert = true): void {
+export default function (browser: NightwatchBrowser, callback: VoidFunction, url?: string, preloadPlugins = true, closeWorkspaceAlert = false): void {
   browser
     .url(url || 'http://127.0.0.1:8080')
     .pause(5000)


### PR DESCRIPTION
A new call to getworkspaces was added via https://github.com/ethereum/remix-project/pull/1140 to create workspaces and get them 
https://github.com/ethereum/remix-project/blob/f974fcf823a6852c232ddc1e3357c722bb4d246e/apps/remix-ide/src/app/panels/file-panel.js#L174 
So we don't need the first one. 

Also a fix was need as a test failed that preloads a file when there is no workspace.
The file creation has a delay which caused the filemanager not to find the file. Writing directly to filesystem solves this particular problem. 