### PR TITLE
fix display json rpc error

### DIFF
--- a/apps/remix-ide/src/app/panels/terminal.js
+++ b/apps/remix-ide/src/app/panels/terminal.js
@@ -100,8 +100,8 @@ class Terminal extends Plugin {
     this.terminalApi.logHtml(html)
   }
 
-  log (message) {
-    this.terminalApi.log(message)
+  log (message, type) {
+    this.terminalApi.log(message, type)
   }
 
   setDispatch(dispatch) {

--- a/apps/remix-ide/src/app/tabs/web3-provider.js
+++ b/apps/remix-ide/src/app/tabs/web3-provider.js
@@ -29,7 +29,10 @@ export class Web3ProviderModule extends Plugin {
             const provider = this.blockchain.web3().currentProvider
             // see https://github.com/ethereum/web3.js/pull/1018/files#diff-d25786686c1053b786cc2626dc6e048675050593c0ebaafbf0814e1996f22022R129
             provider[provider.sendAsync ? 'sendAsync' : 'send'](payload, async (error, message) => {
-              if (error) return reject(error)
+              if (error) {
+                this.call('terminal', 'log', error.data ? error.data : error, 'error')
+                return reject(error.data ? error.data : error)
+              }
               if (payload.method === 'eth_sendTransaction') {
                 if (payload.params.length && !payload.params[0].to && message.result) {
                   setTimeout(async () => {

--- a/libs/remix-ui/terminal/src/lib/remix-ui-terminal.tsx
+++ b/libs/remix-ui/terminal/src/lib/remix-ui-terminal.tsx
@@ -86,8 +86,8 @@ export const RemixUiTerminal = (props: RemixUiTerminalProps) => {
         scriptRunnerDispatch({ type: 'html', payload: { message: [html ? html.innerText ? html.innerText : html : null] } })
       },
 
-      log: (message) => {
-        scriptRunnerDispatch({ type: 'log', payload: { message: [message] } })
+      log: (message, type) => {
+        scriptRunnerDispatch({ type: type ? type : 'log', payload: { message: [message] } })
       }
     })
   }, [])


### PR DESCRIPTION
This ensure that while calling the json rpc servic error are displayed correctly .

In order to test it:
 - clone https://github.com/yann300/remix-reward
 - compile the proxy contract
 - move to injected Optimism or Goerli (you should have some test eth)
 - open the script `mint`
 - put any addresses in the variable `to`
 - execute that script
 - terminal should log 2 errors rather than an empty object