### PR TITLE
prevent recreating directories after deleting a file in a deleted directory

### DIFF
--- a/libs/remix-ui/file-explorer/src/lib/reducers/fileSystem.ts
+++ b/libs/remix-ui/file-explorer/src/lib/reducers/fileSystem.ts
@@ -266,15 +266,16 @@ const removePath = (root, path: string, pathName, files) => {
     return Array.isArray(cur) ? [...acc, ...cur] : [...acc, cur]
   }, [])
   const prevFiles = _.get(files, _path)
-
-  prevFiles && prevFiles.child && prevFiles.child[pathName] && delete prevFiles.child[pathName]
-  files = _.set(files, _path, {
-    isDirectory: true,
-    path,
-    name: extractNameFromKey(path).indexOf('gist-') === 0 ? extractNameFromKey(path).split('-')[1] : extractNameFromKey(path),
-    type: extractNameFromKey(path).indexOf('gist-') === 0 ? 'gist' : 'folder',
-    child: prevFiles ? prevFiles.child : {}
-  })
+  if (prevFiles) {
+    prevFiles.child && prevFiles.child[pathName] && delete prevFiles.child[pathName]
+    files = _.set(files, _path, {
+      isDirectory: true,
+      path,
+      name: extractNameFromKey(path).indexOf('gist-') === 0 ? extractNameFromKey(path).split('-')[1] : extractNameFromKey(path),
+      type: extractNameFromKey(path).indexOf('gist-') === 0 ? 'gist' : 'folder',
+      child: prevFiles ? prevFiles.child : {}
+    })
+  }
 
   return files
 }


### PR DESCRIPTION
if const prevFiles = _.get(files, _path) is undefined
by setting it
files = _.set(files, _path, {
if path is removed, it will recreate the path.
that should not happen