### PR TITLE
Use the cache for the calltree

### DIFF
--- a/libs/remix-debug/src/code/breakpointManager.ts
+++ b/libs/remix-debug/src/code/breakpointManager.ts
@@ -14,7 +14,6 @@ export class BreakpointManager {
   callTree
   solidityProxy
   breakpoints
-  locationToRowConverter
 
   /**
     * constructor

--- a/libs/remix-debug/src/code/breakpointManager.ts
+++ b/libs/remix-debug/src/code/breakpointManager.ts
@@ -89,6 +89,7 @@ export class BreakpointManager {
   async jump (fromStep, direction, defaultToLimit, trace) {
     this.event.trigger('locatingBreakpoint', [])
     let sourceLocation
+    let lineColumn
     let previousSourceLocation
     let currentStep = fromStep + direction
     let lineHadBreakpoint = false
@@ -96,13 +97,14 @@ export class BreakpointManager {
     while (currentStep > 0 && currentStep < trace.length) {
       try {
         previousSourceLocation = sourceLocation
-        sourceLocation = await this.callTree.extractValidSourceLocation(currentStep)
+        const stepInfo = await this.callTree.locationAndOpcodePerVMTraceIndex[currentStep]
+        sourceLocation = stepInfo.sourceLocation
+        lineColumn = stepInfo.lineColumnPos
       } catch (e) {
         console.log('cannot jump to breakpoint ' + e)
         currentStep += direction
         continue
       }
-      const lineColumn = await this.locationToRowConverter(sourceLocation)
       if (!initialLine) initialLine = lineColumn
 
       if (initialLine.start.line !== lineColumn.start.line) {

--- a/libs/remix-debug/src/code/breakpointManager.ts
+++ b/libs/remix-debug/src/code/breakpointManager.ts
@@ -22,13 +22,12 @@ export class BreakpointManager {
     * @param {Object} _debugger - type of EthDebugger
     * @return {Function} _locationToRowConverter - function implemented by editor which return a column/line position for a char source location
     */
-  constructor ({ traceManager, callTree, solidityProxy, locationToRowConverter }) {
+  constructor ({ traceManager, callTree, solidityProxy }) {
     this.event = new EventManager()
     this.traceManager = traceManager
     this.callTree = callTree
     this.solidityProxy = solidityProxy
     this.breakpoints = {}
-    this.locationToRowConverter = locationToRowConverter
   }
 
   setManagers ({ traceManager, callTree, solidityProxy }) {
@@ -43,7 +42,7 @@ export class BreakpointManager {
     *
     */
   async jumpNextBreakpoint (fromStep, defaultToLimit) {
-    if (!this.locationToRowConverter) {
+    if (!this.callTree.locationAndOpcodePerVMTraceIndex[fromStep]) {
       return console.log('row converter not provided')
     }
     this.jump(fromStep || 0, 1, defaultToLimit, this.traceManager.trace)
@@ -55,7 +54,7 @@ export class BreakpointManager {
     *
     */
   async jumpPreviousBreakpoint (fromStep, defaultToLimit) {
-    if (!this.locationToRowConverter) {
+    if (!this.callTree.locationAndOpcodePerVMTraceIndex[fromStep]) {
       return console.log('row converter not provided')
     }
     this.jump(fromStep || 0, -1, defaultToLimit, this.traceManager.trace)
@@ -97,7 +96,7 @@ export class BreakpointManager {
     while (currentStep > 0 && currentStep < trace.length) {
       try {
         previousSourceLocation = sourceLocation
-        const stepInfo = await this.callTree.locationAndOpcodePerVMTraceIndex[currentStep]
+        const stepInfo = this.callTree.locationAndOpcodePerVMTraceIndex[currentStep]
         sourceLocation = stepInfo.sourceLocation
         lineColumn = stepInfo.lineColumnPos
       } catch (e) {

--- a/libs/remix-debug/src/debugger/debugger.ts
+++ b/libs/remix-debug/src/debugger/debugger.ts
@@ -36,12 +36,7 @@ export class Debugger {
     this.breakPointManager = new BreakpointManager({
       traceManager,
       callTree,
-      solidityProxy,
-      locationToRowConverter: async (sourceLocation) => {
-        const compilationResult = await this.compilationResult()
-        if (!compilationResult) return { start: null, end: null }
-        return await this.offsetToLineColumnConverter.offsetToLineColumn(sourceLocation, sourceLocation.file, compilationResult.source.sources, compilationResult.data.sources)
-      }
+      solidityProxy
     })
 
     this.breakPointManager.event.register('breakpointStep', (step) => {

--- a/libs/remix-debug/test/debugger.ts
+++ b/libs/remix-debug/test/debugger.ts
@@ -168,7 +168,12 @@ contract Ballot {
             compilationResult: function () {
               return { data: output }
             },
-            web3: web3
+            web3: web3,
+            offsetToLineColumnConverter: {
+              offsetToLineColumn: async (rawLocation) => {
+                return sourceMappingDecoder.convertOffsetToLineColumn(rawLocation, sourceMappingDecoder.getLinebreakPositions(ballot))
+              }
+            }
           })
   
           debugManager.callTree.event.register('callTreeReady', () => {
@@ -273,9 +278,7 @@ function testDebugging (debugManager) {
   tape('breakPointManager', (t) => {
     t.plan(2)
     const {traceManager, callTree, solidityProxy} = debugManager
-    var breakPointManager = new BreakpointManager({traceManager, callTree, solidityProxy, locationToRowConverter: async (rawLocation) => {
-      return sourceMappingDecoder.convertOffsetToLineColumn(rawLocation, sourceMappingDecoder.getLinebreakPositions(ballot))
-    }})
+    var breakPointManager = new BreakpointManager({traceManager, callTree, solidityProxy})
 
     breakPointManager.add({fileName: 'test.sol', row: 39})
 


### PR DESCRIPTION
This update the Breakpoint Manager to use the cache populated by InternalCallTree instead of recomputing the line/column position.