### PR TITLE
Workspacefix

### DIFF
--- a/apps/remix-ide-e2e/src/tests/workspace.test.ts
+++ b/apps/remix-ide-e2e/src/tests/workspace.test.ts
@@ -361,7 +361,7 @@ module.exports = {
         browser.assert.ok(content.indexOf(`export const deploy = async (contractName: string, args: Array<any>, from?: string, gas?: number): Promise<Options> => {`) !== -1,
           'Incorrect content')
         browser.assert.ok(content.indexOf(`gas: gas || 3600000`) !== -1,
-        'Incorrect gas cost')
+          'Incorrect gas cost')
       })
       .waitForElementVisible('*[data-id="treeViewLitreeViewItemscripts/ethers-lib.ts"]')
       .click('*[data-id="treeViewLitreeViewItemscripts/ethers-lib.ts"]')
@@ -373,7 +373,7 @@ module.exports = {
         browser.assert.ok(content.indexOf(`export const deploy = async (contractName: string, args: Array<any>, accountIndex?: number): Promise<ethers.Contract> => {`) !== -1,
           'Incorrect content')
       })
-      // No test file is added in upgradeable contract template
+    // No test file is added in upgradeable contract template
   },
 
   // WORKSPACE TEMPLATES E2E END
@@ -443,6 +443,61 @@ module.exports = {
       .click('*[data-id="workspacesSelect"]')
       .waitForElementNotPresent(`[data-id="dropdown-item-workspace_name_1"]`)
       .end()
+  },
+
+  'Should create workspace for test #group2': function (browser: NightwatchBrowser) {
+    browser
+      .clickLaunchIcon('filePanel')
+      .click('*[data-id="workspaceCreate"]')
+      .waitForElementVisible('*[data-id="modalDialogCustomPromptTextCreate"]')
+      .waitForElementVisible('[data-id="fileSystemModalDialogModalFooter-react"] > button')
+      .click('select[id="wstemplate"]')
+      .click('select[id="wstemplate"] option[value=ozerc1155]')
+      .execute(function () { document.querySelector('*[data-id="modalDialogCustomPromptTextCreate"]')['value'] = 'sometestworkspace' })
+      .waitForElementPresent('[data-id="fileSystemModalDialogModalFooter-react"] .modal-ok')
+      .execute(function () { (document.querySelector('[data-id="fileSystemModalDialogModalFooter-react"] .modal-ok') as HTMLElement).click() })
+      .waitForElementVisible('*[data-id="treeViewLitreeViewItemcontracts"]')
+      .waitForElementVisible('*[data-id="treeViewLitreeViewItemcontracts/MyToken.sol"]')
+      .waitForElementVisible('*[data-id="treeViewLitreeViewItem.prettierrc.json"]')
+      .pause(2000)
+  },
+
+  'Should change the current workspace in localstorage to a non existant value, reload the page and see the workspace created #group2': function (browser: NightwatchBrowser) {
+    browser
+      .execute(function () {
+        localStorage.setItem('currentWorkspace', 'non_existing_workspace')
+      })
+      .refreshPage()
+      .clickLaunchIcon('filePanel')
+      .currentWorkspaceIs('sometestworkspace')
+  },
+
+  'Should create workspace for next test #group2': function (browser: NightwatchBrowser) {
+    browser
+      .click('*[data-id="workspaceCreate"]')
+      .waitForElementVisible('*[data-id="modalDialogCustomPromptTextCreate"]')
+      .waitForElementVisible('[data-id="fileSystemModalDialogModalFooter-react"] > button')
+      // eslint-disable-next-line dot-notation
+      .click('select[id="wstemplate"]')
+      .click('select[id="wstemplate"] option[value=ozerc1155]')
+      .execute(function () { document.querySelector('*[data-id="modalDialogCustomPromptTextCreate"]')['value'] = 'workspace_db_test' })
+      .waitForElementPresent('[data-id="fileSystemModalDialogModalFooter-react"] .modal-ok')
+      .execute(function () { (document.querySelector('[data-id="fileSystemModalDialogModalFooter-react"] .modal-ok') as HTMLElement).click() })
+      .waitForElementVisible('*[data-id="treeViewLitreeViewItemcontracts"]')
+      .waitForElementVisible('*[data-id="treeViewLitreeViewItemcontracts/MyToken.sol"]')
+      .waitForElementVisible('*[data-id="treeViewLitreeViewItem.prettierrc.json"]')
+      .pause(2000)
+  },
+
+  'Should clear indexedDB and reload the page and see the default workspace #group2': function (browser: NightwatchBrowser) {
+    browser
+      .execute(function () {
+        indexedDB.deleteDatabase('RemixFileSystem')
+      })
+      .refreshPage()
+      .clickLaunchIcon('filePanel')
+      .currentWorkspaceIs('default_workspace')
+
   },
 
   tearDown: sauce

