### PR TITLE
Fix copy the deploy payload to clipboard

### DIFF
--- a/libs/remix-ui/run-tab/src/lib/components/contractGUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/contractGUI.tsx
@@ -63,7 +63,12 @@ export function ContractGUI (props: ContractGUIProps) {
       return 'cannot encode empty arguments'
     }
     const multiJSON = JSON.parse('[' + multiString + ']')
-    const encodeObj = txFormat.encodeData(props.funcABI, multiJSON, null)
+
+    const encodeObj = txFormat.encodeData(
+        props.funcABI,
+        multiJSON,
+        props.funcABI.type === 'constructor' ? props.evmBC : null)
+
     if (encodeObj.error) {
       console.error(encodeObj.error)
       return encodeObj.error


### PR DESCRIPTION
When computing a tx call, the input is made of:
signature of the method + encoded input parameter

When computing a deployment, the input is made of:
the contract bytecode + encoded input parameter

passing null for the bytecode in the case of a deployment fails cause then the `encodeData` function is looking at the `name` of the function, which is an empty string cause it's not a function but the constructor.