### PR TITLE
activate blockchain plugin

### DIFF
--- a/apps/remix-ide/src/app.js
+++ b/apps/remix-ide/src/app.js
@@ -482,7 +482,7 @@ Please make a backup of your contracts and start using http://remix.ethereum.org
   await appManager.activatePlugin(['sidePanel']) // activating  host plugin separately
   await appManager.activatePlugin(['home'])
   await appManager.activatePlugin(['settings'])
-  await appManager.activatePlugin(['hiddenPanel', 'filePanel', 'pluginManager', 'contextualListener', 'terminal', 'fetchAndCompile', 'contentImport'])
+  await appManager.activatePlugin(['hiddenPanel', 'filePanel', 'pluginManager', 'contextualListener', 'terminal', 'blockchain', 'fetchAndCompile', 'contentImport'])
   await appManager.registerContextMenuItems()
   // Set workspace after initial activation
   if (Array.isArray(workspace)) {


### PR DESCRIPTION
This was already there https://github.com/ethereum/remix-project/pull/1459/files#diff-d1f537119865b4c08673a1b2bc752fe5d248d3b6f842967a114ebed3427309a8R485 but somehow removed.

Hardhat `console.log` will not work without it.