### PR TITLE
Allow users to specify gasLimit instead of forcing the estimate

### DIFF
--- a/libs/remix-lib/src/execution/txRunnerWeb3.ts
+++ b/libs/remix-lib/src/execution/txRunnerWeb3.ts
@@ -109,8 +109,8 @@ export class TxRunnerWeb3 {
         err = network.name === 'VM' ? null : err // just send the tx if "VM"
         gasEstimationForceSend(err, () => {
           // callback is called whenever no error
-          tx['gas'] = !gasEstimation ? gasLimit : gasEstimation
-  
+          tx['gas'] = gasLimit
+
           if (this._api.config.getUnpersistedProperty('doNotShowTransactionConfirmationAgain')) {
             return this._executeTx(tx, network, null, this._api, promptCb, callback)
           }


### PR DESCRIPTION
Fixes #2310 

## Description

The gas estimation is used to determine if the `gasLimit` provided by the user is enough to execute the transaction, otherwise the UI shows an error regarding it (same for when the estimate exceeds block's `gasLimit`).

For some reason, the tx sent for any contract interaction was forced to use the estimate and fallback to the user's `gasLimit`. Remix should honor whatever the user sets in the `gasLimit` field.

Also [more context here](https://twitter.com/destructioneth/status/1515012325647990794)