### PR TITLE
Etherscan plugin improvements

### DIFF
--- a/apps/etherscan/src/app/views/CaptureKeyView.tsx
+++ b/apps/etherscan/src/app/views/CaptureKeyView.tsx
@@ -23,8 +23,12 @@ export const CaptureKeyView: React.FC = () => {
             return errors
           }}
           onSubmit={(values) => {
-            setAPIKey(values.apiKey)
-            navigate((location.state as any).from)
+            const apiKey = values.apiKey
+            if (apiKey.length === 34) {
+              setAPIKey(values.apiKey)
+              clientInstance.call('notification' as any, 'toast', 'API key saved successfully!!!')
+              navigate((location.state as any).from)
+            } else clientInstance.call('notification' as any, 'toast', 'API key should be 34 characters long')
           }}
         >
           {({ errors, touched, handleSubmit }) => (

--- a/apps/etherscan/src/app/views/CaptureKeyView.tsx
+++ b/apps/etherscan/src/app/views/CaptureKeyView.tsx
@@ -11,8 +11,9 @@ export const CaptureKeyView: React.FC = () => {
   const navigate = useNavigate()
   return (
     <AppContext.Consumer>
-      {({ apiKey, setAPIKey }) => (
-        <Formik
+      {({ apiKey, clientInstance, setAPIKey }) => {
+        if (!apiKey && clientInstance && clientInstance.call) clientInstance.call('notification' as any, 'toast', 'Please add API key to continue')
+        return <Formik
           initialValues={{ apiKey }}
           validate={(values) => {
             const errors = {} as any
@@ -53,7 +54,8 @@ export const CaptureKeyView: React.FC = () => {
             </form>
           )}
         </Formik>
-      )}
+      }
+      }
     </AppContext.Consumer>
   )
 }

--- a/apps/etherscan/src/app/views/CaptureKeyView.tsx
+++ b/apps/etherscan/src/app/views/CaptureKeyView.tsx
@@ -43,7 +43,7 @@ export const CaptureKeyView: React.FC = () => {
                   }
                   type="password"
                   name="apiKey"
-                  placeholder="Example: GM1T20XY6JGSAPWKDCYZ7B2FJXKTJRFVGZ"
+                  placeholder="e.g. GM1T20XY6JGSAPWKDCYZ7B2FJXKTJRFVGZ"
                 />
                 <ErrorMessage
                   className="invalid-feedback"

--- a/apps/etherscan/src/app/views/CaptureKeyView.tsx
+++ b/apps/etherscan/src/app/views/CaptureKeyView.tsx
@@ -41,7 +41,7 @@ export const CaptureKeyView: React.FC = () => {
                       ? "form-control form-control-sm is-invalid"
                       : "form-control form-control-sm"
                   }
-                  type="text"
+                  type="password"
                   name="apiKey"
                   placeholder="Example: GM1T20XY6JGSAPWKDCYZ7B2FJXKTJRFVGZ"
                 />

--- a/apps/etherscan/src/app/views/CaptureKeyView.tsx
+++ b/apps/etherscan/src/app/views/CaptureKeyView.tsx
@@ -30,7 +30,7 @@ export const CaptureKeyView: React.FC = () => {
           {({ errors, touched, handleSubmit }) => (
             <form onSubmit={handleSubmit}>
               <div className="form-group" style={{ marginBottom: "0.5rem" }}>
-                <label htmlFor="apikey">Please Enter your API key</label>
+                <label htmlFor="apikey">Enter Etherscan API Key</label>
                 <Field
                   className={
                     errors.apiKey && touched.apiKey
@@ -49,7 +49,7 @@ export const CaptureKeyView: React.FC = () => {
               </div>
 
               <div>
-                <SubmitButton text="Save API key" dataId="save-api-key" />
+                <SubmitButton text="Save" dataId="save-api-key" />
               </div>
             </form>
           )}

--- a/apps/etherscan/src/app/views/HomeView.tsx
+++ b/apps/etherscan/src/app/views/HomeView.tsx
@@ -11,8 +11,9 @@ export const HomeView: React.FC = () => {
   // const [hasError, setHasError] = useState(false)
   return (
     <AppContext.Consumer>
-      {({ apiKey, clientInstance, setReceipts, receipts, contracts }) =>
-        !apiKey ? (
+      {({ apiKey, clientInstance, setReceipts, receipts, contracts }) => {
+        if (!apiKey && clientInstance && clientInstance.call) clientInstance.call('notification' as any, 'toast', 'Please add API key to continue')
+        return !apiKey ? (
           <Navigate
             to={{
               pathname: "/settings"
@@ -25,12 +26,12 @@ export const HomeView: React.FC = () => {
             apiKey={apiKey}
             onVerifiedContract={(receipt: Receipt) => {
               const newReceipts = [...receipts, receipt]
-
               setReceipts(newReceipts)
             }}
           />
         )
       }
+    }
     </AppContext.Consumer>
   )
 }

--- a/apps/etherscan/src/app/views/ReceiptsView.tsx
+++ b/apps/etherscan/src/app/views/ReceiptsView.tsx
@@ -38,8 +38,9 @@ export const ReceiptsView: React.FC = () => {
 
   return (
     <AppContext.Consumer>
-      {({ apiKey, clientInstance, receipts }) =>
-        !apiKey ? (
+      {({ apiKey, clientInstance, receipts }) => {
+        if (!apiKey && clientInstance && clientInstance.call) clientInstance.call('notification' as any, 'toast', 'Please add API key to continue')
+        return !apiKey ? (
           <Navigate
             to={{
               pathname: "/settings"
@@ -101,6 +102,7 @@ export const ReceiptsView: React.FC = () => {
             <ReceiptsTable receipts={receipts} />
           </div>
         )
+      }
       }
     </AppContext.Consumer>
   )

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -83,29 +83,6 @@ export const VerifyView: React.FC<Props> = ({
         {({ errors, touched, handleSubmit, isSubmitting }) => (
           <form onSubmit={handleSubmit}>
             <h6>Verify your smart contracts</h6>
-            <button
-              type="button"
-              style={{ padding: "0.25rem 0.4rem", marginRight: "0.5em", marginBottom: "0.5em"}}
-              className="btn btn-primary"
-              title="Generate the necessary helpers to start the verification from a TypeScript script"
-              onClick={async () => {
-                if (!await client.call('fileManager', 'exists' as any, 'scripts/etherscan/receiptStatus.ts')) {
-                  await client.call('fileManager', 'writeFile', 'scripts/etherscan/receiptStatus.ts', receiptGuidScript)
-                  await client.call('fileManager', 'open', 'scripts/etherscan/receiptStatus.ts')
-                } else {
-                  client.call('notification' as any, 'toast', 'file receiptStatus.ts already present..')
-                }
-                
-                if (!await client.call('fileManager', 'exists' as any, 'scripts/etherscan/verify.ts')) {
-                  await client.call('fileManager', 'writeFile', 'scripts/etherscan/verify.ts', verifyScript)
-                  await client.call('fileManager', 'open', 'scripts/etherscan/verify.ts')
-                } else {
-                  client.call('notification' as any, 'toast', 'file verify.ts already present..')
-                }
-              }}
-              >
-                Generate Etherscan helper scripts
-              </button>
             <div className="form-group">
               <label htmlFor="contractName">Contract</label>              
               <Field
@@ -172,6 +149,30 @@ export const VerifyView: React.FC<Props> = ({
             </div>
 
             <SubmitButton dataId="verify-contract" text="Verify Contract" isSubmitting={isSubmitting} />
+            <br/><br/>
+            <button
+              type="button"
+              style={{ padding: "0.25rem 0.4rem", marginRight: "0.5em", marginBottom: "0.5em"}}
+              className="btn btn-primary"
+              title="Generate the required TS scripts to verify a contract on Etherscan"
+              onClick={async () => {
+                if (!await client.call('fileManager', 'exists' as any, 'scripts/etherscan/receiptStatus.ts')) {
+                  await client.call('fileManager', 'writeFile', 'scripts/etherscan/receiptStatus.ts', receiptGuidScript)
+                  await client.call('fileManager', 'open', 'scripts/etherscan/receiptStatus.ts')
+                } else {
+                  client.call('notification' as any, 'toast', 'File receiptStatus.ts already exists')
+                }
+                
+                if (!await client.call('fileManager', 'exists' as any, 'scripts/etherscan/verify.ts')) {
+                  await client.call('fileManager', 'writeFile', 'scripts/etherscan/verify.ts', verifyScript)
+                  await client.call('fileManager', 'open', 'scripts/etherscan/verify.ts')
+                } else {
+                  client.call('notification' as any, 'toast', 'File verify.ts already exists')
+                }
+              }}
+              >
+                Generate Verification Scripts
+              </button>
           </form>
         )}
       </Formik>

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -84,11 +84,11 @@ export const VerifyView: React.FC<Props> = ({
           <form onSubmit={handleSubmit}>
             <h6>Verify your smart contracts</h6>
             <div className="form-group">
-              <label htmlFor="contractName">Contract</label>              
+              <label htmlFor="contractName">Contract Name</label>              
               <Field
                 as="select"
                 className={
-                  errors.contractName && touched.contractName
+                  errors.contractName && touched.contractName && contracts.length
                     ? "form-control form-control-sm is-invalid"
                     : "form-control form-control-sm"
                 }
@@ -120,7 +120,7 @@ export const VerifyView: React.FC<Props> = ({
                 }
                 type="text"
                 name="contractArguments"
-                placeholder="hex encoded"
+                placeholder="hex encoded args"
               />
               <ErrorMessage
                 className="invalid-feedback"
@@ -139,7 +139,7 @@ export const VerifyView: React.FC<Props> = ({
                 }
                 type="text"
                 name="contractAddress"
-                placeholder="i.e. 0x11b79afc03baf25c631dd70169bb6a3160b2706e"
+                placeholder="e.g; 0x11b79afc03baf25c631dd70169bb6a3160b2706e"
               />
               <ErrorMessage
                 className="invalid-feedback"

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -73,7 +73,8 @@ export const VerifyView: React.FC<Props> = ({
           if (!values.contractAddress) {
             errors.contractAddress = "Required"
           }
-          if (values.contractAddress.trim() === "") {
+          if (values.contractAddress.trim() === "" || !values.contractAddress.startsWith('0x') 
+              || values.contractAddress.length !== 42) {
             errors.contractAddress = "Please enter a valid contract address"
           }
           return errors

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useRef, useState } from "react"
 
 import {
   PluginClient,
@@ -30,6 +30,7 @@ export const VerifyView: React.FC<Props> = ({
   onVerifiedContract,
 }) => {
   const [results, setResults] = useState("")
+  const verificationResult = useRef({})
 
   const onVerifyContract = async (values: FormValues) => {
     const compilationResult = (await client.call(
@@ -43,7 +44,7 @@ export const VerifyView: React.FC<Props> = ({
 
     const contractArguments = values.contractArguments.replace("0x", "")    
 
-    const verificationResult = await verify(
+    verificationResult.current = await verify(
       apiKey,
       values.contractAddress,
       contractArguments,
@@ -53,8 +54,7 @@ export const VerifyView: React.FC<Props> = ({
       onVerifiedContract,
       setResults,
     )
-
-    setResults(verificationResult.message)
+    setResults(verificationResult.current['message'])
   }
 
   return (
@@ -139,7 +139,7 @@ export const VerifyView: React.FC<Props> = ({
                 }
                 type="text"
                 name="contractAddress"
-                placeholder="e.g; 0x11b79afc03baf25c631dd70169bb6a3160b2706e"
+                placeholder="e.g. 0x11b79afc03baf25c631dd70169bb6a3160b2706e"
               />
               <ErrorMessage
                 className="invalid-feedback"
@@ -178,7 +178,7 @@ export const VerifyView: React.FC<Props> = ({
       </Formik>
 
       <div data-id="verify-result"
-        style={{ marginTop: "2em", fontSize: "0.8em", textAlign: "center" }}
+        style={{ marginTop: "2em", fontSize: "0.8em", textAlign: "center", color: verificationResult.current['succeed'] ? "green" : "red" }}
         dangerouslySetInnerHTML={{ __html: results }}
       />
 


### PR DESCRIPTION
Related to #3597 

- Show toaster on in plugin nav icon click when no API key is provided
- Check API key length
- Show toaster on saving API key
- Show API key in dots not in plain text
- Script generation button placement updated
- Textual updates
- Error msg in red, success msg in green on verification page
- More validations for contract address