### PR TITLE
imports location fixed for static analysis

### DIFF
--- a/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
+++ b/libs/remix-ui/static-analyser/src/lib/remix-ui-static-analyser.tsx
@@ -130,7 +130,7 @@ export const RemixUiStaticAnalyser = (props: RemixUiStaticAnalyserProps) => {
                 row = location.start.line
                 column = location.start.column
                 locationString = row + 1 + ':' + column + ':'
-                fileName = Object.keys(lastCompilationResult.contracts)[file]
+                fileName = Object.keys(lastCompilationResult.sources)[file]
               }
               warningCount++
               const msg = message(item.name, item.warning, item.more, fileName, locationString)


### PR DESCRIPTION
fixes #846 

Issue was that when there is only a contract imported in a file and no `contract` defined, file keys in `lastCompilationResult.contracts` object are 1 less than that of `lastCompilationResult.sources`