### PR TITLE
Fix retrieving events abi

### DIFF
--- a/libs/remix-lib/src/execution/eventsDecoder.ts
+++ b/libs/remix-lib/src/execution/eventsDecoder.ts
@@ -56,18 +56,19 @@ export class EventsDecoder {
     return eventsABI
   }
 
-  _event (hash, eventsABI) {
-    for (const k in eventsABI) {
-      if (eventsABI[k][hash]) {
-        const event = eventsABI[k][hash]
-        for (const input of event.inputs) {
-          if (input.type === 'function') {
-            input.type = 'bytes24'
-            input.baseType = 'bytes24'
-          }
+  _event (hash: string, eventsABI: Record<string, unknown>, contractName: string) {
+    const events = eventsABI[contractName]
+    if (!events) return null
+
+    if (events[hash]) {
+      const event = events[hash]
+      for (const input of event.inputs) {
+        if (input.type === 'function') {
+          input.type = 'bytes24'
+          input.baseType = 'bytes24'
         }
-        return event
       }
+      return event
     }
     return null
   }
@@ -94,7 +95,7 @@ export class EventsDecoder {
       // [address, topics, mem]
       const log = logs[i]
       const topicId = log.topics[0]
-      const eventAbi = this._event(topicId.replace('0x', ''), eventsABI)
+      const eventAbi = this._event(topicId.replace('0x', ''), eventsABI, contractName)
       if (eventAbi) {
         const decodedlog = eventAbi.abi.parseLog(log)
         const decoded = {}


### PR DESCRIPTION
`eventsABI` is a mapping of contract name as key, and the values are mapping of event.

This function loops over all the contracts and all the events hashes to find the one given as parameter.
But there are duplicates..
The bug is that the current contract was ERC721 and event `Transfer` but the one returned by the function was the `Transfer` of an ERC20 (which is part of the compilation result too).

So the PR makes sure we are looking at the right contract.
