### PR TITLE
default readonly false

### DIFF
--- a/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
+++ b/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
@@ -619,7 +619,7 @@ export const EditorUI = (props: EditorUIProps) => {
         language={editorModelsState[props.currentFile] ? editorModelsState[props.currentFile].language : 'text'}
         onMount={handleEditorDidMount}
         beforeMount={handleEditorWillMount}
-        options={{ glyphMargin: true, readOnly: true }}
+        options={{ glyphMargin: true, readOnly: false }}
         defaultValue={defaultEditorValue}
       />
 


### PR DESCRIPTION
when editor component is rendered it is by default readonly, changed that to fix https://github.com/ethereum/remix-project/issues/2786
was there any reason why it was set to readonly @yann300?