### PR TITLE
Flakylistentest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 parameters:
   run_flaky_tests:
     type: boolean
-    default: false
+    default: true
 orbs:
   browser-tools: circleci/browser-tools@1.3.0
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 parameters:
   run_flaky_tests:
     type: boolean
-    default: true
+    default: false
 orbs:
   browser-tools: circleci/browser-tools@1.3.0
 jobs:

--- a/apps/remix-ide-e2e/src/commands/connectToExternalHttpProvider.ts
+++ b/apps/remix-ide-e2e/src/commands/connectToExternalHttpProvider.ts
@@ -7,7 +7,7 @@ class ConnectToExternalHttpProvider extends EventEmitter {
             (result) => {
                 if (result.status as any === -1) {
                     console.log("No connection to external provider found. Adding one.", url)
-                    this.api
+                    browser
                         .click({
                             locateStrategy: 'css selector',
                             selector: '[data-id="basic-http-provider-modal-footer-ok-react"]',

--- a/apps/remix-ide-e2e/src/commands/connectToExternalHttpProvider.ts
+++ b/apps/remix-ide-e2e/src/commands/connectToExternalHttpProvider.ts
@@ -5,7 +5,6 @@ class ConnectToExternalHttpProvider extends EventEmitter {
     command(this: NightwatchBrowser, url: string, identifier: string): NightwatchBrowser {
         this.api.element('xpath', `//*[@class='udapp_environment' and contains(.,'${identifier}')]`,
             (result) => {
-                console.log('ConnectToExternalHttpProvider: ' + result.status, result.value)
                 if (result.status as any === -1 ) {
                     console.log("No connection to external provider found. Adding one.", url)
                     browser

--- a/apps/remix-ide-e2e/src/commands/connectToExternalHttpProvider.ts
+++ b/apps/remix-ide-e2e/src/commands/connectToExternalHttpProvider.ts
@@ -1,0 +1,42 @@
+import { NightwatchBrowser } from 'nightwatch'
+import EventEmitter from 'events'
+
+class ConnectToExternalHttpProvider extends EventEmitter {
+    command(this: NightwatchBrowser, url: string, identifier: string): NightwatchBrowser {
+        this.api.element('xpath', `//*[@class='udapp_environment' and contains(.,'${identifier}')]`,
+            (result) => {
+                console.log('ConnectToExternalHttpProvider: ' + result.status, result.value)
+                if (result.status as any === -1 ) {
+                    console.log("No connection to external provider found. Adding one.", url)
+                    browser
+                        .click({
+                            locateStrategy: 'css selector',
+                            selector: '[data-id="basic-http-provider-modal-footer-ok-react"]',
+                            abortOnFailure: false,
+                            suppressNotFoundErrors: true,
+                            timeout: 5000
+                        })
+                        .switchEnvironment('External Http Provider')
+                        .waitForElementPresent('[data-id="basic-http-provider-modal-footer-ok-react"]')
+                        .execute(() => {
+                            (document.querySelector('*[data-id="basic-http-providerModalDialogContainer-react"] input[data-id="modalDialogCustomPromp"]') as any).focus()
+                        }, [], () => { })
+                        .setValue('[data-id="modalDialogCustomPromp"]', url)
+                        .modalFooterOKClick('basic-http-provider')
+                        .perform((done) => {
+                            done()
+                            this.emit('complete')
+                        })
+                } else {
+                    this.api.perform((done) => {
+                        done()
+                        this.emit('complete')
+                    })
+                }
+            }
+        )
+        return this
+    }
+}
+
+module.exports = ConnectToExternalHttpProvider

--- a/apps/remix-ide-e2e/src/commands/connectToExternalHttpProvider.ts
+++ b/apps/remix-ide-e2e/src/commands/connectToExternalHttpProvider.ts
@@ -7,7 +7,7 @@ class ConnectToExternalHttpProvider extends EventEmitter {
             (result) => {
                 if (result.status as any === -1) {
                     console.log("No connection to external provider found. Adding one.", url)
-                    this
+                    this.api
                         .click({
                             locateStrategy: 'css selector',
                             selector: '[data-id="basic-http-provider-modal-footer-ok-react"]',

--- a/apps/remix-ide-e2e/src/commands/connectToExternalHttpProvider.ts
+++ b/apps/remix-ide-e2e/src/commands/connectToExternalHttpProvider.ts
@@ -5,9 +5,9 @@ class ConnectToExternalHttpProvider extends EventEmitter {
     command(this: NightwatchBrowser, url: string, identifier: string): NightwatchBrowser {
         this.api.element('xpath', `//*[@class='udapp_environment' and contains(.,'${identifier}')]`,
             (result) => {
-                if (result.status as any === -1 ) {
+                if (result.status as any === -1) {
                     console.log("No connection to external provider found. Adding one.", url)
-                    browser
+                    this
                         .click({
                             locateStrategy: 'css selector',
                             selector: '[data-id="basic-http-provider-modal-footer-ok-react"]',

--- a/apps/remix-ide-e2e/src/commands/switchEnvironment.ts
+++ b/apps/remix-ide-e2e/src/commands/switchEnvironment.ts
@@ -3,7 +3,7 @@ import EventEmitter from 'events'
 
 class switchEnvironment extends EventEmitter {
   command (this: NightwatchBrowser, provider: string): NightwatchBrowser {
-    this.api.waitForElementVisible('[data-id="settingsSelectEnvOptions"]')
+    this.api.useCss().waitForElementVisible('[data-id="settingsSelectEnvOptions"]')
     .click('[data-id="settingsSelectEnvOptions"] button')
     .waitForElementVisible(`[data-id="dropdown-item-${provider}"]`)
     .click(`[data-id="dropdown-item-${provider}"]`)

--- a/apps/remix-ide-e2e/src/tests/terminal.test.ts
+++ b/apps/remix-ide-e2e/src/tests/terminal.test.ts
@@ -247,7 +247,10 @@ module.exports = {
       .click({
         selector: '[data-id="listenNetworkCheckInput"]',
       }) // start to listen
-      .pause(5000)
+      .click({
+        selector: '*[data-id="compilerContainerCompileAndRunBtn"]',
+      })
+      .pause(10000)
       .findElements(
         {
           locateStrategy: 'xpath',

--- a/apps/remix-ide-e2e/src/tests/terminal.test.ts
+++ b/apps/remix-ide-e2e/src/tests/terminal.test.ts
@@ -235,7 +235,6 @@ module.exports = {
       .connectToExternalHttpProvider(url, identifier)
       .openFile('contracts')
       .openFile('contracts/1_Storage.sol')
-      .pause(4000)
       .clickLaunchIcon('solidity')
       .click({
         selector: '*[data-id="compilerContainerCompileAndRunBtn"]',

--- a/apps/remix-ide-e2e/src/tests/terminal.test.ts
+++ b/apps/remix-ide-e2e/src/tests/terminal.test.ts
@@ -225,7 +225,7 @@ module.exports = {
       .waitForElementContainsText('*[data-id="terminalJournal"]', '"hex":"0x025cd8"', 120000)
   },
 
-  'Should listen on all transactions #group8 #flaky': function (browser: NightwatchBrowser) {
+  'Should listen on all transactions #group8': function (browser: NightwatchBrowser) {
     const url = 'http://127.0.0.1:8545'
     const identifier = 'Custom'
     browser

--- a/apps/remix-ide-e2e/src/tests/terminal.test.ts
+++ b/apps/remix-ide-e2e/src/tests/terminal.test.ts
@@ -225,7 +225,7 @@ module.exports = {
       .waitForElementContainsText('*[data-id="terminalJournal"]', '"hex":"0x025cd8"', 120000)
     },
 
-    'Should listen on all transactions #group8': function (browser: NightwatchBrowser) {
+    'Should listen on all transactions #group8 #flaky': function (browser: NightwatchBrowser) {
       browser
         .clickLaunchIcon('udapp') // connect to mainnet
         .switchEnvironment('External Http Provider')

--- a/apps/remix-ide-e2e/src/tests/terminal.test.ts
+++ b/apps/remix-ide-e2e/src/tests/terminal.test.ts
@@ -255,7 +255,7 @@ module.exports = {
           timeout: 120000,
         }
         , async (result) => {
-          if (Array.isArray(result.value) && result.value.length == 2) {
+          if (Array.isArray(result.value) && result.value.length > 0) {
             console.log('Found ' + result.value.length + ' transactions')
             browser
             .click({

--- a/apps/remix-ide-e2e/src/types/index.d.ts
+++ b/apps/remix-ide-e2e/src/types/index.d.ts
@@ -65,6 +65,7 @@ declare module 'nightwatch' {
         currentSelectedFileIs (name: string): NightwatchBrowser,
         switchWorkspace: (workspaceName: string) => NightwatchBrowser
         switchEnvironment: (provider: string) => NightwatchBrowser
+        connectToExternalHttpProvider: (url: string, identifier: string) => NightwatchBrowser
     }
 
     export interface NightwatchBrowser {


### PR DESCRIPTION
we have to use ganache to test this RPC listener. the external urls are unreliable. because they disconnect continuously causing chaos and lots of modals at any moment during tests. 
using ganache-cli and sending a transaction using compile and run script also mimics the correct behaviour for the test because it is a ts script doing the transaction just like it would on an external RPC