### PR TITLE
remove toast for parser

### DIFF
--- a/apps/remix-ide/src/app/plugins/parser/services/code-parser-antlr-service.ts
+++ b/apps/remix-ide/src/app/plugins/parser/services/code-parser-antlr-service.ts
@@ -71,7 +71,7 @@ export default class CodeParserAntlrService {
 
     setFileParsingState(file: string) {
         if (this.cache[file]) {
-            if (this.cache[file].blockDurations && this.cache[file].blockDurations.length > (this.parserTrehsholdSampleAmount-1)) {
+            if (this.cache[file].blockDurations && this.cache[file].blockDurations.length > this.parserTrehsholdSampleAmount) {
                 // calculate average of durations to determine if the parsing should be disabled
                 const values = [...this.cache[file].blockDurations]
                 const average = values.reduce((a, b) => a + b, 0) / values.length

--- a/apps/remix-ide/src/app/plugins/parser/services/code-parser-antlr-service.ts
+++ b/apps/remix-ide/src/app/plugins/parser/services/code-parser-antlr-service.ts
@@ -24,7 +24,7 @@ export default class CodeParserAntlrService {
     worker: Worker
     parserStartTime: number = 0
     workerTimer: NodeJS.Timer
-    parserTreshHold: number = 10
+    parserTreshold: number = 10
     parserTresholdSampleAmount = 3
     cache: {
         [name: string]: {
@@ -75,7 +75,7 @@ export default class CodeParserAntlrService {
                 // calculate average of durations to determine if the parsing should be disabled
                 const values = [...this.cache[file].blockDurations]
                 const average = values.reduce((a, b) => a + b, 0) / values.length
-                if (average > this.parserTreshHold) {
+                if (average > this.parserTreshold) {
                     this.cache[file].parsingEnabled = false
                 } else {
                     this.cache[file].parsingEnabled = true

--- a/apps/remix-ide/src/app/plugins/parser/services/code-parser-antlr-service.ts
+++ b/apps/remix-ide/src/app/plugins/parser/services/code-parser-antlr-service.ts
@@ -24,8 +24,8 @@ export default class CodeParserAntlrService {
     worker: Worker
     parserStartTime: number = 0
     workerTimer: NodeJS.Timer
-    parserTreshold: number = 10
-    parserTresholdSampleAmount = 3
+    parserThreshold: number = 10
+    parserThresholdSampleAmount = 3
     cache: {
         [name: string]: {
             text: string,
@@ -59,7 +59,7 @@ export default class CodeParserAntlrService {
                             ast: ev.data.ast,
                             duration: ev.data.duration,
                             blocks: ev.data.blocks,
-                            blockDurations: self.cache[ev.data.file].blockDurations? [...self.cache[ev.data.file].blockDurations.slice(-self.parserTresholdSampleAmount), ev.data.blockDuration]: [ev.data.blockDuration]
+                            blockDurations: self.cache[ev.data.file].blockDurations? [...self.cache[ev.data.file].blockDurations.slice(-self.parserThresholdSampleAmount), ev.data.blockDuration]: [ev.data.blockDuration]
                         }
                         self.setFileParsingState(ev.data.file)
                     }
@@ -71,11 +71,11 @@ export default class CodeParserAntlrService {
 
     setFileParsingState(file: string) {
         if (this.cache[file]) {
-            if (this.cache[file].blockDurations && this.cache[file].blockDurations.length > this.parserTresholdSampleAmount) {
+            if (this.cache[file].blockDurations && this.cache[file].blockDurations.length > this.parserThresholdSampleAmount) {
                 // calculate average of durations to determine if the parsing should be disabled
                 const values = [...this.cache[file].blockDurations]
                 const average = values.reduce((a, b) => a + b, 0) / values.length
-                if (average > this.parserTreshold) {
+                if (average > this.parserThreshold) {
                     this.cache[file].parsingEnabled = false
                 } else {
                     this.cache[file].parsingEnabled = true
@@ -248,7 +248,7 @@ export default class CodeParserAntlrService {
                 const startTime = Date.now()
                 const blocks = (SolidityParser as any).parseBlock(fileContent, { loc: true, range: true, tolerant: true })
                 if(this.cache[this.plugin.currentFile] && this.cache[this.plugin.currentFile].blockDurations){
-                    this.cache[this.plugin.currentFile].blockDurations = [...this.cache[this.plugin.currentFile].blockDurations.slice(-this.parserTresholdSampleAmount), Date.now() - startTime]
+                    this.cache[this.plugin.currentFile].blockDurations = [...this.cache[this.plugin.currentFile].blockDurations.slice(-this.parserThresholdSampleAmount), Date.now() - startTime]
                     this.setFileParsingState(this.plugin.currentFile)
                 }
                 if (blocks) this.cache[this.plugin.currentFile].blocks = blocks

--- a/apps/remix-ide/src/app/plugins/parser/services/code-parser-antlr-service.ts
+++ b/apps/remix-ide/src/app/plugins/parser/services/code-parser-antlr-service.ts
@@ -25,7 +25,7 @@ export default class CodeParserAntlrService {
     parserStartTime: number = 0
     workerTimer: NodeJS.Timer
     parserTreshHold: number = 10
-    parserTrehsholdSampleAmount = 3
+    parserTresholdSampleAmount = 3
     cache: {
         [name: string]: {
             text: string,
@@ -59,7 +59,7 @@ export default class CodeParserAntlrService {
                             ast: ev.data.ast,
                             duration: ev.data.duration,
                             blocks: ev.data.blocks,
-                            blockDurations: self.cache[ev.data.file].blockDurations? [...self.cache[ev.data.file].blockDurations.slice(-self.parserTrehsholdSampleAmount), ev.data.blockDuration]: [ev.data.blockDuration]
+                            blockDurations: self.cache[ev.data.file].blockDurations? [...self.cache[ev.data.file].blockDurations.slice(-self.parserTresholdSampleAmount), ev.data.blockDuration]: [ev.data.blockDuration]
                         }
                         self.setFileParsingState(ev.data.file)
                     }
@@ -71,7 +71,7 @@ export default class CodeParserAntlrService {
 
     setFileParsingState(file: string) {
         if (this.cache[file]) {
-            if (this.cache[file].blockDurations && this.cache[file].blockDurations.length > this.parserTrehsholdSampleAmount) {
+            if (this.cache[file].blockDurations && this.cache[file].blockDurations.length > this.parserTresholdSampleAmount) {
                 // calculate average of durations to determine if the parsing should be disabled
                 const values = [...this.cache[file].blockDurations]
                 const average = values.reduce((a, b) => a + b, 0) / values.length
@@ -248,7 +248,7 @@ export default class CodeParserAntlrService {
                 const startTime = Date.now()
                 const blocks = (SolidityParser as any).parseBlock(fileContent, { loc: true, range: true, tolerant: true })
                 if(this.cache[this.plugin.currentFile] && this.cache[this.plugin.currentFile].blockDurations){
-                    this.cache[this.plugin.currentFile].blockDurations = [...this.cache[this.plugin.currentFile].blockDurations.slice(-this.parserTrehsholdSampleAmount), Date.now() - startTime]
+                    this.cache[this.plugin.currentFile].blockDurations = [...this.cache[this.plugin.currentFile].blockDurations.slice(-this.parserTresholdSampleAmount), Date.now() - startTime]
                     this.setFileParsingState(this.plugin.currentFile)
                 }
                 if (blocks) this.cache[this.plugin.currentFile].blocks = blocks


### PR DESCRIPTION
showing a toast is basically unnecessary, it's better to quickly enable disable the parser based on the timing than to inform the user. the reason is that the only thing it really disables is parsing blocks where the cursor is in to provide context to the autocomplete. otherwise if the parser briefly gets disabled the toast will show all the time while it will be enabled by itself on the next loop.