### PR TITLE
Save proxy addresses and storage layout for upgrade. (Secure Upgrade Part1)

### DIFF
--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -177,11 +177,11 @@ export class Blockchain extends Plugin {
         _paq.push(['trackEvent', 'blockchain', 'Deploy With Proxy', 'Proxy deployment failed: ' + error])
         return this.call('terminal', 'logHtml', log)
       }
-      const hasPreviousDeploys = await this.call('fileManager', 'exists', `.deploys/upgradeable-contracts/${networkInfo.name}.json`)
+      const hasPreviousDeploys = await this.call('fileManager', 'exists', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`)
       
       // make deploys folder read only.
       if (hasPreviousDeploys) {
-        const deployments = await this.call('fileManager', 'readFile', `.deploys/upgradeable-contracts/${networkInfo.name}.json`)
+        const deployments = await this.call('fileManager', 'readFile', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`)
         const parsedDeployments = JSON.parse(deployments)
 
         parsedDeployments.deployments.push({
@@ -190,9 +190,9 @@ export class Blockchain extends Plugin {
           layout: implementationContractObject.contract.object.storageLayout,
           date: new Date().toISOString()
         })
-        await this.call('fileManager', 'writeFile', `.deploys/upgradeable-contracts/${networkInfo.name}.json`, JSON.stringify(parsedDeployments, null, 2))
+        await this.call('fileManager', 'writeFile', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`, JSON.stringify(parsedDeployments, null, 2))
       } else {
-        await this.call('fileManager', 'writeFile', `.deploys/upgradeable-contracts/${networkInfo.name}.json`, JSON.stringify({
+        await this.call('fileManager', 'writeFile', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`, JSON.stringify({
           id: networkInfo.id,
           network: networkInfo.name,
           deployments: [{

--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -185,28 +185,26 @@ export class Blockchain extends Plugin {
         const deployments = await this.call('fileManager', 'readFile', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`)
         const parsedDeployments = JSON.parse(deployments)
 
-        parsedDeployments.deployments[address] = {
+        parsedDeployments.deployments[address] = [{
           date: new Date().toISOString(),
           contractName: contractName,
           fork: networkInfo.currentFork,
-          proxyAddress: address,
           implementationAddress: implementationAddress,
           layout: implementationContractObject.contract.object.storageLayout
-        }
+        }]
         await this.call('fileManager', 'writeFile', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`, JSON.stringify(parsedDeployments, null, 2))
       } else {
         await this.call('fileManager', 'writeFile', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`, JSON.stringify({
           id: networkInfo.id,
           network: networkInfo.name,
           deployments: {
-            [address]: {
+            [address]: [{
               date: new Date().toISOString(),
               contractName: contractName,
               fork: networkInfo.currentFork,
-              proxyAddress: address,
               implementationAddress: implementationAddress,
               layout: implementationContractObject.contract.object.storageLayout
-            }
+            }]
           }
         }, null, 2))
       }
@@ -262,26 +260,27 @@ export class Blockchain extends Plugin {
         const deployments = await this.call('fileManager', 'readFile', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`)
         const parsedDeployments = JSON.parse(deployments)
 
-        parsedDeployments.deployments[proxyAddress] = {
-          lastUpdated: new Date().toISOString(),
-          ...parsedDeployments.deployments[proxyAddress],
+        if (!parsedDeployments.deployments[proxyAddress]) parsedDeployments.deployments[proxyAddress] = []
+        parsedDeployments.deployments[proxyAddress].push({
+          date: new Date().toISOString(),
+          contractName: contractName,
+          fork: networkInfo.currentFork,
           implementationAddress: implementationAddress,
           layout: newImplementationContractObject.contract.object.storageLayout
-        }
+        })
         await this.call('fileManager', 'writeFile', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`, JSON.stringify(parsedDeployments, null, 2))
       } else {
         await this.call('fileManager', 'writeFile', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`, JSON.stringify({
           id: networkInfo.id,
           network: networkInfo.name,
           deployments: {
-            [proxyAddress]: {
+            [address]: [{
               date: new Date().toISOString(),
               contractName: contractName,
               fork: networkInfo.currentFork,
-              proxyAddress,
               implementationAddress: implementationAddress,
               layout: newImplementationContractObject.contract.object.storageLayout
-            }
+            }]
           }
         }, null, 2))
       }

--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -177,6 +177,8 @@ export class Blockchain extends Plugin {
         _paq.push(['trackEvent', 'blockchain', 'Deploy With Proxy', 'Proxy deployment failed: ' + error])
         return this.call('terminal', 'logHtml', log)
       }
+      if (networkInfo.name === 'VM') this.config.set('vm/proxy', address)
+      else this.config.set(`${networkInfo.name}/${networkInfo.currentFork}/${networkInfo.id}/proxy`, address)
       await this.saveDeployedContractStorageLayout(implementationContractObject, address, networkInfo)
       _paq.push(['trackEvent', 'blockchain', 'Deploy With Proxy', 'Proxy deployment successful'])
       this.call('udapp', 'addInstance', addressToString(address), implementationContractObject.abi, implementationContractObject.name)

--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -256,7 +256,7 @@ export class Blockchain extends Plugin {
         return this.call('terminal', 'logHtml', log)
       }
       const { contractName, implementationAddress } = newImplementationContractObject
-      const hasPreviousDeploys = await this.call('fileManager', 'exists', `.deploys/upgradeable-contracts/${networkInfo.name}/$UUPS.json`)
+      const hasPreviousDeploys = await this.call('fileManager', 'exists', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`)
       
       if (hasPreviousDeploys) {
         const deployments = await this.call('fileManager', 'readFile', `.deploys/upgradeable-contracts/${networkInfo.name}/UUPS.json`)

--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -187,6 +187,7 @@ export class Blockchain extends Plugin {
         parsedDeployments.deployments.push({
           fork: networkInfo.currentFork,
           proxyAddress: address,
+          implementationAddress: implementationContractObject.implementationAddress,
           layout: implementationContractObject.contract.object.storageLayout,
           date: new Date().toISOString()
         })
@@ -198,6 +199,7 @@ export class Blockchain extends Plugin {
           deployments: [{
             fork: networkInfo.currentFork,
             proxyAddress: address,
+            implementationAddress: implementationContractObject.implementationAddress,
             layout: implementationContractObject.contract.object.storageLayout,
             date: new Date().toISOString()
           }]

--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -161,7 +161,6 @@ export class Blockchain extends Plugin {
   }
 
   async runProxyTx (proxyData, implementationContractObject) {
-
     const args = { useCall: false, data: proxyData }
     let networkInfo
     const confirmationCb = (network, tx, gasEstimation, continueTxExecution, cancelCb) => {

--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -177,8 +177,12 @@ export class Blockchain extends Plugin {
         _paq.push(['trackEvent', 'blockchain', 'Deploy With Proxy', 'Proxy deployment failed: ' + error])
         return this.call('terminal', 'logHtml', log)
       }
-      if (networkInfo.name === 'VM') this.config.set('vm/proxy', address)
-      else this.config.set(`${networkInfo.name}/${networkInfo.currentFork}/${networkInfo.id}/proxy`, address)
+      if (networkInfo.name === 'VM') {
+        this.call('fileManager', 'exists', '.deploys', (error, exists) => {
+        this.config.set('vm/proxy', address)
+      } else {
+        this.config.set(`${networkInfo.name}/${networkInfo.currentFork}/${networkInfo.id}/proxy`, address)
+      }
       _paq.push(['trackEvent', 'blockchain', 'Deploy With Proxy', 'Proxy deployment successful'])
       this.call('udapp', 'addInstance', addressToString(address), implementationContractObject.abi, implementationContractObject.name)
     }

--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -188,7 +188,6 @@ export class Blockchain extends Plugin {
         parsedDeployments.deployments.push({
           fork: networkInfo.currentFork,
           proxyAddress: address,
-          implementationAddress: implementationContractObject.implementationAddress,
           layout: implementationContractObject.contract.object.storageLayout,
           date: new Date().toISOString()
         })
@@ -200,7 +199,6 @@ export class Blockchain extends Plugin {
           deployments: [{
             fork: networkInfo.currentFork,
             proxyAddress: address,
-            implementationAddress: implementationContractObject.implementationAddress,
             layout: implementationContractObject.contract.object.storageLayout,
             date: new Date().toISOString()
           }]

--- a/libs/remix-core-plugin/src/lib/openzeppelin-proxy.ts
+++ b/libs/remix-core-plugin/src/lib/openzeppelin-proxy.ts
@@ -100,8 +100,9 @@ export class OpenZeppelinProxy extends Plugin {
     }
 
     // re-use implementation contract's ABI for UI display in udapp and change name to proxy name.
-    implementationContractObject.name = proxyName
+    implementationContractObject.contractName = implementationContractObject.name
     implementationContractObject.implementationAddress = implAddress
+    implementationContractObject.name = proxyName
     this.blockchain.deployProxy(data, implementationContractObject)
   }
 
@@ -117,6 +118,8 @@ export class OpenZeppelinProxy extends Plugin {
       dataHex: fnData.replace('0x', '')
     }
     // re-use implementation contract's ABI for UI display in udapp and change name to proxy name.
+    newImplementationContractObject.contractName = newImplementationContractObject.name
+    newImplementationContractObject.implementationAddress = newImplAddress
     newImplementationContractObject.name = proxyName
     this.blockchain.upgradeProxy(proxyAddress, newImplAddress, data, newImplementationContractObject)
   }

--- a/libs/remix-core-plugin/src/lib/openzeppelin-proxy.ts
+++ b/libs/remix-core-plugin/src/lib/openzeppelin-proxy.ts
@@ -101,6 +101,7 @@ export class OpenZeppelinProxy extends Plugin {
 
     // re-use implementation contract's ABI for UI display in udapp and change name to proxy name.
     implementationContractObject.name = proxyName
+    implementationContractObject.implementationAddress = implAddress
     this.blockchain.deployProxy(data, implementationContractObject)
   }
 

--- a/libs/remix-core-plugin/src/lib/openzeppelin-proxy.ts
+++ b/libs/remix-core-plugin/src/lib/openzeppelin-proxy.ts
@@ -101,7 +101,6 @@ export class OpenZeppelinProxy extends Plugin {
 
     // re-use implementation contract's ABI for UI display in udapp and change name to proxy name.
     implementationContractObject.name = proxyName
-    implementationContractObject.implementationAddress = implAddress
     this.blockchain.deployProxy(data, implementationContractObject)
   }
 

--- a/libs/remix-ui/run-tab/src/lib/components/contractGUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/contractGUI.tsx
@@ -1,7 +1,6 @@
 // eslint-disable-next-line no-use-before-define
 import React, { useEffect, useRef, useState } from 'react'
 import * as remixLib from '@remix-project/remix-lib'
-import Web3 from 'web3'
 import { ContractGUIProps } from '../types'
 import { CopyToClipboard } from '@remix-ui/clipboard'
 import { CustomTooltip } from '@remix-ui/helper'


### PR DESCRIPTION
This PR creates a file based on network name for upgradeable contracts (`.deploys/upgradeable-contracts/goerli.json`).
- The proxy address is stored in other to provide a list of previously deployed proxy addresses a user can make upgrades to. This will be implemented in a follow-up PR.
- The storage layout is stored to enable verifying that any storage layout changes between subsequent versions are compatible. (see https://docs.openzeppelin.com/upgrades-plugins/1.x/network-files). This will be implemented in a follow-up PR.

Linked to https://github.com/ethereum/remix-project/issues/3052
Closes https://github.com/ethereum/remix-project/issues/3189