--- a/apps/remix-ide/src/app/panels/file-panel.js
+++ b/apps/remix-ide/src/app/panels/file-panel.js
@@ -95,6 +95,7 @@ module.exports = class Filepanel extends ViewPlugin {
   }
 
   getAvailableWorkspaceName (name) {
+    if(!this.workspaces) return null
     let index = 1
     let workspace = this.workspaces.find(workspace => workspace.name === name + ' - ' + index)
     while (workspace) {

--- a/apps/remix-ide/src/app/panels/file-panel.js
+++ b/apps/remix-ide/src/app/panels/file-panel.js
@@ -95,7 +95,7 @@ module.exports = class Filepanel extends ViewPlugin {
   }
 
   getAvailableWorkspaceName (name) {
-    if(!this.workspaces) return null
+    if(!this.workspaces) return name
     let index = 1
     let workspace = this.workspaces.find(workspace => workspace.name === name + ' - ' + index)
     while (workspace) {

--- a/libs/remix-ui/workspace/src/lib/actions/index.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/index.ts
@@ -124,6 +124,7 @@ export const initWorkspace = (filePanelPlugin) => async (reducerDispatch: React.
         plugin.setWorkspace({ name: name, isLocalhost: false })
         dispatch(setCurrentWorkspace({ name: name, isGitRepo: false }))
       }else{
+        _paq.push(['trackEvent', 'Storage', 'error', `Workspace in localstorage not found: ${localStorage.getItem("currentWorkspace")}`])
         await basicWorkspaceInit(workspaces, workspaceProvider)
       } 
     } else {

--- a/libs/remix-ui/workspace/src/lib/actions/index.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/index.ts
@@ -53,7 +53,6 @@ export const initWorkspace = (filePanelPlugin) => async (reducerDispatch: React.
     const params = queryParams.get() as UrlParametersType
     const workspaces = await getWorkspaces() || []
     dispatch(setWorkspaces(workspaces))
-    // console.log('workspaces: ', workspaces)
     if (params.gist) {
       await createWorkspaceTemplate('gist-sample', 'gist-template')
       plugin.setWorkspace({ name: 'gist-sample', isLocalhost: false })
@@ -124,6 +123,8 @@ export const initWorkspace = (filePanelPlugin) => async (reducerDispatch: React.
         workspaceProvider.setWorkspace(name)
         plugin.setWorkspace({ name: name, isLocalhost: false })
         dispatch(setCurrentWorkspace({ name: name, isGitRepo: false }))
+      }else{
+        await basicWorkspaceInit(workspaces, workspaceProvider)
       } 
     } else {
       await basicWorkspaceInit(workspaces, workspaceProvider)

--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -47,9 +47,15 @@ export function Workspace () {
 
   useEffect(() => {
     if (global.fs.mode === 'browser') {
-      if (global.fs.browser.currentWorkspace) setCurrentWorkspace(global.fs.browser.currentWorkspace)
-      else setCurrentWorkspace(NO_WORKSPACE)
-      global.dispatchFetchWorkspaceDirectory(ROOT_PATH)
+      if (global.fs.browser.currentWorkspace) {
+        setCurrentWorkspace(global.fs.browser.currentWorkspace)
+        global.dispatchFetchWorkspaceDirectory(ROOT_PATH)
+      }
+      else 
+      { 
+        setCurrentWorkspace(NO_WORKSPACE)
+      }
+      
     } else if (global.fs.mode === 'localhost') {
       global.dispatchFetchWorkspaceDirectory(ROOT_PATH)
       setCurrentWorkspace(LOCALHOST)


### PR DESCRIPTION
bug fixes for the situation when:
- localstorage holds a currentworkspace key but indexeddb is empty OR the currentworkspace is not in the DB
  getAvailableWorkspaceName prevent .find in null, would cause errors in this case preventing creating a workspace
- localstorage holds a currentworkspace key but indexeddb is empty OR the currentworkspace is not in the DB
  it should also create default workspaces in this scenario, which it didn't causing a blank list of workspaces
- it makes no sense to call global.dispatchFetchWorkspaceDirectory(ROOT_PATH) when the workspace is NO_WORKSPACE, that would cause errors ( workspace.ts:273 Error: ENOENT: /.workspaces/null )

some e2e to test this scenario
added tracking because this scenario probably means indexeddb was cleared

this is a blocker because it prevents you from creating workspaces when indexeddb is cleared!