### PR TITLE
test result clearing fixed

### DIFF
--- a/apps/remix-ide/src/app/components/vertical-icons.tsx
+++ b/apps/remix-ide/src/app/components/vertical-icons.tsx
@@ -1,13 +1,11 @@
 // eslint-disable-next-line no-use-before-define
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Registry from '../state/registry'
 import packageJson from '../../../../../package.json'
 import { Plugin } from '@remixproject/engine'
 import { EventEmitter } from 'events'
 import { IconRecord, RemixUiVerticalIconsPanel } from '@remix-ui/vertical-icons-panel'
 import { Profile } from '@remixproject/plugin-utils'
-import { timeStamp } from 'console'
 
 const profile = {
   name: 'menuicons',
@@ -95,7 +93,6 @@ export class VerticalIcons extends Plugin {
    */
   select (name: string) {
     // TODO: Only keep `this.emit` (issue#2210)
-    console.log(name, this)
     this.emit('showContent', name)
     this.events.emit('showContent', name)
   }

--- a/libs/remix-ui/solidity-unit-testing/src/lib/solidity-unit-testing.tsx
+++ b/libs/remix-ui/solidity-unit-testing/src/lib/solidity-unit-testing.tsx
@@ -72,6 +72,7 @@ export const SolidityUnitTesting = (props: Record<string, any>) => { // eslint-d
   const isDebugging = useRef<boolean>(false)
   const allTests = useRef<string[]>([])
   const selectedTests = useRef<string[]>([])
+  const currentTestFiles:any = useRef([]) // stores files for which tests have been run
   const currentErrors:any = useRef([]) // eslint-disable-line @typescript-eslint/no-explicit-any
 
   const defaultPath = 'tests'
@@ -104,7 +105,7 @@ export const SolidityUnitTesting = (props: Record<string, any>) => { // eslint-d
     }
     // if current file is changed while debugging and one of the files imported in test file are opened
     // do not clear the test results in SUT plugin
-    if (isDebugging.current && testTab.allFilesInvolved.includes(file)) return
+    if ((isDebugging.current && testTab.allFilesInvolved.includes(file)) || currentTestFiles.current.includes(file)) return
     allTests.current = []
     updateTestFileList()
     clearResults()
@@ -394,6 +395,7 @@ export const SolidityUnitTesting = (props: Record<string, any>) => { // eslint-d
 
   const showTestsResult = () => {
     const filenames = Object.keys(testsResultByFilename)
+    currentTestFiles.current = filenames
     for (const filename of filenames) {
       const fileTestsResult = testsResultByFilename[filename]
       const contracts = Object.keys(fileTestsResult)


### PR DESCRIPTION
Without this, SUT clears test result even when you select one of the test files for which result is getting shown.