### PR TITLE
refactor setworkspace event

### DIFF
--- a/apps/remix-ide/src/app/files/remixd-handle.js
+++ b/apps/remix-ide/src/app/files/remixd-handle.js
@@ -19,6 +19,7 @@ var css = csjs`
     word-break: break-word;
   }
 `
+const LOCALHOST = ' - connect to localhost - '
 
 const profile = {
   name: 'remixd',
@@ -83,7 +84,9 @@ export class RemixdHandle extends WebsocketPlugin {
             this.canceled()
           }
         }, 3000)
-        this.localhostProvider.init(() => {})
+        this.localhostProvider.init(() => {
+          this.call('filePanel', 'setWorkspace', { name: LOCALHOST, isLocalhost: true }, true)
+        })
         this.call('manager', 'activatePlugin', 'hardhat')
       }
     }

--- a/apps/remix-ide/src/app/panels/file-panel.js
+++ b/apps/remix-ide/src/app/panels/file-panel.js
@@ -34,7 +34,7 @@ const modalDialogCustom = require('../ui/modal-dialog-custom')
 const profile = {
   name: 'filePanel',
   displayName: 'File explorers',
-  methods: ['createNewFile', 'uploadFile', 'getCurrentWorkspace', 'getWorkspaces', 'createWorkspace'],
+  methods: ['createNewFile', 'uploadFile', 'getCurrentWorkspace', 'getWorkspaces', 'createWorkspace', 'setWorkspace'],
   events: ['setWorkspace', 'renameWorkspace', 'deleteWorkspace', 'createWorkspace'],
   icon: 'assets/img/fileManager.webp',
   description: ' - ',
@@ -43,7 +43,6 @@ const profile = {
   documentation: 'https://remix-ide.readthedocs.io/en/latest/file_explorer.html',
   version: packageJson.version
 }
-
 module.exports = class Filepanel extends ViewPlugin {
   constructor (appManager) {
     super(profile)
@@ -114,7 +113,6 @@ module.exports = class Filepanel extends ViewPlugin {
   async getWorkspaces () {
     const result = new Promise((resolve, reject) => {
       const workspacesPath = this._deps.fileProviders.workspace.workspacesPath
-
       this._deps.fileProviders.browser.resolveDirectory('/' + workspacesPath, (error, items) => {
         if (error) {
           console.error(error)
@@ -247,14 +245,16 @@ module.exports = class Filepanel extends ViewPlugin {
   }
 
   /** these are called by the react component, action is already finished whent it's called */
-  async setWorkspace (workspace) {
-    this._deps.fileManager.closeAllFiles()
+  async setWorkspace (workspace, setEvent = true) {
     if (workspace.isLocalhost) {
       this.call('manager', 'activatePlugin', 'remixd')
     } else if (await this.call('manager', 'isActive', 'remixd')) {
       this.call('manager', 'deactivatePlugin', 'remixd')
     }
-    this.emit('setWorkspace', workspace)
+    if (setEvent) {
+      this._deps.fileManager.setMode(workspace.isLocalhost ? 'localhost' : 'browser')
+      this.emit('setWorkspace', workspace)
+    }
   }
 
   workspaceRenamed (workspace) {

--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -6,7 +6,7 @@ import { Toaster } from '@remix-ui/toaster'// eslint-disable-line
 
 /* eslint-disable-next-line */
 export interface WorkspaceProps {
-  setWorkspace: ({ name: string, isLocalhost: boolean }) => void,
+  setWorkspace: ({ name: string, isLocalhost: boolean }, setEvent: boolean) => void,
   createWorkspace: (name: string) => void,
   renameWorkspace: (oldName: string, newName: string) => void
   workspaceRenamed: ({ name: string }) => void,
@@ -74,7 +74,7 @@ export const Workspace = (props: WorkspaceProps) => {
     let getWorkspaces = async () => {
       if (props.workspaces && Array.isArray(props.workspaces)) {
         if (props.workspaces.length > 0 && state.currentWorkspace === NO_WORKSPACE) {
-          props.workspace.setWorkspace(props.workspaces[0])
+          await props.workspace.setWorkspace(props.workspaces[0])
           setState(prevState => {
             return { ...prevState, workspaces: props.workspaces, currentWorkspace: props.workspaces[0] }
           })
@@ -240,14 +240,15 @@ export const Workspace = (props: WorkspaceProps) => {
   }
 
   const setWorkspace = async (name) => {
-    await props.setWorkspace({ name, isLocalhost: name === LOCALHOST })
+    await props.fileManager.closeAllFiles()
     if (name === LOCALHOST) {
       props.workspace.clearWorkspace()
     } else if (name === NO_WORKSPACE) {
       props.workspace.clearWorkspace()
     } else {
-      props.workspace.setWorkspace(name)
+      await props.workspace.setWorkspace(name)
     }
+    await props.setWorkspace({ name, isLocalhost: name === LOCALHOST }, !(name === LOCALHOST || name === NO_WORKSPACE))
     props.plugin.getWorkspaces()
     setState(prevState => {
       return { ...prevState, currentWorkspace: name }


### PR DESCRIPTION
problem to be solved:
- setworkspace should only be fired when you're sure the new fileprovider is ready to accept calls
- plugins that react to this event then call the correct fileprovider
- remixd knows when the provider is ready, only then fire the event
- now the events will be fired correctly also when going back to default_workspace