### PR TITLE
added missing deps for remix-solidity

### DIFF
--- a/libs/remix-solidity/package.json
+++ b/libs/remix-solidity/package.json
@@ -23,6 +23,8 @@
     "eslint-scope": "^5.0.0",
     "ethereumjs-util": "^7.0.10",
     "ethers": "^5.4.2",
+    "minixhr": "^3.2.2",
+    "semver": "^6.3.0",
     "solc": "^0.7.4",
     "string-similarity": "^4.0.4",
     "web3": "^1.5.1",


### PR DESCRIPTION
`remix-tests` as CLI shows error because of this: `Error: Cannot find module 'minixhr'`