### PR TITLE
Return empty array for undefined nextIndexes

### DIFF
--- a/libs/remix-ui/debugger-ui/src/reducers/assembly-items.ts
+++ b/libs/remix-ui/debugger-ui/src/reducers/assembly-items.ts
@@ -34,7 +34,7 @@ const reducedOpcode = (opCodes, payload) => {
   const top = bottom + length
   return {
     index: opCodes.index - bottom,
-    nextIndexes: opCodes.nextIndexes.map(index => index - bottom),
+    nextIndexes: opCodes.nextIndexes ? opCodes.nextIndexes.map(index => index - bottom) : [],
     currentLineIndexes: (opCodes.absoluteCurrentLineIndexes && opCodes.absoluteCurrentLineIndexes.map(index => index - bottom)) || [],
     display: opCodes.code.slice(bottom, top),
     returnInstructionIndexes: payload.returnInstructionIndexes.map((index) => index.instructionIndex - bottom),


### PR DESCRIPTION
Fixes the issue of remix crashing when debugging a self destruct function. https://twitter.com/AmadiMichaels/status/1608466560116563969