### PR TITLE
Replace 'Lanaguage' (typo) in the settings with 'Language'

### DIFF
--- a/apps/remix-ide/src/app/tabs/locales/en/settings.json
+++ b/apps/remix-ide/src/app/tabs/locales/en/settings.json
@@ -20,7 +20,7 @@
   "settings.save": "Save",
   "settings.remove": "Remove",
   "settings.themes": "Themes",
-  "settings.locales": "Lanaguage",
+  "settings.locales": "Language",
   "settings.swarm": "Swarm Settings",
   "settings.ipfs": "IPFS Settings"
 }


### PR DESCRIPTION
<img width="406" alt="Screen Shot 2023-01-08 at 4 52 03 PM" src="https://user-images.githubusercontent.com/4665163/211225195-4340aced-0104-4f9f-9855-71e5d78d5474.png">

Fixes this typo