### PR TITLE
add remappings for Foundry project

### DIFF
--- a/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
@@ -33,6 +33,7 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
     configurationSettings,
     isHardhatProject,
     isTruffleProject,
+    isFoundryProject,
     workspaceName,
     configFilePath,
     setConfigFilePath,
@@ -245,7 +246,16 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
     if (filePath === '') filePath = defaultPath
     if (!filePath.endsWith('.json')) filePath = filePath + '.json'
 
-    await api.writeFile(filePath, configFileContent)
+    let compilerConfig = configFileContent
+    if (isFoundryProject && !compilerConfig.includes('remappings')) {
+      let config = JSON.parse(compilerConfig)
+      config.settings.remappings = [
+        'ds-test/=lib/forge-std/lib/ds-test/src/',
+        'forge-std/=lib/forge-std/src/'
+      ]
+      compilerConfig = JSON.stringify(config, null, '\t')
+    }
+    await api.writeFile(filePath, compilerConfig)
     api.setAppParameter('configFilePath', filePath)
     setConfigFilePath(filePath)
     compileTabLogic.setConfigFilePath(filePath)

--- a/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
@@ -248,7 +248,7 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
 
     let compilerConfig = configFileContent
     if (isFoundryProject && !compilerConfig.includes('remappings')) {
-      let config = JSON.parse(compilerConfig)
+      const config = JSON.parse(compilerConfig)
       config.settings.remappings = [
         'ds-test/=lib/forge-std/lib/ds-test/src/',
         'forge-std/=lib/forge-std/src/'

--- a/libs/remix-ui/solidity-compiler/src/lib/logic/compileTabLogic.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/logic/compileTabLogic.ts
@@ -131,6 +131,12 @@ export class CompileTabLogic {
     } else return false
   }
 
+  async isFoundryProject () {
+    if (this.api.getFileManagerMode() === 'localhost') {
+      return await this.api.fileExists('foundry.toml')
+    } else return false
+  }
+
   runCompiler (externalCompType) {
     try {
       if (this.api.getFileManagerMode() === 'localhost') {

--- a/libs/remix-ui/solidity-compiler/src/lib/solidity-compiler.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/solidity-compiler.tsx
@@ -13,6 +13,7 @@ export const SolidityCompiler = (props: SolidityCompilerProps) => {
   const [state, setState] = useState({
     isHardhatProject: false,
     isTruffleProject: false,
+    isFoundryProject: false,
     workspaceName: '',
     currentFile,
     configFilePath: 'compiler_config.json',
@@ -67,9 +68,10 @@ export const SolidityCompiler = (props: SolidityCompilerProps) => {
 
   api.onSetWorkspace = async (isLocalhost: boolean, workspaceName: string) => {
     const isHardhat = isLocalhost && await compileTabLogic.isHardhatProject()
-    const isTruffle =  await compileTabLogic.isTruffleProject()
+    const isTruffle = isLocalhost && await compileTabLogic.isTruffleProject()
+    const isFoundry = isLocalhost && await compileTabLogic.isFoundryProject()
     setState(prevState => {
-      return { ...prevState, currentFile, isHardhatProject: isHardhat, workspaceName: workspaceName, isTruffleProject:  isTruffle }
+      return { ...prevState, currentFile, isHardhatProject: isHardhat, workspaceName: workspaceName, isTruffleProject:  isTruffle, isFoundryProject: isFoundry }
     })
   }
   
@@ -171,6 +173,7 @@ export const SolidityCompiler = (props: SolidityCompilerProps) => {
           isHardhatProject={state.isHardhatProject}
           workspaceName={state.workspaceName}
           isTruffleProject={state.isTruffleProject}
+          isFoundryProject={state.isFoundryProject}
           compileTabLogic={compileTabLogic}
           tooltip={toast}
           modal={modal}

--- a/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
@@ -11,6 +11,7 @@ export interface CompilerContainerProps {
   compileTabLogic: CompileTabLogic,
   isHardhatProject: boolean,
   isTruffleProject: boolean,
+  isFoundryProject: boolean,
   workspaceName: string,
   tooltip: (message: string | JSX.Element) => void,
   modal: (title: string, message: string | JSX.Element, okLabel: string, okFn: () => void, cancelLabel?: string, cancelFn?: () => void) => void,


### PR DESCRIPTION
fixes #2096 

It adds default remappings in compiler configuration file needed to compile a contract from Foundry project only when a Foundry project is loaded under localhost workspace.