### PR TITLE
Make sure we remove the current file from the previous session

### DIFF
--- a/apps/remix-ide/src/app/files/fileManager.ts
+++ b/apps/remix-ide/src/app/files/fileManager.ts
@@ -410,6 +410,9 @@ class FileManager extends Plugin {
       workspaceExplorer: this._components.registry.get('fileproviders/workspace').api,
       filesProviders: this._components.registry.get('fileproviders').api
     }
+
+    this._deps.config.set('currentFile', '') // make sure we remove the current file from the previous session
+
     this._deps.browserExplorer.event.on('fileChanged', (path) => { this.fileChangedEvent(path) })
     this._deps.browserExplorer.event.on('fileRenamed', (oldName, newName, isFolder) => { this.fileRenamedEvent(oldName, newName, isFolder) })
     this._deps.localhostExplorer.event.on('fileRenamed', (oldName, newName, isFolder) => { this.fileRenamedEvent(oldName, newName, isFolder) })


### PR DESCRIPTION
This fixes this situation:

 - run remixd and connect to remix ide.
 - close remix ide first and remixd.
 - reload remix ide, the `current file` is still a remixd file and loading the workspace fails.