### PR TITLE
Fix value formating check

### DIFF
--- a/libs/remix-debug/src/solidity-decoder/types/util.ts
+++ b/libs/remix-debug/src/solidity-decoder/types/util.ts
@@ -48,7 +48,7 @@ export async function extractHexValue (location, storageResolver, byteLength) {
   try {
     slotvalue = await readFromStorage(location.slot, storageResolver)
   } catch (e) {
-    return '0x'
+    return ''
   }
   return extractHexByteSlice(slotvalue, byteLength, location.offset)
 }

--- a/libs/remix-debug/src/trace/traceManager.ts
+++ b/libs/remix-debug/src/trace/traceManager.ts
@@ -151,7 +151,7 @@ export class TraceManager {
     if (this.trace[stepIndex] && this.trace[stepIndex].stack) { // there's always a stack
       const stack = this.trace[stepIndex].stack.slice(0)
       stack.reverse()
-      return stack
+      return stack.map(el => el.startsWith('0x') ? el : '0x' + el)
     } else {
       throw new Error('no stack found')
     }


### PR DESCRIPTION
Ganache CLI returns a sligthly different format for the transaction trace (some values aren't prefixed with 0x).
