### PR TITLE
fix ipfs publish

### DIFF
--- a/apps/etherscan/src/app/routes.tsx
+++ b/apps/etherscan/src/app/routes.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import {
-  BrowserRouter as Router,
+  HashRouter as Router,
   Route,
   Routes,
   RouteProps,


### PR DESCRIPTION
This ensure routing is done using the hash parameter instead of the path itself.
this fix loading the app from an ipfs gateway, like https://url.gateway/ipfs/-hash-