### PR TITLE
fix: update test name with missing g

### DIFF
--- a/apps/remix-ide-e2e/src/examples/example-contracts.ts
+++ b/apps/remix-ide-e2e/src/examples/example-contracts.ts
@@ -301,7 +301,7 @@ contract BallotTest {
         Assert.equal(ballotToTest.winnerName(), bytes32("candidate1"), "candidate1 should be the winner name");
     }
     
-    function checkWinninProposalWithReturnValue () public view returns (bool) {
+    function checkWinningProposalWithReturnValue () public view returns (bool) {
         return ballotToTest.winningProposal() == 0;
     }
 }

--- a/apps/remix-ide-e2e/src/tests/solidityUnittests.test.ts
+++ b/apps/remix-ide-e2e/src/tests/solidityUnittests.test.ts
@@ -310,9 +310,9 @@ module.exports = {
       .clickLaunchIcon('solidityUnitTesting').pause(5000)
       .scrollAndClick('#Check_winnin_proposal_with_return_value').pause(5000)
       .waitForElementContainsText('*[data-id="sidePanelSwapitTitle"]', 'DEBUGGER', 60000)
-      .waitForElementContainsText('*[data-id="functionPanel"]', 'checkWinninProposalWithReturnValue()', 60000)
+      .waitForElementContainsText('*[data-id="functionPanel"]', 'checkWinningProposalWithReturnValue()', 60000)
       .goToVMTraceStep(321)
-      .waitForElementContainsText('*[data-id="functionPanel"]', 'checkWinninProposalWithReturnValue()', 60000)
+      .waitForElementContainsText('*[data-id="functionPanel"]', 'checkWinningProposalWithReturnValue()', 60000)
       .clickLaunchIcon('filePanel')
       .pause(2000)
       .openFile('tests/ballotFailedDebug_test.sol')
@@ -572,7 +572,7 @@ const sources = [
               Assert.equal(ballotToTest.winningProposal(), uint(1), "proposal at index 0 should be the winning proposal");
           }
           
-          function checkWinninProposalWithReturnValue () public view returns (bool) {
+          function checkWinningProposalWithReturnValue () public view returns (bool) {
               return ballotToTest.winningProposal() == 0;
           }
       }`

--- a/libs/remix-ui/workspace/src/lib/templates/examples.ts
+++ b/libs/remix-ui/workspace/src/lib/templates/examples.ts
@@ -248,7 +248,7 @@ contract BallotTest {
         Assert.equal(ballotToTest.winnerName(), bytes32("candidate1"), "candidate1 should be the winner name");
     }
     
-    function checkWinninProposalWithReturnValue () public view returns (bool) {
+    function checkWinningProposalWithReturnValue () public view returns (bool) {
         return ballotToTest.winningProposal() == 0;
     }
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/ethereum/remix-project/issues/2108

This updates the test name in `tests/4_Ballot_test.sol` to include the missing `g`, so all instance now show the correctly named test:

```solidity
    function checkWinningProposalWithReturnValue () public view returns (bool) {
      // ...
    }
```

### Before

<img width="318" alt="check-winnin-proposal-with-return-value" src="https://user-images.githubusercontent.com/78528185/155845378-7c297e3a-ab46-4180-838a-1312be2de111.png">


### After

<img width="320" alt="Screen Shot 2022-02-26 at 5 44 57 AM" src="https://user-images.githubusercontent.com/78528185/155845484-51572ac9-b93b-4834-817c-9228f5bb59b1.png">

