### PR TITLE
fix test

### DIFF
--- a/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
+++ b/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
@@ -34,19 +34,6 @@ module.exports = {
         timeout: 120000,
         suppressNotFoundErrors: true
       })
-      .click('[data-id="compilerContainerCompileBtn"]')
-      .isVisible({
-        selector: "//span[contains(.,'not found Untitled11')]",
-        locateStrategy: 'xpath',
-        timeout: 120000,
-        suppressNotFoundErrors: true
-      })
-      .click('[data-id="compilerContainerCompileBtn"]')
-      .waitForElementVisible({
-        selector: "//span[contains(.,'not found Untitled11')]",
-        locateStrategy: 'xpath',
-        timeout: 120000,
-      })
 
   },
 
@@ -135,11 +122,11 @@ const sources = [
     'Untitled.sol': { content: 'contract test1 {} contract test2 {}' }
   },
   {
-    'Untitled1.sol': { content: 'import "./Untitled2.sol"; contract test6 {}' },
+    'Untitled1.sol': { content: 'import "/Untitled2.sol"; contract test6 {}' },
     'Untitled2.sol': { content: 'contract test4 {} contract test5 {}' }
   },
   {
-    'Untitled3.sol': { content: 'import "./Untitled11.sol"; contract test6 {}' }
+    'Untitled3.sol': { content: 'import "/Untitled11.sol"; contract test6 {}' }
   },
   {
     'Untitled4.sol': { content: 'import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol"; contract test7 {}' }


### PR DESCRIPTION
if you 
import "test3.sol"; contract test6 {}
 OR
import "./test3.sol"; contract test6 {}
  or  it will call local fs, unpkg etc, 

 but when:

import "/test3.sol"; contract test6 {}
 
it won't, only local request is made

When testing for a failed import with ./ it will try unpkg and potentially last forever if unpkg is slow again, failing the test. This will fix this.

Also removed unneeded retries which were there before because unpkg didn't react properly ... 
