### PR TITLE
Provider: Add Anvil from Foundry as provider

### DIFF
--- a/apps/remix-ide-e2e/src/tests/providers.test.ts
+++ b/apps/remix-ide-e2e/src/tests/providers.test.ts
@@ -29,5 +29,26 @@ module.exports = {
     .waitForElementVisible('*[data-id="ganache-providerModalDialogModalBody-react"]')
     .modalFooterOKClick('ganache-provider')
     .waitForElementContainsText('*[data-id="settingsNetworkEnv"]', 'Custom (')
+  },
+  'Should switch to foundry provider, set a custom URL and fail to connect': function (browser: NightwatchBrowser) {
+    browser.click('*[data-id="Foundry Provider"]')
+    .waitForElementVisible('*[data-id="foundry-providerModalDialogModalBody-react"]')
+    .execute(() => {
+      (document.querySelector('*[data-id="foundry-providerModalDialogModalBody-react"] input') as any).focus()
+    }, [], () => {})
+    .clearValue('*[data-id="foundry-providerModalDialogModalBody-react"] input')
+    .setValue('*[data-id="foundry-providerModalDialogModalBody-react"] input', 'http://127.0.0.1:8084')
+    .modalFooterOKClick('foundry-provider')
+    .waitForElementContainsText('*[data-id="foundry-providerModalDialogModalBody-react"]', 'Error while connecting to the provider')
+    .modalFooterOKClick('foundry-provider')
+    .waitForElementNotVisible('*[data-id="foundry-providerModalDialogModalBody-react"]')
+    .pause(1000)
+
+},
+  'Should switch to foundry provider, use the default foundry URL and succeed to connect': function (browser: NightwatchBrowser) {
+    browser.click('*[data-id="Foundry Provider"]')
+    .waitForElementVisible('*[data-id="foundry-providerModalDialogModalBody-react"]')
+    .modalFooterOKClick('foundry-provider')
+    .waitForElementContainsText('*[data-id="settingsNetworkEnv"]', 'Custom (')
   }
 }

