### PR TITLE
handle test files

### DIFF
--- a/apps/remix-ide-e2e/src/tests/solidityUnittests.spec.ts
+++ b/apps/remix-ide-e2e/src/tests/solidityUnittests.spec.ts
@@ -267,6 +267,8 @@ module.exports = {
       .setValue('*[data-id="slider"]', new Array(1).fill(browser.Keys.RIGHT_ARROW))
       .waitForElementContainsText('*[data-id="functionPanel"]', 'equal(a, b, message)', 60000)
       .waitForElementContainsText('*[data-id="functionPanel"]', 'checkWinningProposalPassed()', 60000)
+      // remix_test.sol should be opened in editor
+      .getEditorValue((content) => browser.assert.ok(content.indexOf('library Assert {') !== -1))
       .pause(1000)
       .clickLaunchIcon('solidityUnitTesting')
       .scrollAndClick('#Check_winning_proposal_again')

--- a/apps/remix-ide/src/app/files/fileProvider.js
+++ b/apps/remix-ide/src/app/files/fileProvider.js
@@ -17,8 +17,9 @@ class FileProvider {
   }
 
   addNormalizedName (path, url) {
-    this.providerExternalsStorage.set(this.type + '/' + path, url)
-    this.providerExternalsStorage.set(this.reverseKey + url, this.type + '/' + path)
+    if (this.type) path = this.type + '/' + path
+    this.providerExternalsStorage.set(path, url)
+    this.providerExternalsStorage.set(this.reverseKey + url, path)
   }
 
   removeNormalizedName (path) {

--- a/apps/remix-ide/src/app/tabs/test-tab.js
+++ b/apps/remix-ide/src/app/tabs/test-tab.js
@@ -42,7 +42,7 @@ module.exports = class TestTab extends ViewPlugin {
     this.areTestsRunning = false
     this.defaultPath = 'tests'
     this.offsetToLineColumnConverter = offsetToLineColumnConverter
-    this.allFilesInvolved = []
+    this.allFilesInvolved = ['.deps/remix-tests/remix_tests.sol', '.deps/remix-tests/remix_accounts.sol']
     this.isDebugging = false
     this.currentErrors = []
 
@@ -112,7 +112,7 @@ module.exports = class TestTab extends ViewPlugin {
 
     this.testRunner.event.on('compilationFinished', (success, data, source) => {
       if (success) {
-        this.allFilesInvolved = Object.keys(data.sources)
+        this.allFilesInvolved.push(...Object.keys(data.sources))
         // forwarding the event to the appManager infra
         // This is listened by compilerArtefacts to show data while debugging
         this.emit('compilationFinished', source.target, source, 'soljson', data)

--- a/apps/remix-ide/src/app/tabs/test-tab.js
+++ b/apps/remix-ide/src/app/tabs/test-tab.js
@@ -74,8 +74,8 @@ module.exports = class TestTab extends ViewPlugin {
     }
   }
 
-  getTestlibs() {
-    return { assertLibCode, accountsLibCode: this.testRunner.accountsLibCode}
+  getTestlibs () {
+    return { assertLibCode, accountsLibCode: this.testRunner.accountsLibCode }
   }
 
   async onActivation () {

--- a/apps/remix-ide/src/app/tabs/test-tab.js
+++ b/apps/remix-ide/src/app/tabs/test-tab.js
@@ -16,7 +16,7 @@ const TestTabLogic = require('./testTab/testTab')
 const profile = {
   name: 'solidityUnitTesting',
   displayName: 'Solidity unit testing',
-  methods: ['testFromPath', 'testFromSource', 'setTestFolderPath'],
+  methods: ['testFromPath', 'testFromSource', 'setTestFolderPath', 'getTestlibs'],
   events: [],
   icon: 'assets/img/unitTesting.webp',
   description: 'Fast tool to generate unit tests for your contracts',
@@ -72,6 +72,10 @@ module.exports = class TestTab extends ViewPlugin {
     if (event.path.length > 0) {
       await this.setCurrentPath(event.path[0])
     }
+  }
+
+  getTestlibs() {
+    return { assertLibCode, accountsLibCode: this.testRunner.accountsLibCode}
   }
 
   async onActivation () {

--- a/apps/remix-ide/src/app/tabs/test-tab.js
+++ b/apps/remix-ide/src/app/tabs/test-tab.js
@@ -84,7 +84,7 @@ module.exports = class TestTab extends ViewPlugin {
       await this.call('manager', 'activatePlugin', 'solidity')
     }
     await this.testRunner.init()
-    const provider = await this.fileManager.getProviderOf()
+    const provider = await this.fileManager.currentFileProvider()
     if (provider) {
       provider.addExternal('.deps/remix-tests/remix_tests.sol', assertLibCode, 'remix_tests.sol')
       provider.addExternal('.deps/remix-tests/remix_accounts.sol', this.testRunner.accountsLibCode, 'remix_accounts.sol')

--- a/apps/remix-ide/src/app/tabs/test-tab.js
+++ b/apps/remix-ide/src/app/tabs/test-tab.js
@@ -7,7 +7,7 @@ var async = require('async')
 var tooltip = require('../ui/tooltip')
 var Renderer = require('../ui/renderer')
 var css = require('./styles/test-tab-styles')
-var { UnitTestRunner } = require('@remix-project/remix-tests')
+var { UnitTestRunner, assertLibCode } = require('@remix-project/remix-tests')
 
 const _paq = window._paq = window._paq || []
 
@@ -78,6 +78,12 @@ module.exports = class TestTab extends ViewPlugin {
     const isSolidityActive = await this.call('manager', 'isActive', 'solidity')
     if (!isSolidityActive) {
       await this.call('manager', 'activatePlugin', 'solidity')
+    }
+    await this.testRunner.init()
+    const provider = await this.fileManager.getProviderOf()
+    if (provider) {
+      provider.addExternal('.deps/remix-tests/remix_tests.sol', assertLibCode, 'remix_tests.sol')
+      provider.addExternal('.deps/remix-tests/remix_accounts.sol', this.testRunner.accountsLibCode, 'remix_accounts.sol')
     }
     this.updateRunAction()
   }

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -117,7 +117,11 @@ export class CompilerImports extends Plugin {
     * @returns {Promise} - string content
     */
   async resolveAndSave (url, targetPath) {
-    if (url.indexOf('remix_tests.sol') !== -1) return remixTests.assertLibCode
+    if (url.indexOf('remix_tests.sol') !== -1 || url.indexOf('remix_accounts.sol') !== -1) {
+      const {assertLibCode, accountsLibCode} = await this.call('solidityUnitTesting', 'getTestlibs')
+      if (url === 'remix_tests.sol') return assertLibCode
+      else if (url === 'remix_accounts.sol') return accountsLibCode
+    }
     try {
       const provider = await this.call('fileManager', 'getProviderOf', url)
       if (provider) {

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -119,7 +119,7 @@ export class CompilerImports extends Plugin {
     if (url.indexOf('remix_tests.sol') !== -1 || url.indexOf('remix_accounts.sol') !== -1) {
       const { assertLibCode, accountsLibCode } = await this.call('solidityUnitTesting', 'getTestlibs')
       let content
-      if (url === 'remix_tests.sol') content =  assertLibCode
+      if (url === 'remix_tests.sol') content = assertLibCode
       else if (url === 'remix_accounts.sol') content = accountsLibCode
       const provider = await this.call('fileManager', 'getProviderOf', null)
       if (provider) provider.addExternal('.deps/remix-tests/' + url, content, url)

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -1,7 +1,8 @@
 'use strict'
 import { Plugin } from '@remixproject/engine'
 import { RemixURLResolver } from '@remix-project/remix-url-resolver'
-const remixTests = require('@remix-project/remix-tests')
+// const remixTests = require('@remix-project/remix-tests')
+var { assertLibCode, getAccountsLib } = require('@remix-project/remix-tests')
 
 const profile = {
   name: 'contentImport',
@@ -106,10 +107,12 @@ export class CompilerImports extends Plugin {
     })
   }
 
-  async importTestFiles () {
+  async importTestFiles (url) {
     const provider = await this.call('fileManager', 'getProviderOf', null)
-    const content = remixTests.assertLibCode
-    if (provider) provider.addExternal('.deps/remix-tests/remix-tests.sol', content, 'remix_tests.sol')
+    let content
+    if (url === 'remix_tests.sol' || url === 'tests.sol') content = assertLibCode
+    else if (url === 'remix_accounts.sol') content = getAccountsLib()
+    if (provider) provider.addExternal('.deps/remix-tests/' + url, content, url)
     return content
   }
 
@@ -124,9 +127,7 @@ export class CompilerImports extends Plugin {
     * @returns {Promise} - string content
     */
   async resolveAndSave (url, targetPath) {
-    if (url.indexOf('remix_tests.sol') !== -1) {
-      return await this.importTestFiles()
-    }
+    if (['remix_tests.sol', 'tests.sol', 'remix_accounts.sol'].includes(url)) return await this.importTestFiles(url)
     try {
       const provider = await this.call('fileManager', 'getProviderOf', url)
       if (provider) {

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -106,6 +106,13 @@ export class CompilerImports extends Plugin {
     })
   }
 
+  async importTestFiles () {
+    const provider = await this.call('fileManager', 'getProviderOf', null)
+    const content = remixTests.assertLibCode
+    if (provider) provider.addExternal('.deps/remix-tests/remix-tests.sol', content, 'remix_tests.sol')
+    return content
+  }
+
   /**
     * import the content of @arg url.
     * first look in the browser localstorage (browser explorer) or locahost explorer. if the url start with `browser/*` or  `localhost/*`
@@ -117,7 +124,9 @@ export class CompilerImports extends Plugin {
     * @returns {Promise} - string content
     */
   async resolveAndSave (url, targetPath) {
-    if (url.indexOf('remix_tests.sol') !== -1) return remixTests.assertLibCode
+    if (url.indexOf('remix_tests.sol') !== -1) {
+      return await this.importTestFiles()
+    }
     try {
       const provider = await this.call('fileManager', 'getProviderOf', url)
       if (provider) {

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -1,8 +1,6 @@
 'use strict'
 import { Plugin } from '@remixproject/engine'
 import { RemixURLResolver } from '@remix-project/remix-url-resolver'
-// const remixTests = require('@remix-project/remix-tests')
-var { assertLibCode, getAccountsLib } = require('@remix-project/remix-tests')
 
 const profile = {
   name: 'contentImport',
@@ -107,15 +105,6 @@ export class CompilerImports extends Plugin {
     })
   }
 
-  async importTestFiles (url) {
-    const provider = await this.call('fileManager', 'getProviderOf', null)
-    let content
-    if (url === 'remix_tests.sol' || url === 'tests.sol') content = assertLibCode
-    else if (url === 'remix_accounts.sol') content = getAccountsLib()
-    if (provider) provider.addExternal('.deps/remix-tests/' + url, content, url)
-    return content
-  }
-
   /**
     * import the content of @arg url.
     * first look in the browser localstorage (browser explorer) or locahost explorer. if the url start with `browser/*` or  `localhost/*`
@@ -127,7 +116,6 @@ export class CompilerImports extends Plugin {
     * @returns {Promise} - string content
     */
   async resolveAndSave (url, targetPath) {
-    if (['remix_tests.sol', 'tests.sol', 'remix_accounts.sol'].includes(url)) return await this.importTestFiles(url)
     try {
       const provider = await this.call('fileManager', 'getProviderOf', url)
       if (provider) {

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -1,6 +1,7 @@
 'use strict'
 import { Plugin } from '@remixproject/engine'
 import { RemixURLResolver } from '@remix-project/remix-url-resolver'
+const remixTests = require('@remix-project/remix-tests')
 
 const profile = {
   name: 'contentImport',
@@ -116,6 +117,7 @@ export class CompilerImports extends Plugin {
     * @returns {Promise} - string content
     */
   async resolveAndSave (url, targetPath) {
+    if (url.indexOf('remix_tests.sol') !== -1) return remixTests.assertLibCode
     try {
       const provider = await this.call('fileManager', 'getProviderOf', url)
       if (provider) {

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -118,8 +118,12 @@ export class CompilerImports extends Plugin {
   async resolveAndSave (url, targetPath) {
     if (url.indexOf('remix_tests.sol') !== -1 || url.indexOf('remix_accounts.sol') !== -1) {
       const { assertLibCode, accountsLibCode } = await this.call('solidityUnitTesting', 'getTestlibs')
-      if (url === 'remix_tests.sol') return assertLibCode
-      else if (url === 'remix_accounts.sol') return accountsLibCode
+      let content
+      if (url === 'remix_tests.sol') content =  assertLibCode
+      else if (url === 'remix_accounts.sol') content = accountsLibCode
+      const provider = await this.call('fileManager', 'getProviderOf', null)
+      if (provider) provider.addExternal('.deps/remix-tests/' + url, content, url)
+      return content
     }
     try {
       const provider = await this.call('fileManager', 'getProviderOf', url)

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -1,7 +1,6 @@
 'use strict'
 import { Plugin } from '@remixproject/engine'
 import { RemixURLResolver } from '@remix-project/remix-url-resolver'
-const remixTests = require('@remix-project/remix-tests')
 
 const profile = {
   name: 'contentImport',
@@ -118,7 +117,7 @@ export class CompilerImports extends Plugin {
     */
   async resolveAndSave (url, targetPath) {
     if (url.indexOf('remix_tests.sol') !== -1 || url.indexOf('remix_accounts.sol') !== -1) {
-      const {assertLibCode, accountsLibCode} = await this.call('solidityUnitTesting', 'getTestlibs')
+      const { assertLibCode, accountsLibCode } = await this.call('solidityUnitTesting', 'getTestlibs')
       if (url === 'remix_tests.sol') return assertLibCode
       else if (url === 'remix_accounts.sol') return accountsLibCode
     }

--- a/libs/remix-tests/sol/tests_accounts.sol.ts
+++ b/libs/remix-tests/sol/tests_accounts.sol.ts
@@ -3,7 +3,7 @@ module.exports = `// SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.4.22 <0.9.0;
 
 library TestsAccounts {
-    function getAccount(uint index) public returns (address) {
+    function getAccount(uint index) pure public returns (address) {
         >accounts<
         return accounts[index];
     }

--- a/libs/remix-tests/src/compiler.ts
+++ b/libs/remix-tests/src/compiler.ts
@@ -9,7 +9,7 @@ const log = logger.logger
 var accountsLibCode
 
 export function getAccountsLib () {
- return accountsLibCode
+  return accountsLibCode
 }
 
 function regexIndexOf (inputString: string, regex: RegExp, startpos = 0) {

--- a/libs/remix-tests/src/compiler.ts
+++ b/libs/remix-tests/src/compiler.ts
@@ -177,7 +177,7 @@ export function compileContractSources (sources: SrcIfc, compilerConfig: Compile
   // Iterate over sources keys. Inject test libraries. Inject test library import statements.
   if (!('remix_tests.sol' in sources) && !('tests.sol' in sources)) {
     sources['tests.sol'] = { content: require('../sol/tests.sol.js') }
-    sources['remix_tests.sol'] = { content: require('../sol/tests.sol.js') }
+    // sources['remix_tests.sol'] = { content: require('../sol/tests.sol.js') }
     sources['remix_accounts.sol'] = { content: writeTestAccountsContract(accounts) }
   }
   const testFileImportRegEx = /^(import)\s['"](remix_tests.sol|tests.sol)['"];/gm

--- a/libs/remix-tests/src/compiler.ts
+++ b/libs/remix-tests/src/compiler.ts
@@ -6,18 +6,13 @@ import { Compiler as RemixCompiler } from '@remix-project/remix-solidity'
 import { SrcIfc, CompilerConfiguration, CompilationErrors } from './types'
 const logger = new Log()
 const log = logger.logger
-var accountsLibCode
-
-export function getAccountsLib () {
-  return accountsLibCode
-}
 
 function regexIndexOf (inputString: string, regex: RegExp, startpos = 0) {
   const indexOf = inputString.substring(startpos).search(regex)
   return (indexOf >= 0) ? (indexOf + (startpos)) : indexOf
 }
 
-function writeTestAccountsContract (accounts: string[]) {
+export function writeTestAccountsContract (accounts: string[]) {
   const testAccountContract = require('../sol/tests_accounts.sol')
   let body = `address[${accounts.length}] memory accounts;`
   if (!accounts.length) body += ';'
@@ -26,7 +21,7 @@ function writeTestAccountsContract (accounts: string[]) {
       body += `\n\t\taccounts[${index}] = ${address};\n`
     })
   }
-  accountsLibCode = testAccountContract.replace('>accounts<', body)
+  return testAccountContract.replace('>accounts<', body)
 }
 
 /**
@@ -92,11 +87,10 @@ const isBrowser = !(typeof (window) === 'undefined' || userAgent.indexOf(' elect
 export function compileFileOrFiles (filename: string, isDirectory: boolean, opts: any, compilerConfig: CompilerConfiguration, cb): void {
   let compiler: any
   const accounts: string[] = opts.accounts || []
-  writeTestAccountsContract(accounts)
   const sources: SrcIfc = {
     'tests.sol': { content: require('../sol/tests.sol') },
     'remix_tests.sol': { content: require('../sol/tests.sol') },
-    'remix_accounts.sol': { content: getAccountsLib() }
+    'remix_accounts.sol': { content: writeTestAccountsContract(accounts) }
   }
   const filepath: string = (isDirectory ? filename : path.dirname(filename))
   try {
@@ -178,8 +172,6 @@ export function compileFileOrFiles (filename: string, isDirectory: boolean, opts
  */
 export function compileContractSources (sources: SrcIfc, compilerConfig: CompilerConfiguration, importFileCb: any, opts: any, cb): void {
   let compiler
-  const accounts: string[] = opts.accounts || []
-  writeTestAccountsContract(accounts)
   const filepath = opts.testFilePath || ''
   const testFileImportRegEx = /^(import)\s['"](remix_tests.sol|tests.sol)['"];/gm
 

--- a/libs/remix-tests/src/index.ts
+++ b/libs/remix-tests/src/index.ts
@@ -3,4 +3,4 @@ export { UnitTestRunner } from './runTestSources'
 export { runTest } from './testRunner'
 export * from './types'
 export const assertLibCode = require('../sol/tests.sol')
-export { getAccountsLib } from './compiler'
+export { writeTestAccountsContract } from './compiler'

--- a/libs/remix-tests/src/index.ts
+++ b/libs/remix-tests/src/index.ts
@@ -3,4 +3,4 @@ export { UnitTestRunner } from './runTestSources'
 export { runTest } from './testRunner'
 export * from './types'
 export const assertLibCode = require('../sol/tests.sol')
-export { getAccountsLib }  from './compiler'
+export { getAccountsLib } from './compiler'

--- a/libs/remix-tests/src/index.ts
+++ b/libs/remix-tests/src/index.ts
@@ -3,3 +3,4 @@ export { UnitTestRunner } from './runTestSources'
 export { runTest } from './testRunner'
 export * from './types'
 export const assertLibCode = require('../sol/tests.sol')
+export { getAccountsLib }  from './compiler'


### PR DESCRIPTION
Remix test files that are `remix_tests.sol` and `remix_accounts.sol` will be stored in file explorer inside `.deps/remix-tests` once someone runs unit tests in SUT plugin. To be exact they are created during compilation of a contract importing them.

Update:

Files will also be created when SUT plugin is activated.