### PR TITLE
General improv tab file expo search solidity compiler deploy & run

### DIFF
--- a/apps/remix-ide-e2e/src/tests/runAndDeploy.test.ts
+++ b/apps/remix-ide-e2e/src/tests/runAndDeploy.test.ts
@@ -19,12 +19,12 @@ module.exports = {
     browser.waitForElementPresent('*[data-id="remixIdeSidePanel"]')
       .clickLaunchIcon('udapp')
       .waitForElementPresent('*[data-id="sidePanelSwapitTitle"]')
-      .assert.containsText('*[data-id="sidePanelSwapitTitle"]', 'DEPLOY & RUN TRANSACTIONS')
+      .assert.containsText('*[data-id="sidePanelSwapitTitle"]', 'DEPLOY & RUN')
   },
 
   'Should load run and deploy tab and check value validation #group1': function (browser: NightwatchBrowser) {
     browser.waitForElementPresent('*[data-id="remixIdeSidePanel"]')
-      .assert.containsText('*[data-id="sidePanelSwapitTitle"]', 'DEPLOY & RUN TRANSACTIONS')
+      .assert.containsText('*[data-id="sidePanelSwapitTitle"]', 'DEPLOY & RUN')
       .validateValueInput('#value', '0000', '0')
       .validateValueInput('#value', '', '0')
       .validateValueInput('#value', 'dragon', '0')

--- a/apps/remix-ide/src/app/udapp/run-tab.js
+++ b/apps/remix-ide/src/app/udapp/run-tab.js
@@ -10,7 +10,7 @@ const _paq = window._paq = window._paq || []
 
 const profile = {
   name: 'udapp',
-  displayName: 'Deploy & run transactions',
+  displayName: 'Deploy & run',
   icon: 'assets/img/deployAndRun.webp',
   description: 'Execute, save and replay transactions',
   kind: 'udapp',

--- a/apps/remix-ide/src/assets/css/themes/remix-dark_tvx1s2.css
+++ b/apps/remix-ide/src/assets/css/themes/remix-dark_tvx1s2.css
@@ -1757,7 +1757,7 @@ textarea.form-control {
 .form-check-label {
   margin-bottom: 0;
   font-size: 13px;
-  line-height: 18px;
+  line-height: 22px;
   color: #A2A3BD;
   text-transform: initial;
   display: initial;

--- a/libs/remix-ui/panel/src/lib/plugins/panel-header.tsx
+++ b/libs/remix-ui/panel/src/lib/plugins/panel-header.tsx
@@ -26,7 +26,7 @@ const RemixUIPanelHeader = (props: RemixPanelProps) => {
 
   return (
     <header className='d-flex flex-column'>
-      <div className="swapitHeader px-3 pt-2 pb-0 d-flex flex-row">
+      <div className="swapitHeader px-3 pt-3 pb-0 d-flex flex-row">
         <h6 className="mb-3" data-id='sidePanelSwapitTitle'>{plugin?.profile.displayName || plugin?.profile.name}</h6>
         <div className="d-flex flex-row">
           <div className="d-flex flex-row">

--- a/libs/remix-ui/run-tab/src/lib/components/environment.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/environment.tsx
@@ -27,7 +27,7 @@ export function EnvironmentUI (props: EnvironmentProps) {
 
   const isL2 = (provider) => provider && (provider.value === 'Optimism Provider' || provider.value === 'Arbitrum One Provider')
   return (
-    <div className="udapp_crow">
+    <div style={{marginTop: "0px"}} className="udapp_crow">
       <label id="selectExEnv" className="udapp_settingsLabel">
         Environment <OverlayTrigger placement={'right'} overlay={
               <Tooltip className="text-nowrap" id="info-recorder">
@@ -39,7 +39,7 @@ export function EnvironmentUI (props: EnvironmentProps) {
       </label>
       <div className="udapp_environment">
 
-      <Dropdown id="selectExEnvOptions" data-id="settingsSelectEnvOptions" className='udapp_selectExEnvOptions'>
+        <Dropdown id="selectExEnvOptions" data-id="settingsSelectEnvOptions" className='udapp_selectExEnvOptions'>
           <Dropdown.Toggle as={CustomToggle} id="dropdown-custom-components" className="btn btn-light btn-block w-100 d-inline-block border border-dark form-control" icon={null}>
             { isL2(currentProvider) && 'L2 - '}
             { currentProvider && currentProvider.content }

--- a/libs/remix-ui/run-tab/src/lib/components/recorderCardUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/recorderCardUI.tsx
@@ -47,7 +47,7 @@ export function RecorderUI (props: RecorderProps) {
           </span>
         </div>
       </div>
-      <div className={`flex-column ${toggleExpander ? "d-flex" : "d-none"}`}>
+      <div style={{paddingBottom:"15px"}} className={`flex-column ${toggleExpander ? "d-flex" : "d-none"}`}>
         <div className="mb-1 mt-1 fmt-2 custom-control custom-checkbox mb-1">
           <input ref={inputLive} type="checkbox" id="livemode-recorder" className="custom-control-input custom-select" name="input-livemode"/>
           <OverlayTrigger placement={'right'} overlay={

--- a/libs/remix-ui/run-tab/src/lib/components/recorderCardUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/recorderCardUI.tsx
@@ -27,7 +27,7 @@ export function RecorderUI (props: RecorderProps) {
 
 
   return (
-    <div className="udapp_cardContainer list-group-item border border-bottom">
+    <div className="udapp_cardContainer list-group-item border-bottom border-top">
       <div className="udapp_recorderSection d-flex justify-content-between" onClick={toggleClass}>
         <div className="d-flex justify-content-center align-items-center">
           <label className="mt-1 udapp_recorderSectionLabel">Transactions recorded</label>

--- a/libs/remix-ui/run-tab/src/lib/css/card.css
+++ b/libs/remix-ui/run-tab/src/lib/css/card.css
@@ -1,5 +1,5 @@
 .udapp_cardContainer {
-  padding             : 0 24px 16px;
+  padding             : 6px;
   margin              : 0;
   background          : none;
 }

--- a/libs/remix-ui/run-tab/src/lib/css/run-tab.css
+++ b/libs/remix-ui/run-tab/src/lib/css/run-tab.css
@@ -54,7 +54,7 @@
 }
 .udapp_cardContainer {
   padding: 0 14px;
-  padding-bottom: 0;
+  padding-bottom: 0px;
 }
 .udapp_instanceContainer {
   display: flex;

--- a/libs/remix-ui/run-tab/src/lib/css/run-tab.css
+++ b/libs/remix-ui/run-tab/src/lib/css/run-tab.css
@@ -6,7 +6,7 @@
   display: none;
 }
 .udapp_settings {
-  padding: 0 24px 16px;
+  padding: 6px;
 }
 .udapp_crow {
   display: block;
@@ -52,13 +52,17 @@
   width: 100%;
   overflow: hidden;
 }
+.udapp_cardContainer {
+  padding: 0 14px;
+  padding-bottom: 0;
+}
 .udapp_instanceContainer {
   display: flex;
   flex-direction: column;
   margin-bottom: 2%;
   border: none;
   text-align: center;
-  padding: 0 14px 16px;
+  padding: 0 6px;
 }
 .udapp_deployedContracts {
   font-size: 1rem;
@@ -71,7 +75,8 @@
   text-align: center;
 }
 .udapp_container {
-  padding: 0 24px 16px;
+  padding: 6px;
+  padding-bottom: 16px;
 }
 .udapp_contractNames {
   width: 100%;

--- a/libs/remix-ui/run-tab/src/lib/run-tab.tsx
+++ b/libs/remix-ui/run-tab/src/lib/run-tab.tsx
@@ -196,7 +196,7 @@ export function RunTabUI (props: RunTabProps) {
 
   return (
     <Fragment>
-      <div className="udapp_runTabView run-tab" id="runTabView" data-id="runTabView">
+      <div className="udapp_runTabView run-tab px-2" id="runTabView" data-id="runTabView">
         <div className="list-group list-group-flush">
           <SettingsUI
             networkName={runTab.networkName}

--- a/libs/remix-ui/search/src/lib/components/Search.tsx
+++ b/libs/remix-ui/search/src/lib/components/Search.tsx
@@ -12,8 +12,8 @@ export const SearchTab = props => {
   const plugin = props.plugin
 
   return (
-    <>
-      <div className="search_plugin_search_tab pr-4 px-2 pb-4">
+    <div className="px-2">
+      <div className="search_plugin_search_tab">
         <SearchProvider plugin={plugin}>
           <FindContainer></FindContainer>
           <Include></Include>
@@ -22,6 +22,6 @@ export const SearchTab = props => {
           <Results></Results>
         </SearchProvider>
       </div>
-    </>
+    </div>
   )
 }

--- a/libs/remix-ui/search/src/lib/search.css
+++ b/libs/remix-ui/search/src/lib/search.css
@@ -28,6 +28,11 @@
     display: flex;
 }
 
+.search_plugin_search_tab {
+    padding: 6px;
+    padding-left: 2px;
+}
+
 .search_plugin_search_tab .search_plugin_search_line_container {
     display: flex;
     flex-direction: row;

--- a/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/compiler-container.tsx
@@ -709,8 +709,8 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
 
  return (
     <section>
-      <article>
-        <div className='pt-0 remixui_compilerSection'>
+      <article className="px-2">
+        <div className="remixui_compilerSection">
           <div className="mb-1">
             <label className="remixui_compilerLabel form-check-label" htmlFor="versionSelector">Compiler</label>
             <span className="far fa-plus border-0 p-0 ml-3" onClick={() => promptCompiler()} title="Add a custom compiler with URL"></span>
@@ -772,7 +772,7 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
             </div>
           }
         </div>
-        <div className="d-flex px-4 remixui_compilerConfigSection justify-content-between" onClick={toggleConfigurations}>
+        <div className="d-flex remixui_compilerSection remixui_compilerConfigSection justify-content-between" onClick={toggleConfigurations}>
           <div className="d-flex">
             <label className="mt-1 remixui_compilerConfigSection">Advanced Configurations</label>
           </div>
@@ -782,7 +782,7 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
             </span>
           </div>
         </div>
-        <div className={`px-4 pb-4 border-bottom flex-column ${toggleExpander ? "d-flex" : "d-none"}`}>
+        <div className={`remixui_compilerSection pb-4 border-bottom flex-column ${toggleExpander ? "d-flex" : "d-none"}`}>
           <div className="d-flex pb-1 remixui_compilerConfig custom-control custom-radio">
             <input className="custom-control-input" type="radio" name="configradio" value="manual" onChange={toggleConfigType} checked={!state.useFileConfiguration} id="scManualConfig" />
             <label className="form-check-label custom-control-label" htmlFor="scManualConfig" data-id="scManualConfiguration">Compiler configuration</label>
@@ -843,10 +843,10 @@ export const CompilerContainer = (props: CompilerContainerProps) => {
                 }
               }}
             />
-            { !showFilePathInput && <button disabled={!state.useFileConfiguration} data-id="scConfigChangeFilePath" className="btn-secondary" onClick={() => {setShowFilePathInput(true)}}>Change</button> }
+            { !showFilePathInput && <button disabled={!state.useFileConfiguration} data-id="scConfigChangeFilePath" className="btn-secondary py-2" onClick={() => {setShowFilePathInput(true)}}>Change</button> }
           </div>
         </div>
-        <div className="px-4">
+        <div style={{padding: "6px"}}>
           <button id="compileBtn" data-id="compilerContainerCompileBtn" className="btn btn-primary btn-block d-block w-100 text-break remixui_disabled mb-1 mt-3" onClick={compile} disabled={(configFilePath === '' && state.useFileConfiguration) || disableCompileButton}>
             <OverlayTrigger overlay={
               <Tooltip id="overlay-tooltip-compile">

--- a/libs/remix-ui/solidity-compiler/src/lib/css/style.css
+++ b/libs/remix-ui/solidity-compiler/src/lib/css/style.css
@@ -70,7 +70,7 @@
   margin: 0;
 }
 .remixui_compilerSection {
-  padding: 12px 24px 16px;
+  padding: 6px;
 }
 .remixui_compilerConfigSection:hover {
   cursor: pointer;
@@ -80,6 +80,12 @@
 }
 .remixui_compilerConfigPath {
   cursor: pointer;
+}
+.remixui_workspacesLabel {
+  margin-bottom: 2px;
+  font-size: 11px;
+  line-height: 12px;
+  text-transform: uppercase;
 }
 .remixui_compilerLabel {
   margin-bottom: 2px;

--- a/libs/remix-ui/terminal/src/lib/terminalWelcome.tsx
+++ b/libs/remix-ui/terminal/src/lib/terminalWelcome.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react' // eslint-disable-line
 const TerminalWelcomeMessage = ({ packageJson, storage }) => {
   return (
     <div className="remix_ui_terminal_block px-4 " data-id="block_null">
-      <div className="remix_ui_terminal_welcome"> Welcome to Remix {packageJson} </div><br />
+      <div className="remix_ui_terminal_welcome">Welcome to Remix {packageJson} </div><br />
       <div className="">Your files are stored in {(window as any).remixFileSystem.name}, {storage} used</div><br />
       <div>You can use this terminal to: </div>
       <ul className='ml-0 mr-4'>

--- a/libs/remix-ui/tree-view/src/lib/remix-ui-tree-view.tsx
+++ b/libs/remix-ui/tree-view/src/lib/remix-ui-tree-view.tsx
@@ -7,7 +7,7 @@ export const TreeView = (props: TreeViewProps) => {
   const { children, id, ...otherProps } = props
 
   return (
-    <ul data-id={`treeViewUl${id}`} className="ul_tv ml-0 pl-2" { ...otherProps }>
+    <ul data-id={`treeViewUl${id}`} className="ul_tv ml-0" { ...otherProps }>
       { children }
     </ul>
   )

--- a/libs/remix-ui/workspace/src/lib/css/remix-ui-workspace.css
+++ b/libs/remix-ui/workspace/src/lib/css/remix-ui-workspace.css
@@ -10,9 +10,7 @@
     flex-direction    : column;
     position          : relative;
     width             : 100%;
-    padding-left      : 6px;
-    padding-right     : 6px;
-    padding-top       : 6px;
+    padding           : 6px;
     overflow-y        : auto;
   }
   .remixui_fileExplorerTree   {

--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -193,8 +193,8 @@ export function Workspace () {
         <div>
           <header>
             <div className="mb-2">
-              <label className="pl-1 form-check-label" htmlFor="workspacesSelect">
-                Workspaces
+              <label className="remixui_workspacesLabel" htmlFor="workspacesSelect">
+                WORKSPACES
               </label>
                 <span className="remixui_menu">
                   <span


### PR DESCRIPTION
Hello guys, really love what you do with remix-project, and thought to myself to contribute directly into the repo.

Here are some of the details that would improve the aligment on General tab section (like File Explorer, Search, etc.) with after before on each of it
- File explorer (folder logo alignment)

| Before | After |
| ------------- | ------------- |
| <img width="369" alt="Screen Shot 2022-08-18 at 17 50 53" src="https://user-images.githubusercontent.com/20473526/185378040-1a82710f-1f82-474b-8c6c-b377d4ead325.png"> | <img width="366" alt="Screen Shot 2022-08-18 at 13 06 35" src="https://user-images.githubusercontent.com/20473526/185377815-e29149e8-fa21-43d0-a646-7c08c04f0af4.png"> |


- Search in files (alignment of input component)

| Before | After |
| ------------- | ------------- |
| <img width="368" alt="Screen Shot 2022-08-18 at 17 58 42" src="https://user-images.githubusercontent.com/20473526/185379319-f14b48da-8089-45fa-af0d-3f5768e3a434.png"> | <img width="368" alt="Screen Shot 2022-08-18 at 13 06 58" src="https://user-images.githubusercontent.com/20473526/185379064-89af2b90-8b1c-4326-b21b-d81cf23f58fb.png"> |


- Solidity compiler (alignment styling)

| Before | After |
| ------------- | ------------- |
| <img width="368" alt="Screen Shot 2022-08-18 at 18 01 13" src="https://user-images.githubusercontent.com/20473526/185379805-7f31c3fd-0e53-4498-af49-5eb655341203.png"> | <img width="367" alt="Screen Shot 2022-08-18 at 18 06 13" src="https://user-images.githubusercontent.com/20473526/185380590-ae845eb9-788a-4b8d-bc53-36a4b293b041.png"> |


- Deploy & run transactions (Change to Deploy & run for better UI & UX, and other alignment details)

| Before | After |
| ------------- | ------------- |
| <img width="369" alt="Screen Shot 2022-08-18 at 18 02 30" src="https://user-images.githubusercontent.com/20473526/185380006-7415b720-b8c5-4a32-8eed-caef28995f78.png"> | <img width="369" alt="Screen Shot 2022-08-18 at 18 04 08" src="https://user-images.githubusercontent.com/20473526/185380369-1f5af9ee-5f1a-463b-8145-8027a2d3bfe5.png"> |

May my contribution be useful!

cc : @Aniket-Engg 