### PR TITLE
add markers to editor

### DIFF
--- a/apps/remix-ide-e2e/src/tests/editor_error_marker.test.ts
+++ b/apps/remix-ide-e2e/src/tests/editor_error_marker.test.ts
@@ -1,0 +1,84 @@
+'use strict'
+
+import { NightwatchBrowser } from 'nightwatch'
+import init from '../helpers/init'
+
+module.exports = {
+
+  before: function (browser: NightwatchBrowser, done: VoidFunction) {
+    init(browser, done, 'http://127.0.0.1:8080', true)
+  },
+  'Should add error marker': function (browser: NightwatchBrowser) {
+    browser
+    .openFile('contracts')
+    .openFile('contracts/1_Storage.sol')
+    .addFile('scripts/adderror.ts', {content: addErrorMarker})
+    .pause(4000)
+    .executeScriptInTerminal('remix.exeCurrent()')
+    .pause(4000)
+    .openFile('contracts/1_Storage.sol')
+    .useXpath()
+    .waitForElementVisible("//*[@class='cdr squiggly-error']")
+    .waitForElementVisible("//*[@class='cdr squiggly-warning']")
+  },
+  'Should clear error marker': function (browser: NightwatchBrowser) {
+    browser 
+    .useCss()
+    .addFile('scripts/clear.ts', {content: clearMarkers})
+    .pause(4000)
+    .executeScriptInTerminal('remix.exeCurrent()')
+    .pause(4000)
+    .openFile('contracts/1_Storage.sol')
+    .useXpath()
+    .waitForElementNotPresent("//*[@class='cdr squiggly-error']")
+    .waitForElementNotPresent("//*[@class='cdr squiggly-warning']")
+  }
+}
+
+const clearMarkers =`
+(async () => {
+    await remix.call('editor', 'clearErrorMarkers' as any, ['contracts/1_Storage.sol'])
+})()`
+
+const addErrorMarker = `
+(async () => {
+
+ 
+    let errors = [
+        {
+            position: {
+                start: {
+                    line: 10,
+                    column: 1,
+                },
+                end: {
+                    line: 10,
+                    column: 10
+                }
+            },
+            message: 'testing',
+            severity: 'error',
+            file: 'contracts/1_Storage.sol'
+        },
+        {
+            position: {
+                start: {
+                    line: 18,
+                    column: 1,
+                },
+                end: {
+                    line: 18,
+                    column: 10
+                }
+            },
+            message: 'testing2',
+            severity: 'warning',
+            file: 'contracts/1_Storage.sol'
+        },
+    ]
+
+
+    await remix.call('editor', 'addErrorMarker' as any, errors)
+
+    
+})()`

