### PR TITLE
Fix generating inherited functions

### DIFF
--- a/apps/doc-gen/src/app/docgen/common/helpers.ts
+++ b/apps/doc-gen/src/app/docgen/common/helpers.ts
@@ -20,3 +20,16 @@ export function formatVariable(v: VariableDeclaration): string {
 }
 
 export const eq = (a: unknown, b: unknown) => a === b;
+
+export const slug = (str) => {
+  if (str === undefined) {
+    throw new Error('Missing argument');
+  }
+  return str.replace(/\W/g, '-');
+}
+
+export const names = params => params.map(p => p.name).join(', ');
+
+export const typedParams = params => {
+  return params?.map(p => `${p.type}${p.indexed ? ' indexed' : ''}${p.name ? ' ' + p.name : ''}`).join(', ');
+};

--- a/apps/doc-gen/src/app/docgen/themes/markdown/contract.hbs
+++ b/apps/doc-gen/src/app/docgen/themes/markdown/contract.hbs
@@ -1,6 +1,6 @@
 {{>common}}
 
-{{h 2}} .Contract
+{{h 2}} Contract
 {{name}} : {{__item_context.file.absolutePath}}
 
 {{{natspec.dev}}}

--- a/apps/doc-gen/src/app/docgen/themes/markdown/contract.hbs
+++ b/apps/doc-gen/src/app/docgen/themes/markdown/contract.hbs
@@ -1,8 +1,46 @@
 {{>common}}
 
-{{#each items}}
+{{h 2}} .Contract
+{{name}} : {{__item_context.file.absolutePath}}
+
+{{{natspec.dev}}}
+
+{{#if modifiers}}
+{{s}}
+{{h 2}} Modifiers:
+{{#each modifiers}}
 {{#hsection}}
 {{>item}}
 {{/hsection}}
-
 {{/each}}
+{{/if}}
+
+{{#if hasfunctions}}
+{{s}}
+{{h 2}} Functions:
+{{#each inheritedfunctions}}
+{{#unless @first}}
+inherits {{contract.name}}:
+{{/unless}}
+{{#each functions}}
+{{#hsection}}
+{{>item}}
+{{/hsection}}
+{{/each}}
+{{/each}}
+{{/if}}
+
+{{#if hasevents}}
+{{s}}
+{{h 2}} Events:
+{{#each inheritance}}
+{{#unless @first}}
+inherits {{name}}:
+{{/unless}}
+{{#each events}}
+{{#hsection}}
+{{>item}}
+{{/hsection}}
+{{/each}}
+{{/each}}
+{{/if}}

--- a/apps/doc-gen/src/app/docgen/themes/markdown/helpers.ts
+++ b/apps/doc-gen/src/app/docgen/themes/markdown/helpers.ts
@@ -34,6 +34,19 @@ export function hsection(this: unknown, hsublevel: number | HelperOptions, opts?
 }
 
 /**
+ * Returns a Markdown heading marker. An optional number increases the heading level.
+ *
+ *    Input                  Output
+ *    {{h}} {{name}}         # Name
+ *    {{h 2}} {{name}}       ## Name
+ */
+export function s(opts: HelperOptions): string;
+export function s(hsublevel: number, opts: HelperOptions): string;
+export function s(hsublevel: number | HelperOptions, opts?: HelperOptions) {
+  return ' --- '
+};
+
+/**
  * Helper for dealing with the optional hsublevel argument.
  */
 function getHLevel(hsublevel: number | HelperOptions, opts?: HelperOptions) {


### PR DESCRIPTION
 - compile an openzeppelin ERC20 token
 - generate the documentation
 - the inherited function, their interface and documentation should be included in the md file.

remaining issues:
 - there is no visible separator between function and events (but if one copy the md to hack md, the separator is visible...)
 - params description aren't generated
 