### PR TITLE
fix sending tx with the api

### DIFF
--- a/apps/remix-ide/src/blockchain/blockchain.js
+++ b/apps/remix-ide/src/blockchain/blockchain.js
@@ -13,7 +13,8 @@ import { execution, EventManager, helpers } from '@remix-project/remix-lib'
 import { etherScanLink } from './helper'
 import { logBuilder, cancelUpgradeMsg, cancelProxyMsg, addressToString } from "@remix-ui/helper"
 const { txFormat, txExecution, typeConversion, txListener: Txlistener, TxRunner, TxRunnerWeb3, txHelper } = execution
-const { txResultHelper: resultToRemixTx } = helpers
+const { txResultHelper } = helpers
+const { resultToRemixTx } = txResultHelper
 const packageJson = require('../../../../package.json')
 
 const _paq = window._paq = window._paq || []  //eslint-disable-line
@@ -575,8 +576,11 @@ export class Blockchain extends Plugin {
           async (error, result) => {
             if (error) return reject(error)
             try {
-              const execResult = await this.web3().eth.getExecutionResultFromSimulator(result.transactionHash)
-              resolve(resultToRemixTx(result, execResult))
+              if (this.executionContext.isVM()) {
+                const execResult = await this.web3().eth.getExecutionResultFromSimulator(result.transactionHash)
+                resolve(resultToRemixTx(result, execResult))
+              } else
+                resolve(resultToRemixTx(result))              
             } catch (e) {
               reject(e)
             }

--- a/libs/remix-lib/src/execution/txRunner.ts
+++ b/libs/remix-lib/src/execution/txRunner.ts
@@ -1,6 +1,16 @@
 'use strict'
 import { EventManager } from '../eventManager'
 
+export type Transaction = {
+  from: string,
+  to: string,
+  value: string,
+  data: string,
+  gasLimit: number,
+  useCall: boolean,
+  timestamp?: number
+}
+
 export class TxRunner {
   event
   runAsync
@@ -19,11 +29,11 @@ export class TxRunner {
     this.queusTxs = []
   }
 
-  rawRun (args, confirmationCb, gasEstimationForceSend, promptCb, cb) {
+  rawRun (args: Transaction, confirmationCb, gasEstimationForceSend, promptCb, cb) {
     run(this, args, args.timestamp || Date.now(), confirmationCb, gasEstimationForceSend, promptCb, cb)
   }
 
-  execute (args, confirmationCb, gasEstimationForceSend, promptCb, callback) {
+  execute (args: Transaction, confirmationCb, gasEstimationForceSend, promptCb, callback) {
     let data = args.data
     if (data.slice(0, 2) !== '0x') {
       data = '0x' + data
@@ -32,7 +42,7 @@ export class TxRunner {
   }
 }
 
-function run (self, tx, stamp, confirmationCb, gasEstimationForceSend = null, promptCb = null, callback = null) {
+function run (self, tx: Transaction, stamp, confirmationCb, gasEstimationForceSend = null, promptCb = null, callback = null) {
   if (!self.runAsync && Object.keys(self.pendingTxs).length) {
     return self.queusTxs.push({ tx, stamp, callback })
   }

--- a/libs/remix-lib/src/execution/txRunnerVM.ts
+++ b/libs/remix-lib/src/execution/txRunnerVM.ts
@@ -6,6 +6,7 @@ import { BN, bufferToHex, Address } from 'ethereumjs-util'
 import type { Account } from '@ethereumjs/util'
 import { EventManager } from '../eventManager'
 import { LogsManager } from './logsManager'
+import type { Transaction as InternalTransaction } from './txRunner'
 
 export type VMexecutionResult = {
   result: RunTxResult,
@@ -52,7 +53,7 @@ export class TxRunnerVM {
     this.nextNonceForCall = 0
   }
 
-  execute (args, confirmationCb, gasEstimationForceSend, promptCb, callback: VMExecutionCallBack) {
+  execute (args: InternalTransaction, confirmationCb, gasEstimationForceSend, promptCb, callback: VMExecutionCallBack) {
     let data = args.data
     if (data.slice(0, 2) !== '0x') {
       data = '0x' + data

--- a/libs/remix-lib/src/execution/txRunnerWeb3.ts
+++ b/libs/remix-lib/src/execution/txRunnerWeb3.ts
@@ -1,5 +1,6 @@
 'use strict'
 import { EventManager } from '../eventManager'
+import type { Transaction as InternalTransaction } from './txRunner'
 import Web3 from 'web3'
 
 export class TxRunnerWeb3 {
@@ -79,7 +80,7 @@ export class TxRunnerWeb3 {
     }
   }
 
-  execute (args, confirmationCb, gasEstimationForceSend, promptCb, callback) {
+  execute (args: InternalTransaction, confirmationCb, gasEstimationForceSend, promptCb, callback) {
     let data = args.data
     if (data.slice(0, 2) !== '0x') {
       data = '0x' + data


### PR DESCRIPTION
When using the plugin call `remix.call('udapp', 'sendTransaction', tx)` this will fail (throw an error) when a testnet is used rather than the VM.
