### PR TITLE
fix compiler license loading

### DIFF
--- a/libs/remix-solidity/src/compiler/compiler.ts
+++ b/libs/remix-solidity/src/compiler/compiler.ts
@@ -281,7 +281,7 @@ export class Compiler {
       }
       switch (data.cmd) {
         case 'versionLoaded':
-          if (data.data && data.license) this.onCompilerLoaded(data.data, data.license)
+          if (data.data) this.onCompilerLoaded(data.data, data.license)
           break
         case 'compiled':
           {


### PR DESCRIPTION
Compilers without a license show issue in loading without this.