### PR TITLE
remove unreachable code

### DIFF
--- a/apps/remix-ide/src/app/editor/editor.js
+++ b/apps/remix-ide/src/app/editor/editor.js
@@ -165,10 +165,6 @@ class Editor extends Plugin {
           }
         }
       }
-      if (name !== this.currentFile) {
-        this.currentFile = name
-        this.renderComponent()
-      }
     })
 
     this.on('fileManager', 'noFileSelected', async () => {


### PR DESCRIPTION
`currentFileChanged` event returns `name` as the current file so condition should always return `false` 