### PR TITLE
Add lerna publish dev command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,7 +52,8 @@ task('syncLibVersions', async function () {
         'remix-tests',
         'remix-url-resolver',
         'remix-ws-templates',
-        'remixd'
+        'remixd',
+        'ghaction-helper'
     ]
 
     libs.forEach(lib => {

--- a/lerna.json
+++ b/lerna.json
@@ -8,7 +8,8 @@
     "dist/libs/remix-solidity",
     "dist/libs/remix-tests",
     "dist/libs/remix-url-resolver",
-    "dist/libs/remix-ws-templates"
+    "dist/libs/remix-ws-templates",
+    "dist/libs/ghaction-helper"
   ],
   "version": "independent",
   "command": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "build:libs": "nx run-many --target=build --parallel=false --with-deps=true --projects=remix-analyzer,remix-astwalker,remix-debug,remix-lib,remix-simulator,remix-solidity,remix-tests,remix-url-resolver,remix-ws-templates,remixd,ghaction-helper",
     "test:libs": "nx run-many --target=test --projects=remix-analyzer,remix-astwalker,remix-debug,remix-lib,remix-simulator,remix-tests,remix-url-resolver,remixd",
     "publish:libs": "yarn run build:libs && lerna publish --skip-git && yarn run bumpVersion:libs",
+    "publishDev:libs": "yarn run build:libs && lerna publish --npm-tag alpha --skip-git && yarn run bumpVersion:libs",
     "build:e2e": "node apps/remix-ide-e2e/src/buildGroupTests.js && tsc -p apps/remix-ide-e2e/tsconfig.e2e.json",
     "babel": "babel",
     "watch:e2e": "nodemon",


### PR DESCRIPTION
This PR adds lerna publish command for pre-release npm tag `alpha` and bumps all libs to pre-release versions.