### PR TITLE
fix: decode URL-encoded characters

### DIFF
--- a/libs/remix-ui/workspace/src/lib/actions/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/workspace.ts
@@ -176,7 +176,7 @@ export const loadWorkspacePreset = async (template: WorkspaceTemplate = 'remixDe
           const hashed = bufferToHex(hash.keccakFromString(params.code))
 
           path = 'contract-' + hashed.replace('0x', '').substring(0, 10) + (params.language && params.language.toLowerCase() === 'yul' ? '.yul' : '.sol')
-          content = atob(params.code)
+          content = atob(decodeURIComponent(params.code))
           await workspaceProvider.set(path, content)
         }
         if (params.url) {


### PR DESCRIPTION
## Description
This PR fixes the URL decoding issue with base64 encoded contract codes.

For example, `bWFwcGluZyhhZGRyZXNzID0+IHVpbnQyNTYpIHB1YmxpYyBmb287` is base64 encoded value of  `mapping(address => uint256) public foo;`. 

`+` is URL encoded to `%2B` causing the following error in the Remix IDE:

> DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.

The `decodeURIComponent` function is used to decode any URL-encoded characters in the params.code string before passing it to the atob function. This is necessary because `atob` expects a string that has already been encoded in base64 format and does not handle URL-encoded characters. By applying `decodeURIComponent` first, you ensure that the `atob` function will be able to properly decode the base64-encoded string.

NOTE:
The set of characters used in Base64 encoding includes the 26 uppercase letters of the alphabet (A-Z), the 26 lowercase letters (a-z), the 10 digits (0-9), and two additional characters: the plus sign (+) and the forward slash (/). Additionally, the equals sign (=) is used as a padding character to make the length of the output a multiple of 4.

