### PR TITLE
add timestamp to url

### DIFF
--- a/apps/remix-ide/src/app/plugins/parser/code-parser.tsx
+++ b/apps/remix-ide/src/app/plugins/parser/code-parser.tsx
@@ -118,9 +118,7 @@ export class CodeParser extends Plugin {
         })
 
         this.on('solidity', 'loadingCompiler', async (url) => {
-            // add timestamp to avoid caching
-            url = url + '?t=' + Date.now()
-            this.compilerService.compiler.loadVersion(true, url)
+            this.compilerService.compiler.loadVersion(true, `${url}?t=${Date.now()}`)
         })
 
         await this.compilerService.init()

--- a/apps/remix-ide/src/app/plugins/parser/code-parser.tsx
+++ b/apps/remix-ide/src/app/plugins/parser/code-parser.tsx
@@ -118,6 +118,8 @@ export class CodeParser extends Plugin {
         })
 
         this.on('solidity', 'loadingCompiler', async (url) => {
+            // add timestamp to avoid caching
+            url = url + '?t=' + Date.now()
             this.compilerService.compiler.loadVersion(true, url)
         })
 


### PR DESCRIPTION
FF doesn't deal well with loading the compiler twice, it basically aborts the first load so nothing loads. 