### PR TITLE
handle various compiler version from URL

### DIFF
--- a/apps/remix-ide-e2e/src/tests/url.test.ts
+++ b/apps/remix-ide-e2e/src/tests/url.test.ts
@@ -159,7 +159,7 @@ module.exports = {
       .expect.element('[data-id="contractGUIUpgradeImplementation"]').to.be.selected
   },
 
-  'Should load using URL compiler params': function (browser: NightwatchBrowser) {
+  'Should load using various URL compiler params': function (browser: NightwatchBrowser) {
     browser
       .pause(5000)
       .url('http://127.0.0.1:8080/#optimize=true&runs=300&autoCompile=true&evmVersion=istanbul&version=soljson-v0.7.4+commit.3f05b770.js&language=Yul')
@@ -173,6 +173,16 @@ module.exports = {
       .verify.elementPresent('#optimize:checked')
       .verify.elementPresent('#autoCompile:checked')
       .verify.attributeEquals('#runs', 'value', '300')
+      .url('http://127.0.0.1:8080/#version=0.8.7')
+      .refresh()
+      .pause(5000)
+      .clickLaunchIcon('solidity')
+      .assert.containsText('#versionSelector option[data-id="selected"]', '0.8.7+commit.e28d00a7')
+      .url('http://127.0.0.1:8080/#version=0.8.15+commit.e14f2714')
+      .refresh()
+      .pause(5000)
+      .clickLaunchIcon('solidity')
+      .assert.containsText('#versionSelector option[data-id="selected"]', '0.8.15+commit.e14f2714')
   },
 
   'Should load using compiler from link passed in remix URL': function (browser: NightwatchBrowser) {

--- a/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
@@ -311,17 +311,20 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
       selectedVersion = state.defaultVersion
       if (api.getCompilerParameters().version) {
         const versionFromURL = api.getCompilerParameters().version
-        // URL version can be like 0.8.7+commit.e28d00a7, 0.8.7 or soljson-v0.8.7+commit.e28d00a7.js
-        const selectedVersionArr = versions.filter(obj => obj.path === versionFromURL || obj.longVersion === versionFromURL || obj.version === versionFromURL)
-        // for version like 0.8.15, there will be more than one elements in the array
-        // In that case too, index 0 will have non-nightly version object
-        if (selectedVersionArr.length) selectedVersion = selectedVersionArr[0].path
-      }
-      // Check if version is a URL and corresponding filename starts with 'soljson'
-      if (selectedVersion.startsWith('https://')) {
-        const urlArr = selectedVersion.split('/')
-
-        if (urlArr[urlArr.length - 1].startsWith('soljson')) isURL = true
+        // Check if version is a URL and corresponding filename starts with 'soljson'
+        if (versionFromURL.startsWith('https://')) {
+          const urlArr = versionFromURL.split('/')
+          if (urlArr[urlArr.length - 1].startsWith('soljson')) {
+            isURL = true
+            selectedVersion = versionFromURL
+          }
+        } else {
+          // URL version can be like 0.8.7+commit.e28d00a7, 0.8.7 or soljson-v0.8.7+commit.e28d00a7.js
+          const selectedVersionArr = versions.filter(obj => obj.path === versionFromURL || obj.longVersion === versionFromURL || obj.version === versionFromURL)
+          // for version like 0.8.15, there will be more than one elements in the array
+          // In that case too, index 0 will have non-nightly version object
+          if (selectedVersionArr.length) selectedVersion = selectedVersionArr[0].path
+        }
       }
       if (wasmRes.event.type !== 'error') {
         allVersionsWasm = JSON.parse(wasmRes.json).builds.slice().reverse()

--- a/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
@@ -309,7 +309,14 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
 
       allVersions = [...allVersions, ...versions]
       selectedVersion = state.defaultVersion
-      if (api.getCompilerParameters().version) selectedVersion = api.getCompilerParameters().version
+      if (api.getCompilerParameters().version) {
+        const versionFromURL = api.getCompilerParameters().version
+        // URL version can be like 0.8.7+commit.e28d00a7, 0.8.7 or soljson-v0.8.7+commit.e28d00a7.js
+        const selectedVersionArr = versions.filter(obj => obj.path === versionFromURL || obj.longVersion === versionFromURL || obj.version === versionFromURL)
+        // for version like 0.8.15, there will be more than one elements in the array
+        // In that case too, index 0 will have non-nightly version object
+        if (selectedVersionArr.length) selectedVersion = selectedVersionArr[0].path
+      }
       // Check if version is a URL and corresponding filename starts with 'soljson'
       if (selectedVersion.startsWith('https://')) {
         const urlArr = selectedVersion.split('/')


### PR DESCRIPTION
fixes #1490 

It now accepts version like one of `0.8.7+commit.e28d00a7`, `0.8.7 ` or `soljson-v0.8.7+commit.e28d00a7.js`

fixes #2693 

It only updates the version for valid values as mentioned above. Otherwise, default version will be selected