### PR TITLE
Fix debugging live transactions

### DIFF
--- a/apps/debugger/src/app/debugger-api.ts
+++ b/apps/debugger/src/app/debugger-api.ts
@@ -83,7 +83,7 @@ export const DebuggerApiMixin = (Base) => class extends Base {
     const target = (address && remixDebug.traceHelper.isContractCreation(address)) ? receipt.contractAddress : address
     const targetAddress = target || receipt.contractAddress || receipt.to
     const codeAtAddress = await this._web3.eth.getCode(targetAddress)
-    const output = await this.call('fetchAndCompile', 'resolve', targetAddress, codeAtAddress, 'browser/.debug')
+    const output = await this.call('fetchAndCompile', 'resolve', targetAddress, codeAtAddress, '.debug')
     if (output) {
       return new CompilerAbstract(output.languageversion, output.data, output.source)
     }

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -35,7 +35,8 @@ export class CompilerImports extends Plugin {
 
   isExternalUrl (url) {
     const handlers = this.urlResolver.getHandlers()
-    return handlers.some(handler => handler.match(url))
+    // we filter out "npm" because this will be recognized as internal url although it's not the case.
+    return handlers.filter((handler) => handler.type !== 'npm').some(handler => handler.match(url))
   }
 
   /**


### PR DESCRIPTION
This PR fixes the following use case:

 - connect to metamask, switch to Ropsten.
 - activate the debugger and start debugging `0x959371506b8f6223d71c709ac2eb2d0158104dca2d76ca949f1662712cf0e6db`.
 - it should grab the sources from sourcify and ipfs (check that the sources are present under the folder `.debug`).
 - it should switch to that file, start debugging.
 - check that source highlight is present.