### PR TITLE
re-add assets for remix libs

### DIFF
--- a/libs/remix-analyzer/project.json
+++ b/libs/remix-analyzer/project.json
@@ -15,7 +15,9 @@
           "outputPath": "dist/libs/remix-analyzer",
           "main": "libs/remix-analyzer/src/index.ts",
           "tsConfig": "libs/remix-analyzer/tsconfig.lib.json",
-          "assets": []
+          "assets": [
+            "libs/remix-analyzer/*.md"
+          ]
         }
       },
       "lint": {

--- a/libs/remix-astwalker/project.json
+++ b/libs/remix-astwalker/project.json
@@ -14,7 +14,9 @@
           "outputPath": "dist/libs/remix-astwalker",
           "main": "libs/remix-astwalker/src/index.ts",
           "tsConfig": "libs/remix-astwalker/tsconfig.lib.json",
-          "assets": []
+          "assets": [
+            "libs/remix-astwalker/*.md"
+          ]
         }
       },
       "lint": {

--- a/libs/remix-debug/project.json
+++ b/libs/remix-debug/project.json
@@ -15,7 +15,18 @@
           "outputPath": "dist/libs/remix-debug",
           "main": "libs/remix-debug/src/index.ts",
           "tsConfig": "libs/remix-debug/tsconfig.lib.json",
-          "assets": []
+          "assets": [
+            {
+              "glob": "rdb",
+              "input": "libs/remix-debug/bin/",
+              "output": "bin/"
+            },
+            {
+              "glob": "*.md",
+              "input": "libs/remix-debug/",
+              "output": "/"
+            }
+          ]
         }
       },
       "lint": {

--- a/libs/remix-lib/project.json
+++ b/libs/remix-lib/project.json
@@ -11,7 +11,9 @@
           "outputPath": "dist/libs/remix-lib",
           "main": "libs/remix-lib/src/index.ts",
           "tsConfig": "libs/remix-lib/tsconfig.lib.json",
-          "assets": []
+          "assets": [
+            "libs/remix-lib/*.md"
+          ]
         }
       },
       "lint": {

--- a/libs/remix-simulator/project.json
+++ b/libs/remix-simulator/project.json
@@ -14,7 +14,18 @@
           "outputPath": "dist/libs/remix-simulator",
           "main": "libs/remix-simulator/src/index.ts",
           "tsConfig": "libs/remix-simulator/tsconfig.lib.json",
-          "assets": []
+          "assets": [
+            {
+              "glob": "ethsim",
+              "input": "libs/remix-simulator/bin/",
+              "output": "bin/"
+            },
+            {
+              "glob": "*.md",
+              "input": "libs/remix-simulator/",
+              "output": "/"
+            }
+          ]
         }
       },
       "lint": {

--- a/libs/remix-solidity/project.json
+++ b/libs/remix-solidity/project.json
@@ -14,7 +14,9 @@
           "outputPath": "dist/libs/remix-solidity",
           "main": "libs/remix-solidity/src/index.ts",
           "tsConfig": "libs/remix-solidity/tsconfig.lib.json",
-          "assets": []
+          "assets": [
+            "libs/remix-solidity/*.md"
+          ]
         }
       },
       "lint": {

--- a/libs/remix-url-resolver/project.json
+++ b/libs/remix-url-resolver/project.json
@@ -13,7 +13,9 @@
           "outputPath": "dist/libs/remix-url-resolver",
           "main": "libs/remix-url-resolver/src/index.ts",
           "tsConfig": "libs/remix-url-resolver/tsconfig.lib.json",
-          "assets": []
+          "assets": [
+            "libs/remix-url-resolver/*.md"
+          ]
         }
       },
       "lint": {

--- a/libs/remix-ws-templates/project.json
+++ b/libs/remix-ws-templates/project.json
@@ -13,7 +13,26 @@
           "outputPath": "dist/libs/remix-ws-templates",
           "main": "libs/remix-ws-templates/src/index.ts",
           "tsConfig": "libs/remix-ws-templates/tsconfig.lib.json",
-          "assets": []
+          "assets": [
+            {
+              "glob": "templates/**/*",
+              "ignore": [
+                "templates/**/*/index.ts"
+              ],
+              "input": "libs/remix-ws-templates/src/",
+              "output": "src/"
+            },
+            {
+              "glob": "*.md",
+              "input": "libs/remix-ws-templates/",
+              "output": "/"
+            },
+            {
+              "glob": "templates/**/.prettierrc",
+              "input": "libs/remix-ws-templates/src/",
+              "output": "src/"
+            }
+          ]
         }
       },
       "lint": {


### PR DESCRIPTION
We need to add README.ms files in remix libs to show information on NPM page

https://www.npmjs.com/package/@remix-project/remix-url-resolver/v/0.0.43 misses it.