### PR TITLE
Unwanted Event Listener removal for Docgen

### DIFF
--- a/apps/doc-gen/src/app/App.tsx
+++ b/apps/doc-gen/src/app/App.tsx
@@ -29,7 +29,7 @@ const App = () => {
 
   return (
     <div className="p-3">
-      <h5 className="h-5 mb-3">Compile a solidity contract in order to build documentation as markdown or right click on a contract and click on "Generate Documentation".</h5>
+      <h5 className="h-5 mb-3">Compile a Solidity contract and generate its documentation as Markdown. (Shortcut: right-click on a contract in the File Explorer and select "Generate Docs" from the context menu.).</h5>
       {fileName && <div className="border-bottom border-top px-2 py-3 justify-center align-items-center d-flex">
         <h6>File: {fileName}</h6>
       </div>}

--- a/apps/doc-gen/src/app/App.tsx
+++ b/apps/doc-gen/src/app/App.tsx
@@ -29,7 +29,7 @@ const App = () => {
 
   return (
     <div className="p-3">
-      <h5 className="h-5 mb-3">Compile a Solidity contract and generate its documentation as Markdown. (Shortcut: right-click on a contract in the File Explorer and select "Generate Docs" from the context menu.).</h5>
+      <h5 className="h-5 mb-3">Compile a Solidity contract and generate its documentation as Markdown. (Right-click on a contract in the File Explorer and select "Generate Docs" from the context menu.).</h5>
       {fileName && <div className="border-bottom border-top px-2 py-3 justify-center align-items-center d-flex">
         <h6>File: {fileName}</h6>
       </div>}

--- a/apps/doc-gen/src/app/docgen-client.ts
+++ b/apps/doc-gen/src/app/docgen-client.ts
@@ -89,6 +89,5 @@ export class DocGenClient extends PluginClient {
     this.eventEmitter.on('compilationFinished', async (build: Build, fileName: string) => {
       await this.docgen([build])
     })
-    this.eventEmitter.removeAllListeners('compilationFinished')
   }
 }


### PR DESCRIPTION
Fixes the blanket removal of the 'compilationFinished' event listener. Not removing this causes the documentation generation to never actually happen.