### PR TITLE
Static Analyzer Improvements

### DIFF
--- a/apps/remix-ide-e2e/src/tests/debugger.spec.ts
+++ b/apps/remix-ide-e2e/src/tests/debugger.spec.ts
@@ -207,6 +207,25 @@ module.exports = {
       As we are only testing if debugger is active, this is ok to keep that for now.
     */
       .waitForElementContainsText('*[data-id="stepdetail"]', 'vm trace step:\n154', 60000)
+  },
+
+  'Should start debugging using remix debug nodes (rinkeby)': function (browser: NightwatchBrowser) {
+    browser.addFile('useDebugNodes.sol', sources[5]['useDebugNodes.sol']) // compile contract
+      .clickLaunchIcon('udapp')
+      .click('*[data-id="settingsWeb3Mode"]') // select web3 provider with debug nodes URL
+      .clearValue('*[data-id="modalDialogCustomPromptText"]')
+      .setValue('*[data-id="modalDialogCustomPromptText"]', 'https://remix-rinkeby.ethdevops.io')
+      .modalFooterOKClick()
+      .waitForElementPresent('*[title="Deploy - transact (not payable)"]', 65000) // wait for the compilation to succeed
+      .clickLaunchIcon('debugger')
+      .clearValue('*[data-id="debuggerTransactionInput"]')
+      .setValue('*[data-id="debuggerTransactionInput"]', '0x156dbf7d0f9b435dd900cfc8f3264d523dd25733418ddbea1ce53e294f421013')
+      .click('*[data-id="debugGeneratedSourcesLabel"]') // unselect debug with generated sources
+      .click('*[data-id="debuggerTransactionStartButton"]')
+      .waitForElementVisible('*[data-id="solidityLocals"]', 60000)
+      .pause(10000)
+      .checkVariableDebug('soliditylocals', { num: { value: '2', type: 'uint256' } })
+      .checkVariableDebug('soliditystate', { number: { value: '0', type: 'uint256', constant: false } })
       .end()
   }
 }
@@ -294,6 +313,40 @@ const sources = [
       pragma experimental ABIEncoderV2; 
       contract A { 
         function f(uint[] memory) public returns (uint256) { } 
+      }
+      `
+    }
+  },
+  {
+    'useDebugNodes.sol': {
+      content: `
+      // SPDX-License-Identifier: GPL-3.0
+
+      pragma solidity >=0.7.0 <0.9.0;
+
+      /**
+       * @title Storage
+       * @dev Store & retrieve value in a variable
+       */
+      contract Storage {
+
+          uint256 number;
+
+          /**
+           * @dev Store value in variable
+           * @param num value to store
+           */
+          function store(uint256 num) public {
+              number = num;
+          }
+
+          /**
+           * @dev Return value 
+           * @return value of 'number'
+           */
+          function retrieve() public view returns (uint256){
+              return number;
+          }
       }
       `
     }

--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -73,7 +73,6 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
       }
     } else {
       props.event.trigger('staticAnaysisWarning', [])
-
     }
     return () => { }
   }, [state])

--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -67,12 +67,13 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
 
   useEffect(() => {
     if (autoRun) {
+      setWarningState([])
       if (state.data !== null) {
         run(state.data, state.source, state.file)
       }
     }
     return () => { }
-  }, [autoRun, state])
+  }, [state])
 
   const message = (name, warning, more, fileName, locationString) : string => {
     return (`

--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -327,18 +327,18 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
         <div id='staticanalysisresult' >
           <div className="mb-4">
             {
-              (Object.entries(warningState).map((element) => (
-                <>
+              (Object.entries(warningState).map((element, index) => (
+                <div  key={index}>
                   <span className="text-dark h6">{element[0]}</span>
-                  {element[1].map(x => (
+                  {element[1].map((x, i) => (
                     x.hasWarning ? (
-                      <div id={`staticAnalysisModule${element[1].warningModuleName}`}>
+                      <div id={`staticAnalysisModule${element[1].warningModuleName}`} key={i}>
                         <ErrorRenderer message={x.msg} opt={x.options} warningErrors={ x.warningErrors} editor={props.analysisModule}/>
                       </div>
 
                     ) : null
                   ))}
-                </>
+                </div>
               )))
             }
           </div>

--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -72,7 +72,7 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
       }
     }
     return () => { }
-  }, [autoRun, categoryIndex, state])
+  }, [autoRun, state])
 
   const message = (name, warning, more, fileName, locationString) : string => {
     return (`

--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -323,7 +323,7 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
           {state.file}
         </span>
       </div>
-      { categoryIndex.length > 0 && Object.entries(warningState).length > 0 &&
+      {Object.entries(warningState).length > 0 &&
         <div id='staticanalysisresult' >
           <div className="mb-4">
             {

--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -71,6 +71,9 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
       if (state.data !== null) {
         run(state.data, state.source, state.file)
       }
+    } else {
+      props.event.trigger('staticAnaysisWarning', [])
+
     }
     return () => { }
   }, [state])

--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -302,7 +302,6 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
             label="Autorun"
             onChange={() => {}}
           />
-          {console.log({categoryIndex})}
           <Button buttonText="Run" onClick={() => run(state.data, state.source, state.file)} disabled={state.data === null || categoryIndex.length === 0 }/>
         </div>
       </div>

--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -302,7 +302,8 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
             label="Autorun"
             onChange={() => {}}
           />
-          <Button buttonText="Run" onClick={() => run(state.data, state.source, state.file)} disabled={state.data === null}/>
+          {console.log({categoryIndex})}
+          <Button buttonText="Run" onClick={() => run(state.data, state.source, state.file)} disabled={state.data === null || categoryIndex.length === 0 }/>
         </div>
       </div>
       <div id="staticanalysismodules" className="list-group list-group-flush">

--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -328,7 +328,7 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
           <div className="mb-4">
             {
               (Object.entries(warningState).map((element, index) => (
-                <div  key={index}>
+                <div key={index}>
                   <span className="text-dark h6">{element[0]}</span>
                   {element[1].map((x, i) => (
                     x.hasWarning ? (

--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -66,8 +66,8 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
   }, [])
 
   useEffect(() => {
+    setWarningState([])
     if (autoRun) {
-      setWarningState([])
       if (state.data !== null) {
         run(state.data, state.source, state.file)
       }


### PR DESCRIPTION
- [x] Sometimes shows warning in browser console:
```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `RemixUiStaticAnalyser`. See https://fb.me/react-warning-keys for more information.
in div (created by RemixUiStaticAnalyser)
in RemixUiStaticAnalyser
```

- [x] If analysis result is being shown and I click on `Select all`, results are hidden instantly
- [x] If I have each checkbox unchecked, click on `Run`, no results are displayed. Now if `auto run` is checked and I check the `Select <category name>`, results related to that category are displayed instantly. Auto run is something which should run the analysis just after compilation



fixed warning in console :
```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `RemixUiStaticAnalyser`. See https://fb.me/react-warning-keys for more information.
in div (created by RemixUiStaticAnalyser)
in RemixUiStaticAnalyser
```