### PR TITLE
add contracts to "deployed contracts" when script run externally

### DIFF
--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -486,8 +486,12 @@ export class Blockchain extends Plugin {
   // TODO : event should be triggered by Udapp instead of TxListener
   /** Listen on New Transaction. (Cannot be done inside constructor because txlistener doesn't exist yet) */
   startListening (txlistener) {
-    txlistener.event.register('newTransaction', (tx, receipt) => {
+    txlistener.event.register('newTransaction', async (tx, receipt) => {
       this.events.emit('newTransaction', tx, receipt)
+      const resolvedTransaction = await txlistener.resolvedTransaction(tx.hash)
+      if (resolvedTransaction && !receipt.to) {
+        this.call('udapp', 'addInstance', receipt.contractAddress, resolvedTransaction.abi, resolvedTransaction.contractName)
+      }
     })
   }
 

--- a/libs/remix-lib/src/execution/txListener.ts
+++ b/libs/remix-lib/src/execution/txListener.ts
@@ -323,7 +323,8 @@ export class TxListener {
             contractName: contract.name,
             to: tx.to,
             fn: fn,
-            params: this._decodeInputParams(inputData.substring(8), fnabi)
+            params: this._decodeInputParams(inputData.substring(8), fnabi),
+            abi
           }
           if (tx.returnValue) {
             this._resolvedTransactions[tx.hash].decodedReturnValue = decodeResponse(tx.returnValue, fnabi)
@@ -337,7 +338,8 @@ export class TxListener {
           contractName: contract.name,
           to: tx.to,
           fn: '(receive)',
-          params: null
+          params: null,
+          abi
         }
       } else {
         // fallback function
@@ -345,7 +347,8 @@ export class TxListener {
           contractName: contract.name,
           to: tx.to,
           fn: '(fallback)',
-          params: null
+          params: null,
+          abi
         }
       }
     } else {
@@ -358,7 +361,8 @@ export class TxListener {
         contractName: contract.name,
         to: null,
         fn: '(constructor)',
-        params: params
+        params: params,
+        abi
       }
     }
     return this._resolvedTransactions[tx.hash]

--- a/libs/remix-ui/run-tab/src/lib/reducers/runTab.ts
+++ b/libs/remix-ui/run-tab/src/lib/reducers/runTab.ts
@@ -591,12 +591,13 @@ export const runTabReducer = (state: RunTabState = runTabInitialState, action: A
 
     case ADD_INSTANCE: {
       const payload: { contractData: ContractData, address: string, name: string, abi?: any, decodedResponse?: Record<number, any> } = action.payload
+      const exists = state.instances.instanceList.filter((instance) => instance.address === payload.address)
 
       return {
         ...state,
         instances: {
           ...state.instances,
-          instanceList: [...state.instances.instanceList, payload]
+          instanceList: exists.length ? state.instances.instanceList : [...state.instances.instanceList, payload]
         }
       }
     }


### PR DESCRIPTION
when "listen on all transactions" is checked, all the contracts deployments for which the abi is known will be added to the "deployed contracts" in udapp.
This is a feature request.