### PR TITLE
fix hide warnings

### DIFF
--- a/apps/solidity-compiler/src/app/compiler-api.ts
+++ b/apps/solidity-compiler/src/app/compiler-api.ts
@@ -283,10 +283,12 @@ export const CompilerApiMixin = (Base) => class extends Base {
       if (success) {
         // forwarding the event to the appManager infra
         this.emit('compilationFinished', source.target, source, 'soljson', data, input, version)
-        if (data.errors && data.errors.length > 0) {
+        const hideWarnings = await this.getAppParameter('hideWarnings')
+        if (data.errors && data.errors.length > 0 && !hideWarnings) {
+          const warningsCount = data.errors.length
           this.statusChanged({
-            key: data.errors.length,
-            title: `compilation finished successful with warning${data.errors.length > 1 ? 's' : ''}`,
+            key: warningsCount,
+            title: `compilation successful with ${warningsCount} warning${warningsCount > 1 ? 's' : ''}`,
             type: 'warning'
           })
         } else this.statusChanged({ key: 'succeed', title: 'compilation successful', type: 'success' })

--- a/libs/remix-ui/solidity-compiler/src/lib/solidity-compiler.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/solidity-compiler.tsx
@@ -43,7 +43,7 @@ export const SolidityCompiler = (props: SolidityCompilerProps) => {
       const hide = await api.getAppParameter('hideWarnings') as boolean || false
       setHideWarnings(hide)
     })()
-  }, [])
+  })
 
   useEffect(() => {
     if (badgeStatus[currentFile]) {

--- a/libs/remix-ui/solidity-compiler/src/lib/solidity-compiler.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/solidity-compiler.tsx
@@ -43,7 +43,7 @@ export const SolidityCompiler = (props: SolidityCompilerProps) => {
       const hide = await api.getAppParameter('hideWarnings') as boolean || false
       setHideWarnings(hide)
     })()
-  })
+  }, [compileErrors])
 
   useEffect(() => {
     if (badgeStatus[currentFile]) {


### PR DESCRIPTION
fixes #3278 

This also removes the warnings count badge from the Solidity Compiler plugin icon. Warnings will still be visible in editor.