### PR TITLE
Fix import IPFS files

### DIFF
--- a/libs/remix-url-resolver/src/resolve.ts
+++ b/libs/remix-url-resolver/src/resolve.ts
@@ -117,7 +117,7 @@ export class RemixURLResolver {
       // If you don't find greeter.sol on ipfs gateway use local
       // const req = 'http://localhost:8080/' + url
       const response: AxiosResponse = await axios.get(req)
-      return { content: response.data, cleanUrl: url }
+      return { content: response.data, cleanUrl: url.replace('ipfs/', '') }
     } catch (e) {
       throw e
     }

--- a/libs/remix-url-resolver/tests/test.ts
+++ b/libs/remix-url-resolver/tests/test.ts
@@ -260,7 +260,7 @@ describe('testRunner', () => {
           const content = fs.readFileSync(__dirname + '/example_1/greeter.sol', { encoding: 'utf8'})
           const expt: object = {
             content: content,
-            cleanUrl: 'ipfs/QmcuCKyokk9Z6f65ADAADNiS2R2xCjfRkv7mYBSWDwtA7M',
+            cleanUrl: 'QmcuCKyokk9Z6f65ADAADNiS2R2xCjfRkv7mYBSWDwtA7M',
             type: 'ipfs'
           }
           assert.deepEqual(results, expt)


### PR DESCRIPTION
When using the "import ipfs", it imports it in the folder `ipfs/ipfs/<ipfs hash>`, it changes this to `ipfs/<ipfs hash>`