### PR TITLE
fix vscode spelling

### DIFF
--- a/libs/remix-ui/README.md
+++ b/libs/remix-ui/README.md
@@ -3,7 +3,7 @@
 This library was generated with [Nx](https://nx.dev).
 
 ## Pre-requisite
--	Install **NxConsole** vscose extension
+-	Install **NxConsole** vscode extension
 ## Steps To Generate React App
 -	Open **NxConsole** extension
 -	Click generate option


### PR DESCRIPTION
`vscode` was spelt as `vscose` in the remix-ui README. So, I corrected that