### PR TITLE
handle connections in plugins

### DIFF
--- a/apps/remix-ide/src/app/files/foundry-handle.js
+++ b/apps/remix-ide/src/app/files/foundry-handle.js
@@ -15,4 +15,12 @@ export class FoundryHandle extends WebsocketPlugin {
   constructor () {
     super(profile)
   }
+
+  callPluginMethod(key, payload = []) {
+    if (this.socket.readyState !== this.socket.OPEN) {
+      console.log(`${this.profile.name} connection is not opened.`)
+      return false
+    }
+    return super.callPluginMethod(key, payload)
+  }
 }

--- a/apps/remix-ide/src/app/files/git-handle.js
+++ b/apps/remix-ide/src/app/files/git-handle.js
@@ -15,4 +15,12 @@ export class GitHandle extends WebsocketPlugin {
   constructor () {
     super(profile)
   }
+
+  callPluginMethod(key, payload = []) {
+    if (this.socket.readyState !== this.socket.OPEN) {
+      console.log(`${this.profile.name} connection is not opened.`)
+      return false
+    }
+    return super.callPluginMethod(key, payload)
+  }
 }

--- a/apps/remix-ide/src/app/files/hardhat-handle.js
+++ b/apps/remix-ide/src/app/files/hardhat-handle.js
@@ -15,4 +15,12 @@ export class HardhatHandle extends WebsocketPlugin {
   constructor () {
     super(profile)
   }
+
+  callPluginMethod(key, payload = []) {
+    if (this.socket.readyState !== this.socket.OPEN) {
+      console.log(`${this.profile.name} connection is not opened.`)
+      return false
+    }
+    return super.callPluginMethod(key, payload)
+  }
 }

--- a/apps/remix-ide/src/app/files/slither-handle.js
+++ b/apps/remix-ide/src/app/files/slither-handle.js
@@ -16,4 +16,12 @@ export class SlitherHandle extends WebsocketPlugin {
   constructor () {
     super(profile)
   }
+
+  callPluginMethod(key, payload = []) {
+    if (this.socket.readyState !== this.socket.OPEN) {
+      console.log(`${this.profile.name} connection is not opened.`)
+      return false
+    }
+    return super.callPluginMethod(key, payload)
+  }
 }

--- a/apps/remix-ide/src/app/files/truffle-handle.js
+++ b/apps/remix-ide/src/app/files/truffle-handle.js
@@ -12,7 +12,7 @@ const profile = {
 }
 
 export class TruffleHandle extends WebsocketPlugin {
-  constructor() {
+  constructor () {
     super(profile)
   }
 

--- a/apps/remix-ide/src/app/files/truffle-handle.js
+++ b/apps/remix-ide/src/app/files/truffle-handle.js
@@ -12,7 +12,16 @@ const profile = {
 }
 
 export class TruffleHandle extends WebsocketPlugin {
-  constructor () {
+  constructor() {
     super(profile)
   }
+
+  callPluginMethod(key, payload = []) {
+    if (this.socket.readyState !== this.socket.OPEN) {
+      console.log(`${this.profile.name} connection is not opened.`)
+      return false
+    }
+    return super.callPluginMethod(key, payload)
+  }
+
 }

--- a/apps/remix-ide/src/app/plugins/remixd-handle.tsx
+++ b/apps/remix-ide/src/app/plugins/remixd-handle.tsx
@@ -71,6 +71,14 @@ export class RemixdHandle extends WebsocketPlugin {
 
   }
 
+  async callPluginMethod(key: string, payload?: any[]) {
+    if (this.socket.readyState !== this.socket.OPEN) {
+      console.log(`${this.profile.name} connection is not opened.`)
+      return false
+    }
+    return super.callPluginMethod(key, payload)
+  }
+
   /**
     * connect to localhost if no connection and render the explorer
     * disconnect from localhost if connected and remove the explorer


### PR DESCRIPTION
fixes #2976 

before the plugin call happens check the connection. no use to SEND to the socket if it's not open. prevents timeouts and removes the need to throw errors in the console.