### PR TITLE
Fix listen framework

### DIFF
--- a/libs/remix-ui/run-tab/src/lib/actions/events.ts
+++ b/libs/remix-ui/run-tab/src/lib/actions/events.ts
@@ -124,7 +124,6 @@ const broadcastCompilationResult = async (compilerName: string, plugin: RunTab, 
     dispatch(addDeployOption({ [file]: {} }))
   }
   dispatch(fetchContractListSuccess({ [file]: contracts }))
-  dispatch(setCurrentFile(file))
   dispatch(setCompilationSource(compilerName))
   // TODO: set current contract
 }

--- a/libs/remix-ui/run-tab/src/lib/components/contractDropdownUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/contractDropdownUI.tsx
@@ -240,7 +240,7 @@ export function ContractDropdownUI (props: ContractDropdownProps) {
       <div className='d-flex justify-content-between'>
         <div className="d-flex justify-content-between align-items-end">
           <label className="udapp_settingsLabel pr-1">Contract</label>
-          <div className="d-flex">{ Object.keys(props.contracts.contractList).length > 0 && compilationSource !== '' && <label className="text-capitalize" style={{maxHeight: '0.6rem', lineHeight: '1rem'}} data-id="udappCompiledBy">(Compiled by {compilationSource})</label>}</div>
+          <div className="d-flex">{ contractList[currentFile] && contractList[currentFile].length > 0 && compilationSource !== '' && <label className="text-capitalize" style={{maxHeight: '0.6rem', lineHeight: '1rem'}} data-id="udappCompiledBy">(Compiled by {compilationSource})</label>}</div>
         </div>
         <OverlayTrigger placement={'right'} overlay={
           <Tooltip className="text-nowrap" id="info-sync-compiled-contract">

--- a/libs/remix-ui/run-tab/src/lib/components/contractDropdownUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/contractDropdownUI.tsx
@@ -249,7 +249,7 @@ export function ContractDropdownUI (props: ContractDropdownProps) {
           </Tooltip>
         }>
           <button className="btn d-flex py-0" onClick={_ => props.syncContracts()}>
-            <i style={{ cursor: 'pointer' }} className="fa fa-refresh mr-2 mt-2" aria-hidden="true"></i>
+            <i style={{ cursor: 'pointer' }} className="fa fa-refresh" aria-hidden="true"></i>
           </button>
         </OverlayTrigger>
       </div>


### PR DESCRIPTION
partially_fix https://github.com/ethereum/remix-project/issues/2975

- [x] If a contract is compiled from default_workspace, in Udap, it shows CONTRACT (Compiled by Remix). Then when another contract is selected, Udapp still shows that:
- [x] Clicking on Refresh icon selects a contract in UDapp dropdown list irrespective of file opened in editor