### PR TITLE
fix filename error

### DIFF
--- a/libs/remix-ui/editor/src/lib/providers/definitionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/definitionProvider.ts
@@ -29,6 +29,9 @@ export class RemixDefinitionProvider implements monaco.languages.DefinitionProvi
                 }
             }
         }
+        if (!jumpLocation || !jumpLocation.fileName) {
+            return []
+        }
         return [{
             uri: this.monaco.Uri.parse(jumpLocation.fileName),
             range: {

--- a/libs/remix-ui/editor/src/lib/providers/definitionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/definitionProvider.ts
@@ -29,18 +29,18 @@ export class RemixDefinitionProvider implements monaco.languages.DefinitionProvi
                 }
             }
         }
-        if (!jumpLocation || !jumpLocation.fileName) {
-            return []
+        if (jumpLocation && jumpLocation.fileName) {
+            return [{
+                uri: this.monaco.Uri.parse(jumpLocation.fileName),
+                range: {
+                    startLineNumber: jumpLocation.startLineNumber,
+                    startColumn: jumpLocation.startColumn,
+                    endLineNumber: jumpLocation.endLineNumber,
+                    endColumn: jumpLocation.endColumn
+                }
+            }]
         }
-        return [{
-            uri: this.monaco.Uri.parse(jumpLocation.fileName),
-            range: {
-                startLineNumber: jumpLocation.startLineNumber,
-                startColumn: jumpLocation.startColumn,
-                endLineNumber: jumpLocation.endLineNumber,
-                endColumn: jumpLocation.endColumn
-            }
-        }]
+        return []
     }
 
     async jumpToDefinition(position: any) {

--- a/libs/remix-ui/editor/src/lib/providers/referenceProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/referenceProvider.ts
@@ -28,7 +28,7 @@ export class RemixReferenceProvider implements monaco.languages.ReferenceProvide
               fileTarget = fileTarget.file
               const fileContent = await this.props.plugin.call('fileManager', 'readFile', fileInNode)
               const lineColumn = await this.props.plugin.call('codeParser', 'getLineColumnOfPosition', position)
-              console.log(position, fileTarget, lineColumn)
+
               try {
                 this.props.plugin.call('editor', 'addModel', fileTarget, fileContent)
               } catch (e) {


### PR DESCRIPTION
prevent filename error being thrown when compiler is not done compiling and you try to look up a definition.