### PR TITLE
show contract from compiled file selected in dropdowns

### DIFF
--- a/libs/remix-ui/run-tab/src/lib/actions/events.ts
+++ b/libs/remix-ui/run-tab/src/lib/actions/events.ts
@@ -101,8 +101,13 @@ const broadcastCompilationResult = async (plugin: RunTab, dispatch: React.Dispat
   const contracts = getCompiledContracts(compiler).map((contract) => {
     return { name: languageVersion, alias: contract.name, file: contract.file, compiler }
   })
-  const index = contracts.findIndex(contract => contract.alias === plugin.REACT_API.contracts.currentContract)
-  if ((index < 0) && (contracts.length > 0)) dispatch(setCurrentContract(contracts[0].alias))
+  if ((contracts.length > 0)) {
+    const contractsInCompiledFile = contracts.filter(obj => obj.file === file)
+    let currentContract
+    if (contractsInCompiledFile.length) currentContract = contractsInCompiledFile[0].alias
+    else currentContract = contracts[0].alias
+    dispatch(setCurrentContract(currentContract))
+  }
   const isUpgradeable = await plugin.call('openzeppelin-proxy', 'isConcerned', data.sources && data.sources[file] ? data.sources[file].ast : {})
 
   if (isUpgradeable) {

--- a/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
@@ -7,12 +7,18 @@ import { CopyToClipboard } from '@remix-ui/clipboard' // eslint-disable-line
 import './css/style.css'
 
 export const ContractSelection = (props: ContractSelectionProps) => {
-  const { api, contractsDetails, contractList, modal } = props
+  const { api, compiledFileName, contractsDetails, contractList, modal } = props
   const [selectedContract, setSelectedContract] = useState('')
   const [storage, setStorage] = useState(null)
 
   useEffect(() => {
-    if (contractList.length) setSelectedContract(contractList[0].name)
+    if (contractList.length) {
+      const compiledPathArr = compiledFileName.split('/')
+      const compiledFile = compiledPathArr[compiledPathArr.length - 1]
+      const contractsInCompiledFile = contractList.filter(obj => obj.file === compiledFile)
+      if (contractsInCompiledFile.length) setSelectedContract(contractsInCompiledFile[0].name)
+      else setSelectedContract(contractList[0].name)
+    }
   }, [contractList])
 
   const resetStorage = () => {

--- a/libs/remix-ui/solidity-compiler/src/lib/solidity-compiler.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/solidity-compiler.tsx
@@ -183,7 +183,7 @@ export const SolidityCompiler = (props: SolidityCompilerProps) => {
           configFilePath={state.configFilePath}
           setConfigFilePath={setConfigFilePath}
         />
-        { contractsFile[currentFile] && contractsFile[currentFile].contractsDetails && <ContractSelection api={api} contractsDetails={contractsFile[currentFile].contractsDetails} contractList={contractsFile[currentFile].contractList} modal={modal} /> }
+        { contractsFile[currentFile] && contractsFile[currentFile].contractsDetails && <ContractSelection api={api} compiledFileName={currentFile} contractsDetails={contractsFile[currentFile].contractsDetails} contractList={contractsFile[currentFile].contractList} modal={modal} /> }
         { compileErrors[currentFile] &&
           <div className="remixui_errorBlobs p-4" data-id="compiledErrors">
             <span data-id={`compilationFinishedWith_${currentVersion}`}></span>

--- a/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
@@ -23,6 +23,7 @@ export interface CompilerContainerProps {
 }
 export interface ContractSelectionProps {
   api: ICompilerApi,
+  compiledFileName: string,
   contractList: { file: string, name: string }[],
   modal: (title: string, message: string | JSX.Element, okLabel: string, okFn: () => void, cancelLabel?: string, cancelFn?: () => void) => void,
   contractsDetails: Record<string, any>


### PR DESCRIPTION
fixes #1826 
fixes #1651 

We don't compile a specific contract but a file and there can be more than one contract per file. 
This PR ensures that on the drop-downs in `Solidity Compiler` & `Deploy & Run Transactions` plugins, we select a contract from compiled file