### PR TITLE
worker error improved

### DIFF
--- a/apps/remix-ide-e2e/src/commands/noWorkerErrorFor.ts
+++ b/apps/remix-ide-e2e/src/commands/noWorkerErrorFor.ts
@@ -18,7 +18,7 @@ function noWorkerErrorFor (browser: NightwatchBrowser, version: string, callback
     .setSolidityCompilerVersion(version)
     .click('*[data-id="compilerContainerCompileBtn"]')
     .waitForElementPresent('*[data-id="compilationFinishedWith_' + version + '"]', 60000)
-    .notContainsText('*[data-id="compiledErrors"]', 'worker error:undefined')
+    .notContainsText('*[data-id="compiledErrors"]', `Worker error: Uncaught NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'https://binaries.soliditylang.org/wasm/${version}' failed to load.`)
     .notContainsText('*[data-id="compiledErrors"]', 'Uncaught RangeError: Maximum call stack size exceeded')
     .notContainsText('*[data-id="compiledErrors"]', 'RangeError: Maximum call stack size exceeded')
     .perform(() => {

--- a/apps/remix-ide/src/app/tabs/compile-tab.js
+++ b/apps/remix-ide/src/app/tabs/compile-tab.js
@@ -162,7 +162,7 @@ class CompileTab extends ViewPlugin {
           )
         })
       } else {
-        const count = (data.errors ? data.errors.filter(error => error.severity === 'error').length : 0 + data.error ? 1 : 0)
+        const count = (data.errors ? data.errors.filter(error => error.severity === 'error').length : 0) + data.error ? 1 : 0
         this.emit('statusChanged', { key: count, title: `compilation failed with ${count} error${count.length > 1 ? 's' : ''}`, type: 'error' })
       }
       // Update contract Selection

--- a/libs/remix-solidity/src/compiler/compiler.ts
+++ b/libs/remix-solidity/src/compiler/compiler.ts
@@ -281,7 +281,8 @@ export class Compiler {
     })
 
     this.state.worker.addEventListener('error', (msg: Record <'data', MessageFromWorker>) => {
-      this.onCompilationFinished({ error: { formattedMessage: 'Worker error: ' + msg.data } })
+      const formattedMessage = `Worker error: ${msg.data && msg.data !== undefined ? msg.data : msg['message']}`
+      this.onCompilationFinished({ error: { formattedMessage } })
     })
 
     this.state.compileJSON = (source: SourceWithTarget) => {


### PR DESCRIPTION
No more shows `undefined` with `Worker error:`, instead shows actual error message