--- a/apps/remix-ide/src/app/editor/editor.js
+++ b/apps/remix-ide/src/app/editor/editor.js
@@ -13,7 +13,7 @@ const profile = {
   name: 'editor',
   description: 'service - editor',
   version: packageJson.version,
-  methods: ['highlight', 'discardHighlight', 'clearAnnotations', 'addLineText', 'discardLineTexts', 'addAnnotation', 'gotoLine', 'revealRange', 'getCursorPosition']
+  methods: ['highlight', 'discardHighlight', 'clearAnnotations', 'addLineText', 'discardLineTexts', 'addAnnotation', 'gotoLine', 'revealRange', 'getCursorPosition', 'addErrorMarker', 'clearErrorMarkers']
 }
 
 class Editor extends Plugin {
@@ -502,6 +502,15 @@ class Editor extends Plugin {
       this.clearDecorationsByPlugin(session, plugin, 'sourceAnnotationsPerFile')
       this.clearDecorationsByPlugin(session, plugin, 'markerPerFile')
     }
+  }
+
+  // error markers
+  async addErrorMarker (error){
+    this.api.addErrorMarker(error)
+  }
+
+  async clearErrorMarkers(sources){
+    this.api.clearErrorMarkers(sources)
   }
 
   /**

--- a/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
+++ b/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
@@ -110,7 +110,7 @@ export interface EditorUIProps {
     clearDecorationsByPlugin: (filePath: string, plugin: string, typeOfDecoration: string, registeredDecorations: any, currentDecorations: any) => DecorationsReturn
     keepDecorationsFor: (filePath: string, plugin: string, typeOfDecoration: string, registeredDecorations: any, currentDecorations: any) => DecorationsReturn
     addErrorMarker: (errors: []) => void
-    clearErrorMarkers: (sources: any) => void
+    clearErrorMarkers: (sources: string[] | {[fileName: string]: any}) => void
   }
 }
 
@@ -441,7 +441,7 @@ export const EditorUI = (props: EditorUIProps) => {
     }
   }
 
-  props.editorAPI.clearErrorMarkers = async (sources: any) => {
+  props.editorAPI.clearErrorMarkers = async (sources: string[] | {[fileName: string]: any}) => {
     if (sources) {
       for (const source of (Array.isArray(sources) ? sources : Object.keys(sources))) {
         const filePath = source

--- a/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
+++ b/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
@@ -9,6 +9,8 @@ import { IMarkdownString } from 'monaco-editor'
 
 import './remix-ui-editor.css'
 import { loadTypes } from './web-types'
+import monaco from '../types/monaco'
+import { MarkerSeverity } from 'monaco-editor'
 
 type cursorPosition = {
   startLineNumber: number,
@@ -91,6 +93,8 @@ export interface EditorUIProps {
     addDecoration: (marker: sourceMarker, filePath: string, typeOfDecoration: string) => DecorationsReturn
     clearDecorationsByPlugin: (filePath: string, plugin: string, typeOfDecoration: string, registeredDecorations: any, currentDecorations: any) => DecorationsReturn
     keepDecorationsFor: (filePath: string, plugin: string, typeOfDecoration: string, registeredDecorations: any, currentDecorations: any) => DecorationsReturn
+    addErrorMarker: (errors: []) => void
+    clearErrorMarkers: (sources: any) => void
   }
 }
 
@@ -379,6 +383,63 @@ export const EditorUI = (props: EditorUIProps) => {
   
   props.editorAPI.addDecoration = (marker: sourceMarker, filePath: string, typeOfDecoration: string) => {
     return addDecoration(marker, filePath, typeOfDecoration)
+  }
+
+  props.editorAPI.addErrorMarker = async (errors: []) => {
+
+    const allMarkersPerfile: Record<string, Array<monaco.editor.IMarkerData>> = {}
+    console.log(errors)
+    for (const error of errors) {
+      const marker = (error as any).error
+      const lineColumn = (error as any).lineColumn
+      let filePath = marker.sourceLocation.file
+
+      if (!filePath) return
+      const fileFromUrl = await props.plugin.call('fileManager', 'getPathFromUrl', filePath)
+      filePath = fileFromUrl.file
+      const model = editorModelsState[filePath]?.model
+      console.log(filePath)
+      const errorServerityMap = {
+        'error': MarkerSeverity.Error,
+        'warning': MarkerSeverity.Warning,
+        'info': MarkerSeverity.Info
+      }
+      if (model) {
+        const markerData: monaco.editor.IMarkerData = {
+          severity: errorServerityMap[marker.severity],
+          startLineNumber: ((lineColumn.start && lineColumn.start.line) || 0) + 1,
+          startColumn: ((lineColumn.start && lineColumn.start.column) || 0) + 1,
+          endLineNumber: ((lineColumn.end && lineColumn.end.line) || 0) + 1,
+          endColumn: ((lineColumn.end && lineColumn.end.column) || 0) + 1,
+          message: marker.message,
+        }
+        console.log(markerData)
+        if (!allMarkersPerfile[filePath]) {
+          allMarkersPerfile[filePath] = []
+        }
+        allMarkersPerfile[filePath].push(markerData)
+      }
+    }
+    console.log(allMarkersPerfile)
+    for (const filePath in allMarkersPerfile) {
+      const model = editorModelsState[filePath]?.model
+      if (model) {
+        console.log(model)
+        monacoRef.current.editor.setModelMarkers(model, 'remix-solidity', allMarkersPerfile[filePath])
+      }
+    }
+  }
+
+  props.editorAPI.clearErrorMarkers = async (sources: any) => {
+    if (sources) {
+      for (const source of (Array.isArray(sources) ? sources : Object.keys(sources))) {
+        const filePath = source
+        const model = editorModelsState[filePath]?.model
+        if (model) {
+          monacoRef.current.editor.setModelMarkers(model, 'remix-solidity', [])
+        }
+      }
+    }
   }
 
   props.editorAPI.findMatches = (uri: string, value: string) => {

--- a/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
+++ b/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
@@ -432,7 +432,6 @@ export const EditorUI = (props: EditorUIProps) => {
         allMarkersPerfile[filePath].push(markerData)
       }
     }
-    console.log(allMarkersPerfile)
     for (const filePath in allMarkersPerfile) {
       const model = editorModelsState[filePath]?.model
       if (model) {


### PR DESCRIPTION
Adds squiggly line markers to the editor, this includes a message that appears on hover

<img width="852" alt="Screenshot 2022-08-09 at 13 29 04" src="https://user-images.githubusercontent.com/2787300/183636738-ee361377-646d-4eb5-b9eb-f02e6b7bc59a.png">


```
let errors = [
        {
            position: {
                start: {
                    line: 10,
                    column: 1,
                },
                end: {
                    line: 10,
                    column: 10
                }
            },
            message: 'testing',
            severity: 'error',
            file: 'contracts/1_Storage.sol'
        },
        {
            position: {
                start: {
                    line: 18,
                    column: 1,
                },
                end: {
                    line: 18,
                    column: 10
                }
            },
            message: 'testing2',
            severity: 'warning',
            file: 'contracts/1_Storage.sol'
        },
    ]
    await remix.call('editor', 'addErrorMarker' as any, errors)
```