### PR TITLE
do not throw if ast not present

### DIFF
--- a/libs/remix-debug/src/solidity-decoder/internalCallTree.ts
+++ b/libs/remix-debug/src/solidity-decoder/internalCallTree.ts
@@ -82,18 +82,22 @@ export class InternalCallTree {
       if (!compResult) {
         this.event.trigger('noCallTreeAvailable', [])
       } else {
-        buildTree(this, 0, scopeId, isCreation).then((result) => {
-          if (result.error) {
-            this.event.trigger('callTreeBuildFailed', [result.error])
-          } else {
-            createReducedTrace(this, traceManager.trace.length - 1)
-            console.log('call tree build lasts ', (Date.now() - time) / 1000)
-            this.event.trigger('callTreeReady', [this.scopes, this.scopeStarts])
-          }
-        }, (reason) => {
-          console.log('analyzing trace falls ' + reason)
-          this.event.trigger('callTreeNotReady', [reason])
-        })
+        try {
+          buildTree(this, 0, scopeId, isCreation).then((result) => {
+            if (result.error) {
+              this.event.trigger('callTreeBuildFailed', [result.error])
+            } else {
+              createReducedTrace(this, traceManager.trace.length - 1)
+              console.log('call tree build lasts ', (Date.now() - time) / 1000)
+              this.event.trigger('callTreeReady', [this.scopes, this.scopeStarts])
+            }
+          }, (reason) => {
+            console.log('analyzing trace falls ' + reason)
+            this.event.trigger('callTreeNotReady', [reason])
+          })
+        } catch (e) {
+          console.log(e)
+        }        
       }
     })
   }

--- a/libs/remix-debug/src/solidity-decoder/solidityProxy.ts
+++ b/libs/remix-debug/src/solidity-decoder/solidityProxy.ts
@@ -115,7 +115,7 @@ export class SolidityProxy {
       for (const source of generatedSources) {
         if (source.id === sourceLocation.file) return source.ast
       }
-    } else if (compilationResult.data.sources[file]) {
+    } else if (compilationResult.data.sources && compilationResult.data.sources[file]) {
       return compilationResult.data.sources[file].ast
     }
     return null


### PR DESCRIPTION
This ensure source location are resolved when debugging a yul contract.
This can be tested with https://docs.soliditylang.org/en/v0.8.17/yul.html#complete-erc20-example