### PR TITLE
fix storageAt rpc call

### DIFF
--- a/libs/remix-simulator/src/VmProxy.ts
+++ b/libs/remix-simulator/src/VmProxy.ts
@@ -310,15 +310,8 @@ export class VmProxy {
     // we don't use the range params here
     address = toChecksumAddress(address)
 
-    let txHash
-    if (txIndex === 'latest') {
-      txHash = this.lastProcessedStorageTxHash[address]
-    } else {
-      const block = this.vmContext.blocks[blockNumber]
-      txHash = '0x' + block.transactions[txIndex].hash().toString('hex')
-    }
-    
-    
+    const block = this.vmContext.blocks[blockNumber]
+    const txHash = '0x' + block.transactions[txIndex].hash().toString('hex')
 
     if (this.storageCache['after_' + txHash] && this.storageCache['after_' + txHash][address]) {
       const storage = this.storageCache['after_' + txHash][address]

--- a/libs/remix-simulator/src/methods/blocks.ts
+++ b/libs/remix-simulator/src/methods/blocks.ts
@@ -175,7 +175,7 @@ export class Blocks {
   eth_getStorageAt (payload, cb) {
     const [ address, position, blockNumber ] = payload.params
 
-    this.vmContext.web3().debug.storageRangeAt(blockNumber, 'latest', address.toLowerCase(), position, 1, (err, result) => {
+    this.vmContext.web3().debug.storageRangeAt(blockNumber + 1, 0, address.toLowerCase(), position, 1, (err, result) => {
       if (err || (result.storage && Object.values(result.storage).length === 0)) {
         return cb(err, '')
       }

--- a/libs/remix-simulator/src/methods/blocks.ts
+++ b/libs/remix-simulator/src/methods/blocks.ts
@@ -1,7 +1,7 @@
 import Web3 from 'web3'
-
+import { VMContext } from '../vm-context'
 export class Blocks {
-  vmContext
+  vmContext: VMContext
   coinbase: string
   TX_INDEX = '0x0' // currently there's always only 1 tx per block, so the transaction index will always be 0x0
   constructor (vmContext, _options) {
@@ -73,7 +73,7 @@ export class Blocks {
       stateRoot: this.toHex(block.header.stateRoot),
       miner: this.coinbase,
       difficulty: this.toHex(block.header.difficulty),
-      totalDifficulty: this.toHex(block.header.totalDifficulty),
+      totalDifficulty: this.toHex((block.header as any).totalDifficulty),
       extraData: this.toHex(block.header.extraData),
       size: '0x027f07', // 163591
       gasLimit: this.toHex(block.header.gasLimit),
@@ -127,7 +127,7 @@ export class Blocks {
       stateRoot: this.toHex(block.header.stateRoot),
       miner: this.coinbase,
       difficulty: this.toHex(block.header.difficulty),
-      totalDifficulty: this.toHex(block.header.totalDifficulty),
+      totalDifficulty: this.toHex((block.header as any).totalDifficulty),
       extraData: this.toHex(block.header.extraData),
       size: '0x027f07', // 163591
       gasLimit: this.toHex(block.header.gasLimit),
@@ -173,15 +173,10 @@ export class Blocks {
   }
 
   eth_getStorageAt (payload, cb) {
-    const [ address, position, blockNumber ] = payload.params
-
-    this.vmContext.web3().debug.storageRangeAt(blockNumber + 1, 0, address.toLowerCase(), position, 1, (err, result) => {
-      if (err || (result.storage && Object.values(result.storage).length === 0)) {
-        return cb(err, '')
-      }
-
-      const value = Object.values(result.storage)[0]['value']
-      cb(err, value)
-    })
+    return this.vmContext.web3().eth.getStorageAt(
+      payload.params[0],
+      payload.params[1],
+      payload.params[2],
+      cb)
   }
 }

--- a/libs/remix-simulator/src/methods/blocks.ts
+++ b/libs/remix-simulator/src/methods/blocks.ts
@@ -173,7 +173,7 @@ export class Blocks {
   }
 
   eth_getStorageAt (payload, cb) {
-    const [address, position, blockNumber] = payload.params
+    const [ address, position, blockNumber ] = payload.params
 
     this.vmContext.web3().debug.storageRangeAt(blockNumber, 'latest', address.toLowerCase(), position, 1, (err, result) => {
       if (err || (result.storage && Object.values(result.storage).length === 0)) {

--- a/libs/remix-simulator/test/blocks.ts
+++ b/libs/remix-simulator/test/blocks.ts
@@ -212,13 +212,13 @@ describe('blocks', () => {
       let storage = await web3.eth.getStorageAt(contractInstance.options.address, 0)
       assert.deepEqual(storage, '0x64')
 
-      await contractInstance.methods.set(200).send({ from: accounts[0], gas: 400000 })
-      storage = await web3.eth.getStorageAt(contractInstance.options.address, 0)
-      assert.deepEqual(storage, '0x64')
-
-      await contractInstance.methods.set(200).send({ from: accounts[0], gas: 400000 })
+      await contractInstance.methods.set(200).send({ from: accounts[0].toLowerCase(), gas: 400000 })
       storage = await web3.eth.getStorageAt(contractInstance.options.address, 0)
       assert.deepEqual(storage, '0xc8')
+
+      await contractInstance.methods.set(1).send({ from: accounts[0].toLowerCase(), gas: 400000 })
+      storage = await web3.eth.getStorageAt(contractInstance.options.address, 0)
+      assert.deepEqual(storage, '0x01')
     })
   })
   describe('eth_call', () => {


### PR DESCRIPTION
fix https://github.com/ethereum/remix-project/issues/2887

to test it:

 - deploy the Storage.sol
 - set it to a value
 - add a script in remix which uses `web3.eth.getStorage` end point (the slot should be 0)
 - the value should be the same as the value set.