### PR TITLE
Fix broken workspace UI

### DIFF
--- a/apps/remix-ide/src/app/files/fileManager.js
+++ b/apps/remix-ide/src/app/files/fileManager.js
@@ -140,7 +140,7 @@ class FileManager extends Plugin {
   refresh () {
     const provider = this.fileProviderOf('/')
     // emit rootFolderChanged so that File Explorer reloads the file tree
-    provider.event.emit('rootFolderChanged')
+    provider.event.emit('rootFolderChanged', provider.workspace || '/')
   }
 
   /**

--- a/apps/remix-ide/src/app/files/workspaceFileProvider.js
+++ b/apps/remix-ide/src/app/files/workspaceFileProvider.js
@@ -33,7 +33,13 @@ class WorkspaceFileProvider extends FileProvider {
   removePrefix (path) {
     path = path.replace(/^\/|\/$/g, '') // remove first and last slash
     if (path.startsWith(this.workspacesPath + '/' + this.workspace)) return path
-    if (path.startsWith(this.workspace)) return path.replace(this.workspace, this.workspacesPath + '/' + this.workspace)
+    const splitPath = path.split('/')
+
+    if (splitPath[0] === this.workspace) {
+      splitPath[0] = this.workspacesPath + '/' + this.workspace
+      path = splitPath.join('/')
+      return path
+    }
     path = super.removePrefix(path)
     let ret = this.workspacesPath + '/' + this.workspace + '/' + (path === '/' ? '' : path)
 

--- a/libs/remix-ui/workspace/src/lib/reducers/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/reducers/workspace.ts
@@ -231,7 +231,8 @@ export const browserReducer = (state = browserInitialState, action: Action) => {
           files: state.mode === 'localhost' ? fetchWorkspaceDirectoryContent(state, payload) : state.localhost.files,
           isRequestingWorkspace: false,
           isSuccessfulWorkspace: true,
-          error: null
+          error: null,
+          sharedFolder: null
         }
       }
     }


### PR DESCRIPTION
Fixed boken UI for workspace named 'test', pass directory name for fileManager refresh.

Fixed https://github.com/ethereum/remix-project/issues/1714