### PR TITLE
that -> than in `apps/remix-de/docs/layout.md`

### DIFF
--- a/apps/remix-ide/docs/layout.md
+++ b/apps/remix-ide/docs/layout.md
@@ -49,6 +49,6 @@ The Plugin Manager is also the place you go when you are creating your own plugi
 Themes
 ---------------
 
-So you want to work on Remix with a dark theme or a gray theme or just a different theme that the one you are currently looking at?  Go to the settings tab and at the bottom is a choice of lots of bootstrap based themes.
+So you want to work on Remix with a dark theme or a gray theme or just a different theme than the one you are currently looking at?  Go to the settings tab and at the bottom is a choice of lots of bootstrap based themes.
 
 ![](images/a-themes.png) 


### PR DESCRIPTION
This pull request corrects a mis-spelling on this page of the documentation, under "Themes": https://remix-ide.readthedocs.io/en/latest/layout.html#themes