### PR TITLE
add item.id in the payload to matomo

### DIFF
--- a/libs/remix-ui/file-explorer/src/lib/file-explorer-context-menu.tsx
+++ b/libs/remix-ui/file-explorer/src/lib/file-explorer-context-menu.tsx
@@ -108,7 +108,7 @@ export const FileExplorerContextMenu = (props: FileExplorerContextMenuProps) => 
               deletePath(getPath())
               break
             default:
-              _paq.push(['trackEvent', 'fileExplorer', 'customAction', `${item.id}${item.name}`])
+              _paq.push(['trackEvent', 'fileExplorer', 'customAction', `${item.id}/${item.name}`])
               emit && emit({ ...item, path: [path] } as customAction)
               break
           }


### PR DESCRIPTION
(having only `name` doesn't give much detail, like the plugin that is being called)
fix https://github.com/ethereum/remix-project/issues/1381