### PR TITLE
Fix Remixd Sync

### DIFF
--- a/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
+++ b/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
@@ -31,8 +31,7 @@ module.exports = {
       .isVisible({
         selector: "//span[contains(.,'not found Untitled11')]",
         locateStrategy: 'xpath',
-        timeout: 120000,
-        suppressNotFoundErrors: true
+        timeout: 120000
       })
 
   },

--- a/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
+++ b/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
@@ -31,7 +31,8 @@ module.exports = {
       .isVisible({
         selector: "//span[contains(.,'not found Untitled11')]",
         locateStrategy: 'xpath',
-        timeout: 120000
+        timeout: 120000,
+        suppressNotFoundErrors: true
       })
 
   },


### PR DESCRIPTION
#### Description
Fixes triggering external file changed modal pop up for changes made via remix-ide.
<img width="517" alt="Screenshot 2023-02-22 at 12 17 04" src="https://user-images.githubusercontent.com/23282059/220604982-839ddad4-8847-4784-a3df-6a4ef7a35066.png">

#### To Test
- Run remixd (`yarn run remixd`)
- Open a shared file in vscode and open the same shared file in remix-ide
- Make changes to the file on vscode. A modal pop-up should appear on remix-ide
- Make changes to the file on remix-ide. There shouldn't be a modal pop-up on remix-ide