### PR TITLE
Enable deploy with proxy url params

### DIFF
--- a/apps/remix-ide-e2e/src/tests/proxy.test.ts
+++ b/apps/remix-ide-e2e/src/tests/proxy.test.ts
@@ -181,6 +181,7 @@ module.exports = {
       .click('select.udapp_contractNames')
       .click('select.udapp_contractNames option[value=MyTokenV2]')
       .waitForElementPresent('[data-id="contractGUIUpgradeImplementationLabel"]')
+      .click('[data-id="contractGUIUpgradeImplementationLabel"]')
       .waitForElementPresent('[data-id="contractGUIProxyAddressLabel"]')
       .click('[data-id="contractGUIProxyAddressLabel"]')
       .waitForElementPresent('[data-id="ERC1967AddressInput"]')

--- a/apps/remix-ide-e2e/src/tests/proxy.test.ts
+++ b/apps/remix-ide-e2e/src/tests/proxy.test.ts
@@ -181,7 +181,6 @@ module.exports = {
       .click('select.udapp_contractNames')
       .click('select.udapp_contractNames option[value=MyTokenV2]')
       .waitForElementPresent('[data-id="contractGUIUpgradeImplementationLabel"]')
-      .click('[data-id="contractGUIUpgradeImplementationLabel"]')
       .waitForElementPresent('[data-id="contractGUIProxyAddressLabel"]')
       .click('[data-id="contractGUIProxyAddressLabel"]')
       .waitForElementPresent('[data-id="ERC1967AddressInput"]')

--- a/apps/remix-ide-e2e/src/tests/url.test.ts
+++ b/apps/remix-ide-e2e/src/tests/url.test.ts
@@ -124,6 +124,41 @@ module.exports = {
       })
   },
 
