### PR TITLE
Minor changes to show content

### DIFF
--- a/libs/remix-ui/home-tab/src/lib/components/homeTabFile.tsx
+++ b/libs/remix-ui/home-tab/src/lib/components/homeTabFile.tsx
@@ -136,7 +136,7 @@ function HomeTabFile ({plugin}: HomeTabFileProps) {
         </div>
       </ModalDialog>
       <Toaster message={state.toasterMsg} />
-      <div className="justify-content-start mt-3 p-2 border-bottom d-flex flex-column" id="hTFileSection">
+      <div className="justify-content-start mt-1 p-2 border-bottom d-flex flex-column" id="hTFileSection">
         <label style={{fontSize: "1rem"}}>Files</label>
         <button className="btn btn-primary p-2 border my-1" data-id="homeTabNewFile" style={{width: 'fit-content'}} onClick={() => createNewFile()}>New File</button>
         <label className="btn p-2 border my-1" style={{width: 'fit-content'}} htmlFor="openFileInput">Open File</label>

--- a/libs/remix-ui/home-tab/src/lib/components/homeTabTitle.tsx
+++ b/libs/remix-ui/home-tab/src/lib/components/homeTabTitle.tsx
@@ -119,9 +119,9 @@ function HomeTabTitle() {
       </div>
       <b className="pb-1 text-dark" style={{ fontStyle: 'italic' }}>The Native IDE for Web3 Development.</b>
       <div className="pb-1" id="hTGeneralLinks">
-        <a className="remixui_home_text" target="__blank" href="https://remix-project.org">Project Website</a>
+        <a className="remixui_home_text" target="__blank" href="https://remix-project.org">Website</a>
         <a className="pl-2 remixui_home_text" target="__blank" href="https://remix-ide.readthedocs.io/en/latest">Documentation</a>
-        <a className="pl-2 remixui_home_text" target="__blank" href="https://remix-plugin-docs.readthedocs.io/en/latest/">Remix Plugins</a>
+        <a className="pl-2 remixui_home_text" target="__blank" href="https://remix-plugin-docs.readthedocs.io/en/latest/">Remix Plugin</a>
         <a className="pl-2 remixui_home_text" target="__blank" href="https://github.com/ethereum/remix-desktop/releases">Remix Desktop</a>
       </div>
       <div className="d-flex pb-1 align-items-center">

--- a/libs/remix-ui/home-tab/src/lib/components/homeTabTitle.tsx
+++ b/libs/remix-ui/home-tab/src/lib/components/homeTabTitle.tsx
@@ -59,7 +59,7 @@ function HomeTabTitle() {
         ></audio>
       </div>
       <div className="d-flex justify-content-between">
-        <span className="h-80 text-uppercase" style={{ fontSize: 'xx-large', fontFamily: "Noah" }}>Remix</span>
+        <span className="h-80 text-uppercase" style={{ fontSize: 'xx-large', fontFamily: "Noah, sans-serif" }}>Remix</span>
         <span>
           <OverlayTrigger placement={'top'} overlay={
             <Tooltip className="text-nowrap" id="overlay-tooltip">


### PR DESCRIPTION
Related to https://github.com/ethereum/remix-project/pull/2964

- It makes Learneth tutorial `Get Started` button and `Scam Alert` section visible without scroll.
- Set `sans serif` as fallback font for `REMIX` title as suggested by Andy