### PR TITLE
Fix matomo event

### DIFF
--- a/apps/remix-ide/src/app/tabs/compileTab/compilerContainer.js
+++ b/apps/remix-ide/src/app/tabs/compileTab/compilerContainer.js
@@ -112,7 +112,7 @@ class CompilerContainer {
       this._view.compileIcon.setAttribute('title', 'idle')
       this._view.compileIcon.classList.remove(`${css.spinningIcon}`)
       this._view.compileIcon.classList.remove(`${css.bouncingIcon}`)
-      _paq.push(['trackEvent', 'compiler', `compiled_with_v_${this._retrieveVersion()}`])
+      _paq.push(['trackEvent', 'compiler', 'compiled_with_version', this._retrieveVersion()])
     })
   }
 


### PR DESCRIPTION
The previous way of logging `compiled_with_v_${this._retrieveVersion()}` results in flooding the matomo results.
Matomo events have usually 3 metadatas define although only 2 were defined
