### PR TITLE
save compilation result in file

### DIFF
--- a/apps/remix-ide/src/app/tabs/test-tab.js
+++ b/apps/remix-ide/src/app/tabs/test-tab.js
@@ -89,12 +89,12 @@ module.exports = class TestTab extends ViewPlugin {
       this.createTestLibs()
     })
 
-    this.testRunner.event.on('compilationFinished', (success, data, source) => {
+    this.testRunner.event.on('compilationFinished', (success, data, source, input, version) => {
       if (success) {
         this.allFilesInvolved.push(...Object.keys(data.sources))
         // forwarding the event to the appManager infra
         // This is listened by compilerArtefacts to show data while debugging
-        this.emit('compilationFinished', source.target, source, 'soljson', data)
+        this.emit('compilationFinished', source.target, source, 'soljson', data, input, version)
       }
     })
   }

--- a/apps/remix-ide/src/remixAppManager.js
+++ b/apps/remix-ide/src/remixAppManager.js
@@ -114,6 +114,7 @@ export class RemixAppManager extends PluginManager {
       const res = await fetch(this.pluginsDirectory)
       plugins = await res.json()
       plugins = plugins.filter((plugin) => {
+        if(plugin.name === 'scriptRunner') plugin.url = 'http://127.0.0.1:8081'
         if (plugin.targets && Array.isArray(plugin.targets) && plugin.targets.length > 0) {
           return (plugin.targets.includes('remix'))
         }

--- a/apps/remix-ide/src/remixAppManager.js
+++ b/apps/remix-ide/src/remixAppManager.js
@@ -114,7 +114,6 @@ export class RemixAppManager extends PluginManager {
       const res = await fetch(this.pluginsDirectory)
       plugins = await res.json()
       plugins = plugins.filter((plugin) => {
-        if(plugin.name === 'scriptRunner') plugin.url = 'http://127.0.0.1:8081'
         if (plugin.targets && Array.isArray(plugin.targets) && plugin.targets.length > 0) {
           return (plugin.targets.includes('remix'))
         }

--- a/apps/solidity-compiler/src/app/compiler-api.ts
+++ b/apps/solidity-compiler/src/app/compiler-api.ts
@@ -261,11 +261,11 @@ export const CompilerApiMixin = (Base) => class extends Base {
 
     this.on('fileManager', 'fileClosed', this.data.eventHandlers.onFileClosed)
 
-    this.data.eventHandlers.onCompilationFinished = (success, data, source) => {
+    this.data.eventHandlers.onCompilationFinished = (success, data, source, input, version) => {
       this.compileErrors = data
       if (success) {
         // forwarding the event to the appManager infra
-        this.emit('compilationFinished', source.target, source, 'soljson', data)
+        this.emit('compilationFinished', source.target, source, 'soljson', data, input, version)
         if (data.errors && data.errors.length > 0) {
           this.statusChanged({
             key: data.errors.length,

--- a/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
@@ -80,12 +80,12 @@ export class CompilerArtefacts extends Plugin {
         const artefactsFilePaths = fileList.filter(filePath => {
           const filenameArr = filePath.split('/')
           const filename = filenameArr[filenameArr.length - 1]
-          if (filename === `${contractName}.json` || filename === `${contractName}_metadata.json`) return true
+          if (filename === `${contractName}_fullOP.json`) return true
         })
         if (artefactsFilePaths && artefactsFilePaths.length) {
-          const content = await this.call('fileManager', 'readFile', artefactsFilePaths[1])
+          const content = await this.call('fileManager', 'readFile', artefactsFilePaths[0])
           const artifacts = JSON.parse(content)
-          return { abi: artifacts.abi, bytecode: artifacts.data.bytecode.object }
+          return artifacts
         } else {
           for (const dirPath of dirList) {
             const result = await this.getArtefactsFromFE (dirPath, contractName)
@@ -106,7 +106,7 @@ export class CompilerArtefacts extends Plugin {
     const contractsData = Object.values(contractsDataByFilename)
     if (contractsData && contractsData.length) {
       const index = contractsData.findIndex((contractsObj) => Object.keys(contractsObj).includes(contractName))
-      if (index !== -1) return { abi: contractsData[index][contractName].abi, bytecode: contractsData[index][contractName].evm.bytecode.object }
+      if (index !== -1) return contractsData[index][contractName]
       else {
         const result = await this.getArtefactsFromFE ('contracts', contractName)
         if (result) return result

--- a/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
@@ -72,7 +72,7 @@ export class CompilerArtefacts extends Plugin {
     return contractsData
   }
 
-  getAllContractArtefactsfromOutput (contractsOutput, contractName) {
+  _getAllContractArtefactsfromOutput (contractsOutput, contractName) {
     const contractArtefacts = {}
     for (const filename in contractsOutput) {
       if(Object.keys(contractsOutput[filename]).includes(contractName)) contractArtefacts[filename + ':' + contractName] = contractsOutput[filename][contractName]
@@ -80,7 +80,7 @@ export class CompilerArtefacts extends Plugin {
     return contractArtefacts
   }
 
-  async getArtefactsFromFE (path, contractName, contractArtefacts) {
+  async _getArtefactsFromFE (path, contractName, contractArtefacts) {
     const dirList = await this.call('fileManager', 'dirList', path)
     if(dirList && dirList.length) {
       for (const dirPath of dirList) {
@@ -90,13 +90,13 @@ export class CompilerArtefacts extends Plugin {
             let content = await this.call('fileManager', 'readFile', buildFile)
             if (content) content = JSON.parse(content)
             const contracts = content.output.contracts
-            const artefacts = this.getAllContractArtefactsfromOutput(contracts, contractName)
+            const artefacts = this._getAllContractArtefactsfromOutput(contracts, contractName)
             Object.assign(contractArtefacts, artefacts)
           }
-      } else await this.getArtefactsFromFE (dirPath, contractName, contractArtefacts)
-    } 
-  } else return
-}
+        } else await this._getArtefactsFromFE (dirPath, contractName, contractArtefacts)
+      } 
+    } else return
+  }
 
   async getArtefactsByContractName (contractName) {
     const contractsDataByFilename = this.getAllContractDatas()
@@ -108,15 +108,15 @@ export class CompilerArtefacts extends Plugin {
         return contractsDataByFilename[filename][contract]
       else {
         const allContractsData = {}
-        await this.getArtefactsFromFE ('contracts', contract, allContractsData)
+        await this._getArtefactsFromFE ('contracts', contract, allContractsData)
         if(allContractsData[contractName]) return allContractsData[contractName]
         else throw new Error(`Could not find artifacts for ${contractName}. Compile contract to generate artifacts.`)
       }
     } else {
-      const contractArtefacts = this.getAllContractArtefactsfromOutput(contractsDataByFilename, contractName)
+      const contractArtefacts = this._getAllContractArtefactsfromOutput(contractsDataByFilename, contractName)
       let keys = Object.keys(contractArtefacts)
       if (!keys.length) {
-        await this.getArtefactsFromFE ('contracts', contractName, contractArtefacts)
+        await this._getArtefactsFromFE ('contracts', contractName, contractArtefacts)
         keys = Object.keys(contractArtefacts)
       }
       if (keys.length === 1) return contractArtefacts[keys[0]]

--- a/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
@@ -73,7 +73,7 @@ export class CompilerArtefacts extends Plugin {
   }
 
   getAllContractArtefactsfromOutput (contractsOutput, contractName) {
-    let contractArtefacts = {}
+    const contractArtefacts = {}
     for (const filename in contractsOutput) {
       if(Object.keys(contractsOutput[filename]).includes(contractName)) contractArtefacts[filename + ':' + contractName] = contractsOutput[filename][contractName]
     }
@@ -100,8 +100,8 @@ export class CompilerArtefacts extends Plugin {
 
   async getArtefactsByContractName (contractName) {
     const contractsDataByFilename = this.getAllContractDatas()
-    let contractArtefacts
-    contractArtefacts = this.getAllContractArtefactsfromOutput(contractsDataByFilename, contractName)
+    // let contractArtefacts
+    const  contractArtefacts = this.getAllContractArtefactsfromOutput(contractsDataByFilename, contractName)
     let keys = Object.keys(contractArtefacts)
     if (!keys.length) {
       await this.getArtefactsFromFE ('contracts', contractName, contractArtefacts)

--- a/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
@@ -107,7 +107,7 @@ export class CompilerArtefacts extends Plugin {
       if(Object.keys(contractsDataByFilename).includes(filename) && contractsDataByFilename[filename][contract]) 
         return contractsDataByFilename[filename][contract]
       else {
-        let allContractsData = {}
+        const allContractsData = {}
         await this.getArtefactsFromFE ('contracts', contract, allContractsData)
         if(allContractsData[contractName]) return allContractsData[contractName]
         else throw new Error(`Could not find artifacts for ${contractName}. Compile contract to generate artifacts.`)

--- a/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
@@ -108,12 +108,12 @@ export class CompilerArtefacts extends Plugin {
       keys = Object.keys(contractArtefacts)
     }
     if (keys.length === 1) return contractArtefacts[keys[0]]
-    else {
+    else if (keys.length > 1) {
       throw new Error(`There are multiple artifacts for contract "${contractName}", please use a fully qualified name.\n
         Please replace ${contractName} for one of these options wherever you are trying to read its artifact: \n
         ${keys.join()}\n
         OR just compile the required contract again`)
-    }
+    } else throw new Error(`Could not find artifacts for ${contractName}. Compile contract to generate artifacts.`)
   }
 
   getCompilerAbstract (file) {

--- a/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-artefacts.ts
@@ -24,12 +24,12 @@ export class CompilerArtefacts extends Plugin {
   }
 
   onActivation () {
-    const saveCompilationPerFileResult = (file, source, languageVersion, data) => {
-      this.compilersArtefactsPerFile[file] = new CompilerAbstract(languageVersion, data, source)
+    const saveCompilationPerFileResult = (file, source, languageVersion, data, input?) => {
+      this.compilersArtefactsPerFile[file] = new CompilerAbstract(languageVersion, data, source, input)
     }
 
-    this.on('solidity', 'compilationFinished', (file, source, languageVersion, data) => {
-      this.compilersArtefacts.__last = new CompilerAbstract(languageVersion, data, source)
+    this.on('solidity', 'compilationFinished', (file, source, languageVersion, data, input, version) => {
+      this.compilersArtefacts.__last = new CompilerAbstract(languageVersion, data, source, input)
       saveCompilationPerFileResult(file, source, languageVersion, data)
     })
 
@@ -48,9 +48,9 @@ export class CompilerArtefacts extends Plugin {
       saveCompilationPerFileResult(file, source, languageVersion, data)
     })
 
-    this.on('solidityUnitTesting', 'compilationFinished', (file, source, languageVersion, data) => {
-      this.compilersArtefacts.__last = new CompilerAbstract(languageVersion, data, source)
-      saveCompilationPerFileResult(file, source, languageVersion, data)
+    this.on('solidityUnitTesting', 'compilationFinished', (file, source, languageVersion, data, input, version) => {
+      this.compilersArtefacts.__last = new CompilerAbstract(languageVersion, data, source, input)
+      saveCompilationPerFileResult(file, source, languageVersion, data, input)
     })
   }
 

--- a/libs/remix-core-plugin/src/lib/compiler-metadata.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-metadata.ts
@@ -39,7 +39,8 @@ export class CompilerMetadata extends Plugin {
       const compiler = new CompilerAbstract(languageVersion, data, source)
       const path = self._extractPathOf(source.target)
       const outputFileName = this._OutputFileName(path, source.target)
-      await this.call('fileManager', 'writeFile', outputFileName, JSON.stringify(data, null, '\t'))
+      const buildData = { output: data }
+      await this.call('fileManager', 'writeFile', outputFileName, JSON.stringify(buildData, null, '\t'))
       compiler.visitContracts((contract) => {
         if (contract.file !== source.target) return
         (async () => {

--- a/libs/remix-core-plugin/src/lib/compiler-metadata.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-metadata.ts
@@ -29,7 +29,7 @@ export class CompilerMetadata extends Plugin {
   _OutputFileName (path, target) {
     const paths = target.split('/')
     const fileName = paths[paths.length - 1]
-    return this.joinPath(path, this.innerPath, 'output/' +  fileName + '.json')
+    return this.joinPath(path, this.innerPath, 'build-info/' +  fileName + '.json')
   }
 
   onActivation () {

--- a/libs/remix-core-plugin/src/lib/compiler-metadata.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-metadata.ts
@@ -23,7 +23,7 @@ export class CompilerMetadata extends Plugin {
   }
 
   _MetadataFileName (path, contractName) {
-    return this.joinPath(path, this.innerPath, contractName + '_metadata.json')
+    return this.joinPath(path, this.innerPath, contractName + '_compResult.json')
   }
 
   onActivation () {
@@ -51,27 +51,21 @@ export class CompilerMetadata extends Plugin {
 
   async _setArtefacts (content, contract, path) {
     content = content || '{}'
+    const fileName = this._JSONFileName(path, contract.name)
+    const metadataFileName = this._MetadataFileName(path, contract.name)
+
+    if (contract && contract.object) await this.call('fileManager', 'writeFile', metadataFileName, JSON.stringify(contract.object, null, '\t'))
+
     let metadata
     try {
       metadata = JSON.parse(content)
     } catch (e) {
       console.log(e)
     }
-    const fileName = this._JSONFileName(path, contract.name)
-    const metadataFileName = this._MetadataFileName(path, contract.name)
-
     const deploy = metadata.deploy || {}
     this.networks.forEach((network) => {
       deploy[network] = this._syncContext(contract, deploy[network] || {})
     })
-
-    let parsedMetadata
-    try {
-      parsedMetadata = JSON.parse(contract.object.metadata)
-    } catch (e) {
-      console.log(e)
-    }
-    if (parsedMetadata) await this.call('fileManager', 'writeFile', metadataFileName, JSON.stringify(parsedMetadata, null, '\t'))
 
     const data = {
       deploy,

--- a/libs/remix-core-plugin/src/lib/compiler-metadata.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-metadata.ts
@@ -27,7 +27,7 @@ export class CompilerMetadata extends Plugin {
   }
 
   _OutputFileName (path, target) {
-    return this.joinPath(path, this.innerPath, 'output/' +  target.replace('/', '_') + '.json')
+    return this.joinPath(path, this.innerPath, 'output/' +  target.replace(/\//g, '_') + '.json')
   }
 
   onActivation () {

--- a/libs/remix-core-plugin/src/lib/compiler-metadata.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-metadata.ts
@@ -31,7 +31,7 @@ export class CompilerMetadata extends Plugin {
     const self = this
     this.on('solidity', 'compilationFinished', async (file, source, languageVersion, data, input, version) => {
       if (!await this.call('settings', 'get', 'settings/generate-contract-metadata')) return
-      const compiler = new CompilerAbstract(languageVersion, data, source)
+      const compiler = new CompilerAbstract(languageVersion, data, source, input)
       const path = self._extractPathOf(source.target)
       await this.setBuildInfo(version, input, data, path)
       compiler.visitContracts((contract) => {

--- a/libs/remix-core-plugin/src/lib/compiler-metadata.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-metadata.ts
@@ -26,8 +26,8 @@ export class CompilerMetadata extends Plugin {
     return this.joinPath(path, this.innerPath, contractName + '_metadata.json')
   }
 
-  _OutputFileName (path, contractName) {
-    return this.joinPath(path, this.innerPath, contractName + '_fullOP.json')
+  _OutputFileName (path, target) {
+    return this.joinPath(path, this.innerPath, 'output/' +  target.replace('/', '_') + '.json')
   }
 
   onActivation () {
@@ -36,6 +36,8 @@ export class CompilerMetadata extends Plugin {
       if (!await this.call('settings', 'get', 'settings/generate-contract-metadata')) return
       const compiler = new CompilerAbstract(languageVersion, data, source)
       const path = self._extractPathOf(source.target)
+      const outputFileName = this._OutputFileName(path, source.target)
+      await this.call('fileManager', 'writeFile', outputFileName, JSON.stringify(data, null, '\t'))
       compiler.visitContracts((contract) => {
         if (contract.file !== source.target) return
         (async () => {
@@ -57,9 +59,6 @@ export class CompilerMetadata extends Plugin {
     content = content || '{}'
     const fileName = this._JSONFileName(path, contract.name)
     const metadataFileName = this._MetadataFileName(path, contract.name)
-    const opFileName = this._OutputFileName(path, contract.name)
-
-    if (contract && contract.object) await this.call('fileManager', 'writeFile', opFileName, JSON.stringify(contract.object, null, '\t'))
 
     let metadata
     try {

--- a/libs/remix-core-plugin/src/lib/compiler-metadata.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-metadata.ts
@@ -27,7 +27,9 @@ export class CompilerMetadata extends Plugin {
   }
 
   _OutputFileName (path, target) {
-    return this.joinPath(path, this.innerPath, 'output/' +  target.replace(/\//g, '_') + '.json')
+    const paths = target.split('/')
+    const fileName = paths[paths.length - 1]
+    return this.joinPath(path, this.innerPath, 'output/' +  fileName + '.json')
   }
 
   onActivation () {

--- a/libs/remix-core-plugin/src/lib/editor-context-listener.ts
+++ b/libs/remix-core-plugin/src/lib/editor-context-listener.ts
@@ -42,7 +42,7 @@ export class EditorContextListener extends Plugin {
   onActivation () {
     this.on('editor', 'contentChanged', () => { this._stopHighlighting() })
 
-    this.on('solidity', 'compilationFinished', (file, source, languageVersion, data) => {
+    this.on('solidity', 'compilationFinished', (file, source, languageVersion, data, input, version) => {
       if (languageVersion.indexOf('soljson') !== 0) return
       this._stopHighlighting()
       this._index = {

--- a/libs/remix-core-plugin/src/lib/offset-line-to-column-converter.ts
+++ b/libs/remix-core-plugin/src/lib/offset-line-to-column-converter.ts
@@ -70,7 +70,7 @@ export class OffsetToLineColumnConverter extends Plugin {
    * called by plugin API
    */
   activate () {
-    this.on('solidity', 'compilationFinished', () => {
+    this.on('solidity', 'compilationFinished', (success, data, source, input, version) => {
       this.clear()
     })
   }

--- a/libs/remix-debug/src/source/offsetToLineColumnConverter.ts
+++ b/libs/remix-debug/src/source/offsetToLineColumnConverter.ts
@@ -8,7 +8,7 @@ export class OffsetToColumnConverter {
   constructor (compilerEvent) {
     this.lineBreakPositionsByContent = {}
     if (compilerEvent) {
-      compilerEvent.register('compilationFinished', (success, data, source) => {
+      compilerEvent.register('compilationFinished', (success, data, source, input, version) => {
         this.clear()
       })
     }

--- a/libs/remix-solidity/src/compiler/compiler-abstract.ts
+++ b/libs/remix-solidity/src/compiler/compiler-abstract.ts
@@ -5,10 +5,12 @@ export class CompilerAbstract {
   languageversion: any
     data: any
     source: any
-    constructor (languageversion, data, source) {
+    input: any
+    constructor (languageversion, data, source, input?) {
       this.languageversion = languageversion
       this.data = data
       this.source = source // source code
+      this.input = input // source code
     }
 
     getContracts () {
@@ -25,6 +27,10 @@ export class CompilerAbstract {
 
     getData () {
       return this.data
+    }
+
+    getInput () {
+      return this.input
     }
 
     getAsts () {

--- a/libs/remix-solidity/src/compiler/compiler-helpers.ts
+++ b/libs/remix-solidity/src/compiler/compiler-helpers.ts
@@ -12,8 +12,8 @@ export const compile = async (compilationTargets, settings, contentResolverCallb
       compiler.set('language', settings.language)
       compiler.set('runs', settings.runs)
       compiler.loadVersion(canUseWorker(settings.version), urlFromVersion(settings.version))
-      compiler.event.register('compilationFinished', (success, compilationData, source) => {
-        resolve(new CompilerAbstract(settings.version, compilationData, source))
+      compiler.event.register('compilationFinished', (success, compilationData, source, input, version) => {
+        resolve(new CompilerAbstract(settings.version, compilationData, source, input))
       })
       compiler.event.register('compilerLoaded', _ => compiler.compile(compilationTargets, ''))
     })

--- a/libs/remix-solidity/src/compiler/compiler-worker.ts
+++ b/libs/remix-solidity/src/compiler/compiler-worker.ts
@@ -45,6 +45,7 @@ export default function (self) { // eslint-disable-line @typescript-eslint/expli
             cmd: 'compiled',
             job: data.job,
             data: compileJSON(data.input),
+            input: data.input,
             missingInputs: missingInputs
           })
         }

--- a/libs/remix-solidity/src/compiler/compiler.ts
+++ b/libs/remix-solidity/src/compiler/compiler.ts
@@ -9,8 +9,7 @@ import {
   Source, SourceWithTarget, MessageFromWorker, CompilerState, CompilationResult,
   visitContractsCallbackParam, visitContractsCallbackInterface, CompilationError,
   gatherImportsCallbackInterface,
-  isFunctionDescription,
-  CompilerInput
+  isFunctionDescription
 } from './types'
 
 /*
@@ -38,7 +37,7 @@ export class Compiler {
       }
     }
 
-    this.event.register('compilationFinished', (success: boolean, data: CompilationResult, source: SourceWithTarget) => {
+    this.event.register('compilationFinished', (success: boolean, data: CompilationResult, source: SourceWithTarget, input: string, version: string) => {
       if (success && this.state.compilationStartTime) {
         this.event.trigger('compilationDuration', [(new Date().getTime()) - this.state.compilationStartTime])
       }
@@ -71,7 +70,7 @@ export class Compiler {
     this.gatherImports(files, missingInputs, (error, input) => {
       if (error) {
         this.state.lastCompilationResult = null
-        this.event.trigger('compilationFinished', [false, { error: { formattedMessage: error, severity: 'error' } }, files])
+        this.event.trigger('compilationFinished', [false, { error: { formattedMessage: error, severity: 'error' } }, files, input, this.state.currentVersion])
       } else if (this.state.compileJSON && input) { this.state.compileJSON(input) }
     })
   }

--- a/libs/remix-solidity/src/compiler/compiler.ts
+++ b/libs/remix-solidity/src/compiler/compiler.ts
@@ -148,7 +148,7 @@ export class Compiler {
     if (!noFatalErrors) {
       // There are fatal errors, abort here
       this.state.lastCompilationResult = null
-      this.event.trigger('compilationFinished', [false, data, source])
+      this.event.trigger('compilationFinished', [false, data, source, input, version])
     } else if (missingInputs !== undefined && missingInputs.length > 0 && source && source.sources) {
       // try compiling again with the new set of inputs
       this.internalCompile(source.sources, missingInputs)

--- a/libs/remix-solidity/src/compiler/compiler.ts
+++ b/libs/remix-solidity/src/compiler/compiler.ts
@@ -111,16 +111,17 @@ export class Compiler {
           return { error: 'Deferred import' }
         }
         let result: CompilationResult = {}
+        let input
         try {
           if (source && source.sources) {
             const { optimize, runs, evmVersion, language } = this.state
-            const input = compilerInput(source.sources, { optimize, runs, evmVersion, language })
+            input = compilerInput(source.sources, { optimize, runs, evmVersion, language })
             result = JSON.parse(compiler.compile(input, { import: missingInputsCallback }))
           }
         } catch (exception) {
           result = { error: { formattedMessage: 'Uncaught JavaScript exception:\n' + exception, severity: 'error', mode: 'panic' } }
         }
-        this.onCompilationFinished(result, missingInputs, source)
+        this.onCompilationFinished(result, missingInputs, source, input, this.state.currentVersion)
       }
       this.onCompilerLoaded(compiler.version())
     }
@@ -133,7 +134,7 @@ export class Compiler {
    * @param source Source
    */
 
-  onCompilationFinished (data: CompilationResult, missingInputs?: string[], source?: SourceWithTarget): void {
+  onCompilationFinished (data: CompilationResult, missingInputs?: string[], source?: SourceWithTarget, input?, version?): void {
     let noFatalErrors = true // ie warnings are ok
 
     const checkIfFatalError = (error: CompilationError) => {
@@ -159,7 +160,7 @@ export class Compiler {
           source: source
         }
       }
-      this.event.trigger('compilationFinished', [true, data, source])
+      this.event.trigger('compilationFinished', [true, data, source, input, version])
     }
   }
 
@@ -182,16 +183,17 @@ export class Compiler {
             return { error: 'Deferred import' }
           }
           let result: CompilationResult = {}
+          let input
           try {
             if (source && source.sources) {
               const { optimize, runs, evmVersion, language } = this.state
-              const input = compilerInput(source.sources, { optimize, runs, evmVersion, language })
+              input = compilerInput(source.sources, { optimize, runs, evmVersion, language })
               result = JSON.parse(remoteCompiler.compile(input, { import: missingInputsCallback }))
             }
           } catch (exception) {
             result = { error: { formattedMessage: 'Uncaught JavaScript exception:\n' + exception, severity: 'error', mode: 'panic' } }
           }
-          this.onCompilationFinished(result, missingInputs, source)
+          this.onCompilationFinished(result, missingInputs, source, input, version)
         }
         this.onCompilerLoaded(version)
       }
@@ -273,7 +275,7 @@ export class Compiler {
               sources = jobs[data.job].sources
               delete jobs[data.job]
             }
-            this.onCompilationFinished(result, data.missingInputs, sources)
+            this.onCompilationFinished(result, data.missingInputs, sources, data.input, this.state.currentVersion)
           }
           break
         }

--- a/libs/remix-solidity/src/compiler/compiler.ts
+++ b/libs/remix-solidity/src/compiler/compiler.ts
@@ -9,7 +9,8 @@ import {
   Source, SourceWithTarget, MessageFromWorker, CompilerState, CompilationResult,
   visitContractsCallbackParam, visitContractsCallbackInterface, CompilationError,
   gatherImportsCallbackInterface,
-  isFunctionDescription
+  isFunctionDescription,
+  CompilerInput
 } from './types'
 
 /*
@@ -134,7 +135,7 @@ export class Compiler {
    * @param source Source
    */
 
-  onCompilationFinished (data: CompilationResult, missingInputs?: string[], source?: SourceWithTarget, input?, version?): void {
+  onCompilationFinished (data: CompilationResult, missingInputs?: string[], source?: SourceWithTarget, input?: string, version?: string): void {
     let noFatalErrors = true // ie warnings are ok
 
     const checkIfFatalError = (error: CompilationError) => {
@@ -183,7 +184,7 @@ export class Compiler {
             return { error: 'Deferred import' }
           }
           let result: CompilationResult = {}
-          let input
+          let input: string
           try {
             if (source && source.sources) {
               const { optimize, runs, evmVersion, language } = this.state

--- a/libs/remix-solidity/src/compiler/types.ts
+++ b/libs/remix-solidity/src/compiler/types.ts
@@ -186,6 +186,7 @@ export interface MessageFromWorker {
   cmd: string,
   job?: number,
   missingInputs?: string[],
+  input?: any,
   data?: string
 }
 

--- a/libs/remix-tests/src/compiler.ts
+++ b/libs/remix-tests/src/compiler.ts
@@ -142,7 +142,7 @@ export function compileFileOrFiles (filename: string, isDirectory: boolean, opts
       },
       function doCompilation (next) {
         // @ts-ignore
-        compiler.event.register('compilationFinished', this, (success, data, source) => {
+        compiler.event.register('compilationFinished', this, (success, data, source, input, version) => {
           next(null, data)
         })
         compiler.compile(sources, filepath)
@@ -201,10 +201,10 @@ export function compileContractSources (sources: SrcIfc, newCompConfig: any, imp
       }
     },
     (next) => {
-      const compilationFinishedCb = (success, data, source) => {
+      const compilationFinishedCb = (success, data, source, input, version) => {
         // data.error usually exists for exceptions like worker error etc.
         if (!data.error) UTRunner.compiler = compiler
-        if (opts && opts.event) opts.event.emit('compilationFinished', success, data, source)
+        if (opts && opts.event) opts.event.emit('compilationFinished', success, data, source, input, version)
         next(null, data)
       }
       compiler.event.unregister('compilationFinished', compilationFinishedCb)

--- a/libs/remix-ui/run-tab/src/lib/actions/index.ts
+++ b/libs/remix-ui/run-tab/src/lib/actions/index.ts
@@ -66,7 +66,7 @@ const setupEvents = () => {
 
   plugin.on('manager', 'pluginDeactivated', removePluginProvider.bind(plugin))
 
-  plugin.on('solidity', 'compilationFinished', (file, source, languageVersion, data) => broadcastCompilationResult(file, source, languageVersion, data))
+  plugin.on('solidity', 'compilationFinished', (file, source, languageVersion, data, input, version) => broadcastCompilationResult(file, source, languageVersion, data, input))
 
   plugin.on('vyper', 'compilationFinished', (file, source, languageVersion, data) => broadcastCompilationResult(file, source, languageVersion, data))
 
@@ -301,9 +301,9 @@ export const signMessageWithAddress = (account: string, message: string, modalCo
   })
 }
 
-const broadcastCompilationResult = (file, source, languageVersion, data) => {
+const broadcastCompilationResult = (file, source, languageVersion, data, input?) => {
   // TODO check whether the tab is configured
-  const compiler = new CompilerAbstract(languageVersion, data, source)
+  const compiler = new CompilerAbstract(languageVersion, data, source, input)
 
   plugin.compilersArtefacts[languageVersion] = compiler
   plugin.compilersArtefacts.__last = compiler

--- a/libs/remix-ui/solidity-compiler/src/lib/actions/compiler.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/actions/compiler.ts
@@ -50,7 +50,7 @@ export const listenToEvents = (compileTabLogic: CompileTabLogic, api) => (dispat
     dispatch(setCompilerMode('compilerLoaded'))
   })
 
-  compileTabLogic.compiler.event.register('compilationFinished', (success, data, source) => {
-    dispatch(setCompilerMode('compilationFinished', success, data, source))
+  compileTabLogic.compiler.event.register('compilationFinished', (success, data, source, input, version) => {
+    dispatch(setCompilerMode('compilationFinished', success, data, source, input, version))
   })
 }

--- a/libs/remix-ui/static-analyser/src/lib/actions/staticAnalysisActions.ts
+++ b/libs/remix-ui/static-analyser/src/lib/actions/staticAnalysisActions.ts
@@ -5,9 +5,9 @@ export const compilation = (analysisModule, dispatch) => {
     analysisModule.on(
       'solidity',
       'compilationFinished',
-      (file, source, languageVersion, data) => {
+      (file, source, languageVersion, data, input, version) => {
         if (languageVersion.indexOf('soljson') !== 0) return
-        dispatch({ type: 'compilationFinished', payload: { file, source, languageVersion, data } })
+        dispatch({ type: 'compilationFinished', payload: { file, source, languageVersion, data, input, version } })
       }
     )
   }

--- a/libs/remix-ui/static-analyser/src/lib/reducers/staticAnalysisReducer.ts
+++ b/libs/remix-ui/static-analyser/src/lib/reducers/staticAnalysisReducer.ts
@@ -13,7 +13,9 @@ export const analysisReducer = (state, action) => {
         file: action.payload.file,
         source: action.payload.source,
         languageVersion: action.payload.languageVersion,
-        data: action.payload.data
+        data: action.payload.data,
+        input: action.payload.input,
+        version: action.payload.version
       }
     default:
       return initialState


### PR DESCRIPTION
- compiler input and version is also emitted with `compilationFinished` event
- build info is generated same as in hardhat
- Shows error while accessing the artefacts using contractName in case of same contract name in more than one files
- Allow accessing artefacts using fully qualified name which is `<filepath>:<contractName>`

For more info on compiler input and output: https://docs.soliditylang.org/en/v0.8.12/using-the-compiler.html#compiler-input-and-output-json-description