### PR TITLE
Pass commands to more than one plugin’s API via an url param

### DIFF
--- a/apps/remix-ide/src/app.js
+++ b/apps/remix-ide/src/app.js
@@ -425,7 +425,11 @@ class AppComponent {
                   );
 
                   // @todo(remove the timeout when activatePlugin is on 0.3.0)
-                  await this.appManager.call(...callDetails).catch(console.error);
+                  try {
+                    await this.appManager.call(...callDetails)
+                  } catch (e) {
+                    console.error(e)
+                  }
                 }
               }
             }

--- a/apps/remix-ide/src/app.js
+++ b/apps/remix-ide/src/app.js
@@ -410,6 +410,25 @@ class AppComponent {
                 this.appManager.call(...callDetails).catch(console.error)
               }
             }
+
+            if (params.calls) {
+              const calls = params.calls.split("///");
+
+              // call all functions in the list, one after the other
+              for (const call of calls) {
+                const callDetails = call.split("//");
+                if (callDetails.length > 1) {
+                  this.appManager.call(
+                    "notification",
+                    "toast",
+                    `initiating ${callDetails[0]} ...`
+                  );
+
+                  // @todo(remove the timeout when activatePlugin is on 0.3.0)
+                  await this.appManager.call(...callDetails).catch(console.error);
+                }
+              }
+            }
           })
           .catch(console.error)
       }


### PR DESCRIPTION
### Description
Hi, this contribution will give users using Embed IDE the ability to call more than one plugin at launch.

### Use case
I want to clone a Github repository using `dGit` plugin, then open one of the cloned files using the `fileManager` plugin.

### Problem
The actual version let us call only one plugin at launch using the `call` parameter

```
<iframe src="https://remix.ethereum.org?#embed=true&call=dgit//clone//repo-owner//repo-name//repo-branch" />
```

### Solution
With this update I will simply be able to add a call list separated by `///` using the new `calls` parameter
```
<iframe src="https://remix.ethereum.org?#embed=true&calls=dgit//clone//repo-owner//repo-name//repo-branch///fileManager//open//path-to-file" />
```