+  'Should select deploy with proxy option from URL params': function (browser: NightwatchBrowser) {
+    browser
+      .url('http://127.0.0.1:8080/#optimize=false&runs=200&deployProxy=true')
+      .refresh()
+      .pause(5000)
+      .switchWorkspace('default_workspace')
+      .addFile('myTokenV1.sol', sources[1]['myTokenV1.sol'])
+      .clickLaunchIcon('solidity')
+      .pause(2000)
+      .click('[data-id="compilerContainerCompileBtn"]')
+      .waitForElementPresent('select[id="compiledContracts"] option[value=MyToken]', 60000)
+      .clickLaunchIcon('udapp')
+      .click('select.udapp_contractNames')
+      .click('select.udapp_contractNames option[value=MyToken]')
+      .waitForElementPresent('[data-id="contractGUIDeployWithProxyLabel"]')
+      .expect.element('[data-id="contractGUIDeployWithProxy"]').to.be.selected
+  },
+
+  'Should select upgrade with proxy option from URL params': function (browser: NightwatchBrowser) {
+    browser
+      .url('http://127.0.0.1:8080/#optimize=false&runs=200&upgradeProxy=true')
+      .refresh()
+      .pause(5000)
+      .openFile('myTokenV1.sol')
+      .clickLaunchIcon('solidity')
+      .pause(2000)
+      .click('[data-id="compilerContainerCompileBtn"]')
+      .waitForElementPresent('select[id="compiledContracts"] option[value=MyToken]', 60000)
+      .clickLaunchIcon('udapp')
+      .click('select.udapp_contractNames')
+      .click('select.udapp_contractNames option[value=MyToken]')
+      .waitForElementPresent('[data-id="contractGUIUpgradeImplementationLabel"]')
+      .expect.element('[data-id="contractGUIUpgradeImplementation"]').to.be.selected
+  },
+
   'Should load using URL compiler params': function (browser: NightwatchBrowser) {
     browser
       .pause(5000)

--- a/apps/remix-ide-e2e/src/tests/url.test.ts
+++ b/apps/remix-ide-e2e/src/tests/url.test.ts
@@ -5,7 +5,39 @@ import init from '../helpers/init'
 import examples from '../examples/example-contracts'
 
 const sources = [
-  { 'Untitled.sol': { content: examples.ballot.content } }
+  { 'Untitled.sol': { content: examples.ballot.content } },
+  {
+    'myTokenV1.sol': {
+      content: `
+      // SPDX-License-Identifier: MIT
+      pragma solidity ^0.8.4;
+      
+      import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+      import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+      import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+      import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+      
+      contract MyToken is Initializable, ERC721Upgradeable, OwnableUpgradeable, UUPSUpgradeable {
+          /// @custom:oz-upgrades-unsafe-allow constructor
+          constructor() {
+              _disableInitializers();
+          }
+      
+          function initialize() initializer public {
+              __ERC721_init("MyToken", "MTK");
+              __Ownable_init();
+              __UUPSUpgradeable_init();
+          }
+      
+          function _authorizeUpgrade(address newImplementation)
+              internal
+              onlyOwner
+              override
+          {}
+      }
+        `
+    }
+  }
 ]
 
 module.exports = {

--- a/libs/remix-core-plugin/src/lib/constants/uups.ts
+++ b/libs/remix-core-plugin/src/lib/constants/uups.ts
@@ -104,3 +104,4 @@ export const UUPSupgradeAbi = {
     "type": "function"
 }
 export const EnableProxyURLParam = 'deployProxy'
+export const EnableUpgradeURLParam = 'upgradeProxy'

--- a/libs/remix-core-plugin/src/lib/constants/uups.ts
+++ b/libs/remix-core-plugin/src/lib/constants/uups.ts
@@ -103,3 +103,4 @@ export const UUPSupgradeAbi = {
     "stateMutability": "nonpayable",
     "type": "function"
 }
+export const EnableProxyURLParam = 'deployProxy'

--- a/libs/remix-core-plugin/src/lib/openzeppelin-proxy.ts
+++ b/libs/remix-core-plugin/src/lib/openzeppelin-proxy.ts
@@ -1,6 +1,6 @@
 import { Plugin } from '@remixproject/engine'
 import { ContractAST, ContractSources, DeployOptions } from '../types/contract'
-import { UUPS, UUPSABI, UUPSBytecode, UUPSfunAbi, UUPSupgradeAbi } from './constants/uups'
+import { EnableProxyURLParam, UUPS, UUPSABI, UUPSBytecode, UUPSfunAbi, UUPSupgradeAbi } from './constants/uups'
 
 const proxyProfile = {
   name: 'openzeppelin-proxy',
@@ -33,31 +33,39 @@ export class OpenZeppelinProxy extends Plugin {
   async getProxyOptions (data: ContractSources, file: string): Promise<{ [name: string]: DeployOptions }> {
     const contracts = data.contracts[file]
     const ast = data.sources[file].ast
-    const inputs = {}
 
     if (this.kind === 'UUPS') {
-      Object.keys(contracts).map(name => {
-        if (ast) {
-          const UUPSSymbol = ast.exportedSymbols[UUPS] ? ast.exportedSymbols[UUPS][0] : null
+      const options = await (this.getUUPSContractOptions(contracts, ast, file))
 
-          ast.absolutePath === file && ast.nodes.map((node) => {
-            if (node.name === name && node.linearizedBaseContracts.includes(UUPSSymbol)) {
-              const abi = contracts[name].abi
-              const initializeInput = abi.find(node => node.name === 'initialize')
-      
-              inputs[name] = {
-                options: [{ title: 'Deploy with Proxy', active: false }, { title: 'Upgrade with Proxy', active: false }],
-                initializeOptions: {
-                  inputs: initializeInput,
-                  initializeInputs: initializeInput ? this.blockchain.getInputs(initializeInput) : null
-                }
+      return options
+    }
+  }
+
+  async getUUPSContractOptions (contracts, ast, file) {
+    const options = {}
+
+    await Promise.all(Object.keys(contracts).map(async (name) => {
+      if (ast) {
+        const UUPSSymbol = ast.exportedSymbols[UUPS] ? ast.exportedSymbols[UUPS][0] : null
+
+        await Promise.all(ast.absolutePath === file && ast.nodes.map(async (node) => {
+          if (node.name === name && node.linearizedBaseContracts.includes(UUPSSymbol)) {
+            const abi = contracts[name].abi
+            const initializeInput = abi.find(node => node.name === 'initialize')
+            const isDeployWithProxyEnabled: boolean = await this.call('config', 'getAppParameter', EnableProxyURLParam) || false
+    
+            options[name] = {
+              options: [{ title: 'Deploy with Proxy', active: isDeployWithProxyEnabled }, { title: 'Upgrade with Proxy', active: false }],
+              initializeOptions: {
+                inputs: initializeInput,
+                initializeInputs: initializeInput ? this.blockchain.getInputs(initializeInput) : null
               }
             }
-          })
-        }
-      })
-    }
-    return inputs
+          }
+        }))
+      }
+    }))
+    return options
   }
 
   async executeUUPSProxy(implAddress: string, args: string | string [] = '', initializeABI, implementationContractObject): Promise<void> {

--- a/libs/remix-core-plugin/src/lib/openzeppelin-proxy.ts
+++ b/libs/remix-core-plugin/src/lib/openzeppelin-proxy.ts
@@ -1,6 +1,6 @@
 import { Plugin } from '@remixproject/engine'
 import { ContractAST, ContractSources, DeployOptions } from '../types/contract'
-import { EnableProxyURLParam, UUPS, UUPSABI, UUPSBytecode, UUPSfunAbi, UUPSupgradeAbi } from './constants/uups'
+import { EnableProxyURLParam, EnableUpgradeURLParam, UUPS, UUPSABI, UUPSBytecode, UUPSfunAbi, UUPSupgradeAbi } from './constants/uups'
 
 const proxyProfile = {
   name: 'openzeppelin-proxy',
@@ -53,9 +53,10 @@ export class OpenZeppelinProxy extends Plugin {
             const abi = contracts[name].abi
             const initializeInput = abi.find(node => node.name === 'initialize')
             const isDeployWithProxyEnabled: boolean = await this.call('config', 'getAppParameter', EnableProxyURLParam) || false
+            const isDeployWithUpgradeEnabled: boolean = await this.call('config', 'getAppParameter', EnableUpgradeURLParam) || false
     
             options[name] = {
-              options: [{ title: 'Deploy with Proxy', active: isDeployWithProxyEnabled }, { title: 'Upgrade with Proxy', active: false }],
+              options: [{ title: 'Deploy with Proxy', active: isDeployWithProxyEnabled }, { title: 'Upgrade with Proxy', active: isDeployWithUpgradeEnabled }],
               initializeOptions: {
                 inputs: initializeInput,
                 initializeInputs: initializeInput ? this.blockchain.getInputs(initializeInput) : null

--- a/libs/remix-ui/run-tab/src/lib/components/contractGUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/contractGUI.tsx
@@ -25,6 +25,16 @@ export function ContractGUI (props: ContractGUIProps) {
   const basicInputRef = useRef<HTMLInputElement>()
 
   useEffect(() => {
+    if (props.deployOption && Array.isArray(props.deployOption)) {
+      if (props.deployOption[0] && props.deployOption[0].title === 'Deploy with Proxy') {
+        handleDeployProxySelect(props.deployOption[0].active)
+      } else if (props.deployOption[1] && props.deployOption[1].title === 'Deploy with Proxy') {
+        handleUpgradeImpSelect(props.deployOption[1].active)
+      }
+    }
+  }, [props.deployOption])
+
+  useEffect(() => {
     if (props.title) {
       setTitle(props.title)
     } else if (props.funcABI.name) {
@@ -179,9 +189,7 @@ export function ContractGUI (props: ContractGUIProps) {
     setToggleDeployProxy(!toggleDeployProxy)
   }
 
-  const handleDeployProxySelect = (e) => {
-    const value = e.target.checked
-
+  const handleDeployProxySelect = (value: boolean) => {
     if (value) setToggleUpgradeImp(false)
     setToggleDeployProxy(value)
     setDeployState({ upgrade: false, deploy: value })
@@ -191,9 +199,7 @@ export function ContractGUI (props: ContractGUIProps) {
     setToggleUpgradeImp(!toggleUpgradeImp)
   }
 
-  const handleUpgradeImpSelect = (e) => {
-    const value = e.target.checked
-
+  const handleUpgradeImpSelect = (value: boolean) => {
     setToggleUpgradeImp(value)
     if (value) {
       setToggleDeployProxy(false)
@@ -264,7 +270,7 @@ export function ContractGUI (props: ContractGUIProps) {
                 data-id="contractGUIDeployWithProxy"
                 className="form-check-input custom-control-input"
                 type="checkbox"
-                onChange={handleDeployProxySelect}
+                onChange={(e) => handleDeployProxySelect(e.target.checked)}
                 checked={deployState.deploy}
               />
               <label
@@ -307,7 +313,7 @@ export function ContractGUI (props: ContractGUIProps) {
                 data-id="contractGUIUpgradeImplementation"
                 className="form-check-input custom-control-input"
                 type="checkbox"
-                onChange={handleUpgradeImpSelect}
+                onChange={(e) => handleUpgradeImpSelect(e.target.checked)}
                 checked={deployState.upgrade}
               />
               <label

--- a/libs/remix-ui/run-tab/src/lib/components/contractGUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/contractGUI.tsx
@@ -26,11 +26,8 @@ export function ContractGUI (props: ContractGUIProps) {
 
   useEffect(() => {
     if (props.deployOption && Array.isArray(props.deployOption)) {
-      if (props.deployOption[0] && props.deployOption[0].title === 'Deploy with Proxy') {
-        handleDeployProxySelect(props.deployOption[0].active)
-      } else if (props.deployOption[1] && props.deployOption[1].title === 'Deploy with Proxy') {
-        handleUpgradeImpSelect(props.deployOption[1].active)
-      }
+      if (props.deployOption[0] && props.deployOption[0].title === 'Deploy with Proxy' && props.deployOption[0].active) handleDeployProxySelect(true)
+      else if (props.deployOption[1] && props.deployOption[1].title === 'Upgrade with Proxy' && props.deployOption[1].active)  handleUpgradeImpSelect(true)
     }
   }, [props.deployOption])
 


### PR DESCRIPTION
#### Testing
* Create a new UUPS upgradeable contract using Openzeppelin wizard.
* Open in Remix alpha and modify url params by adding `&deployProxy=true` to the url.
* Compile and select the contract in the run and deploy plugin.
* You should see `Deploy with Proxy` automatically checked/enabled.
* The same applies to `Upgrade with Proxy` using `&upgradeProxy=true` as a url param.

Closes https://github.com/ethereum/remix-project/issues/2680