### PR TITLE
Change Sourcify link in Debugger supported chains

### DIFF
--- a/libs/remix-ui/debugger-ui/src/lib/debugger-ui.tsx
+++ b/libs/remix-ui/debugger-ui/src/lib/debugger-ui.tsx
@@ -409,7 +409,7 @@ export const DebuggerUI = (props: DebuggerUIProps) => {
         <div>
           <i className="fas fa-info-triangle" aria-hidden="true"></i>
           <span>
-            <FormattedMessage id='debugger.introduction' />: <a href="https://sourcify.dev" target="__blank" >https://sourcify.dev</a> & <a href="https://etherscan.io/contractsVerified" target="__blank">https://etherscan.io/contractsVerified</a>
+            <FormattedMessage id='debugger.introduction' />: <a href="https://docs.sourcify.dev/docs/chains/" target="__blank" >Sourcify docs</a> & <a href="https://etherscan.io/contractsVerified" target="__blank">https://etherscan.io/contractsVerified</a>
           </span>
         </div> }
         { state.debugging && <StepManager stepManager={ stepManager } /> }


### PR DESCRIPTION
I suppose the Debugger can work with different chains and here the intention was to direct the user to chains supported by Sourcify i.e. Ethereum Mainnet, Optimism, Polygon etc. 

Therefore it would make more sense to send the user directly to the page where we list supported chains. 

I don't know what would be appropriate in Etherscan's case