--- a/apps/remix-ide-e2e/src/tests/providers.test.ts
+++ b/apps/remix-ide-e2e/src/tests/providers.test.ts
@@ -33,7 +33,6 @@ module.exports = {
 
   'Should switch to foundry provider, set a custom URL and fail to connect': function (browser: NightwatchBrowser) {
     browser.waitForElementVisible('div[data-id="remixIdeIconPanel"]', 10000)
-    .clickLaunchIcon('udapp')
     .click('*[data-id="Foundry Provider"]')
     .waitForElementVisible('*[data-id="foundry-providerModalDialogModalBody-react"]')
     .execute(() => {
@@ -45,6 +44,9 @@ module.exports = {
     .waitForElementContainsText('*[data-id="foundry-providerModalDialogModalBody-react"]', 'Error while connecting to the provider')
     .modalFooterOKClick('foundry-provider')
     .waitForElementNotVisible('*[data-id="foundry-providerModalDialogModalBody-react"]')
+    .waitForElementVisible('*[data-id="PermissionHandler-modal-footer-ok-react"]')
+    .click('*[data-id="PermissionHandler-modal-footer-ok-react"]')
+    .waitForElementNotVisible('*[data-id="PermissionHandler-modal-footer-ok-react"]')
     .pause(1000)
 
 },

--- a/apps/remix-ide-e2e/src/tests/providers.test.ts
+++ b/apps/remix-ide-e2e/src/tests/providers.test.ts
@@ -30,9 +30,11 @@ module.exports = {
     .modalFooterOKClick('ganache-provider')
     .waitForElementContainsText('*[data-id="settingsNetworkEnv"]', 'Custom (')
   },
-  
+
   'Should switch to foundry provider, set a custom URL and fail to connect': function (browser: NightwatchBrowser) {
-    browser.click('*[data-id="Foundry Provider"]')
+    browser.waitForElementVisible('div[data-id="remixIdeIconPanel"]', 10000)
+    .clickLaunchIcon('udapp')
+    .click('*[data-id="Foundry Provider"]')
     .waitForElementVisible('*[data-id="foundry-providerModalDialogModalBody-react"]')
     .execute(() => {
       (document.querySelector('*[data-id="foundry-providerModalDialogModalBody-react"] input') as any).focus()

--- a/apps/remix-ide-e2e/src/tests/providers.test.ts
+++ b/apps/remix-ide-e2e/src/tests/providers.test.ts
@@ -30,6 +30,7 @@ module.exports = {
     .modalFooterOKClick('ganache-provider')
     .waitForElementContainsText('*[data-id="settingsNetworkEnv"]', 'Custom (')
   },
+  
   'Should switch to foundry provider, set a custom URL and fail to connect': function (browser: NightwatchBrowser) {
     browser.click('*[data-id="Foundry Provider"]')
     .waitForElementVisible('*[data-id="foundry-providerModalDialogModalBody-react"]')

--- a/apps/remix-ide/src/app.js
+++ b/apps/remix-ide/src/app.js
@@ -27,6 +27,7 @@ import { NotificationPlugin } from './app/plugins/notification'
 import { Blockchain } from './blockchain/blockchain.js'
 import { HardhatProvider } from './app/tabs/hardhat-provider'
 import { GanacheProvider } from './app/tabs/ganache-provider'
+import { FoundryProvider } from './app/tabs/foundry-provider'
 
 const isElectron = require('is-electron')
 
@@ -177,6 +178,7 @@ class AppComponent {
     const web3Provider = new Web3ProviderModule(blockchain)
     const hardhatProvider = new HardhatProvider(blockchain)
     const ganacheProvider = new GanacheProvider(blockchain)
+    const foundryProvider = new FoundryProvider(blockchain)
     // ----------------- convert offset to line/column service -----------
     const offsetToLineColumnConverter = new OffsetToLineColumnConverter()
     Registry.getInstance().put({
@@ -233,6 +235,7 @@ class AppComponent {
       storagePlugin,
       hardhatProvider,
       ganacheProvider,
+      foundryProvider,
       this.walkthroughService,
       search
     ])

--- a/apps/remix-ide/src/app/tabs/foundry-provider.tsx
+++ b/apps/remix-ide/src/app/tabs/foundry-provider.tsx
@@ -1,0 +1,33 @@
+import * as packageJson from '../../../../../package.json'
+import { Plugin } from '@remixproject/engine'
+import { AppModal, AlertModal, ModalTypes } from '@remix-ui/app'
+import React from 'react' // eslint-disable-line
+import { Blockchain } from '../../blockchain/blockchain'
+import { ethers } from 'ethers'
+import { AbstractProvider } from './abstract-provider'
+
+const profile = {
+  name: 'foundry-provider',
+  displayName: 'Foundry Provider',
+  kind: 'provider',
+  description: 'Anvil',
+  methods: ['sendAsync'],
+  version: packageJson.version
+}
+
+export class FoundryProvider extends AbstractProvider {
+  constructor (blockchain) {
+    super(profile, blockchain, 'http://127.0.0.1:8545')
+  }
+
+  body (): JSX.Element {
+    return (
+      <div> Note: To run Anvil on your system, run
+        <div className="border p-1">curl -L https://foundry.paradigm.xyz | bash</div> 
+        <div className="border p-1">anvil</div>       
+        For more info, visit: <a href="https://github.com/foundry-rs/foundry" target="_blank">Foundry Documentation</a>
+        <div>Anvil JSON-RPC Endpoint:</div>
+      </div>
+    )
+  }
+}

--- a/apps/remix-ide/src/app/udapp/run-tab.js
+++ b/apps/remix-ide/src/app/udapp/run-tab.js
@@ -128,6 +128,20 @@ export class RunTab extends ViewPlugin {
     })
 
     await this.call('blockchain', 'addProvider', {
+      name: 'Foundry Provider',
+      provider: {
+        async sendAsync (payload, callback) {
+          try {
+            const result = await udapp.call('foundry-provider', 'sendAsync', payload)
+            callback(null, result)
+          } catch (e) {
+            callback(e)
+          }
+        }
+      }
+    })
+
+    await this.call('blockchain', 'addProvider', {
       name: 'Wallet Connect',
       provider: {
         async sendAsync (payload, callback) {


### PR DESCRIPTION
# Description
This PR adds support for Anvil, a JSON-RPC provider from the Foundry stack. 

The PR @ Foundry to add `net_listening` call https://github.com/foundry-rs/foundry/pull/1878

## Motivation

An increasing amount of people are using the Foundry stack, so this change adds the necessary description + option to use Foundry's Anvil. 
