### PR TITLE
copy local soljson in webpack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
           at: .
       - run: unzip ./persist/dist.zip
       - run: yarn install --cwd ./apps/remix-ide-e2e --modules-folder ../../node_modules
-      - run: yarn run downloadsolc_assets_e2e && yarn run downloadsolc_assets_dist
+      - run: yarn run downloadsolc_assets_e2e
       - run: ls -la ./dist/apps/remix-ide/assets/js
       - run: yarn run selenium-install || yarn run selenium-install
       - run:
@@ -202,7 +202,7 @@ jobs:
       - run: unzip ./persist/dist.zip
       - run: unzip ./persist/plugin-<< parameters.plugin >>.zip
       - run: yarn install --cwd ./apps/remix-ide-e2e --modules-folder ../../node_modules
-      - run: yarn run downloadsolc_assets_e2e && yarn run downloadsolc_assets_dist
+      - run: yarn run downloadsolc_assets_e2e
       - run: yarn run selenium-install || yarn run selenium-install
       - run:
           name: Start Selenium
@@ -232,7 +232,6 @@ jobs:
           paths:
             - node_modules
       - run: yarn build:production
-      - run: yarn run downloadsolc_assets_dist
       - run: mkdir persist && zip -0 -r persist/predeploy.zip dist
       - persist_to_workspace:
           root: .

--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -15,7 +15,6 @@ jobs:
       - run: yarn install
       - run: ls
       - run: pwd
-      - run: yarn run downloadsolc_assets
       - run: yarn run build:production
       - run: echo "action_state=$('./apps/remix-ide/ci/publishIpfs' ${{ secrets.IPFS_PROJET_ID }} ${{ secrets.IPFS_PROJECT_SECRET }})" >> $GITHUB_ENV
       - uses: mshick/add-pr-comment@v1

--- a/apps/remix-ide/webpack.config.js
+++ b/apps/remix-ide/webpack.config.js
@@ -25,7 +25,7 @@ const loadLocalSolJson = async () => {
     info.builds = info.builds.slice(-1)
     const buildurl = `https://solc-bin.ethereum.org/wasm/${info.builds[0].path}`;
     console.log(`Copying... ${buildurl} to assets`)
-    const path = `./dist/apps/remix-ide/assets/js/soljson.js`;
+    const path = `./apps/remix-ide/src/assets/js/soljson.js`;
     axios({
       method: 'get',
       url: buildurl,

--- a/apps/remix-ide/webpack.config.js
+++ b/apps/remix-ide/webpack.config.js
@@ -6,6 +6,7 @@ const version = require('../../package.json').version
 const fs = require('fs')
 const TerserPlugin = require("terser-webpack-plugin")
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin")
+const axios = require('axios')
 
 const versionData = {
   version: version,
@@ -13,7 +14,32 @@ const versionData = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development'
 }
 
+const loadLocalSolJson = async () => {
+  let url = 'https://binaries.soliditylang.org/wasm/list.json'
+  axios({
+    url: url,
+    method: 'GET',
+  }).then((response) => {
+    let info = response.data;
+    info.builds = info.builds.filter(build => build.path.indexOf('nightly') === -1)
+    info.builds = info.builds.slice(-1)
+    const buildurl = `https://solc-bin.ethereum.org/wasm/${info.builds[0].path}`;
+    console.log(`Copying... ${buildurl} to assets`)
+    const path = `./dist/apps/remix-ide/assets/js/soljson.js`;
+    axios({
+      method: 'get',
+      url: buildurl,
+      responseType: 'stream'
+    }).then(function (response) {
+      response.data.pipe(fs.createWriteStream(path));
+    })
+  }
+  )
+}
+
 fs.writeFileSync('./apps/remix-ide/src/assets/version.json', JSON.stringify(versionData))
+
+loadLocalSolJson()
 
 const project = fs.readFileSync('./apps/remix-ide/project.json', 'utf8')
 
@@ -120,3 +146,5 @@ module.exports = composePlugins(withNx(), withReact(), (config) => {
 
   return config;
 });
+
+

--- a/package.json
+++ b/package.json
@@ -58,8 +58,6 @@
     "browsertest": "sleep 5 && yarn run nightwatch_local",
     "csslint": "csslint --ignore=order-alphabetical --errors='errors,duplicate-properties,empty-rules' --exclude-list='apps/remix-ide/src/assets/css/font-awesome.min.css' apps/remix-ide/src/assets/css/",
     "downloadsolc_assets_e2e": "node ./apps/remix-ide/ci/download_e2e_assets.js",
-    "downloadsolc_assets": "wget --no-check-certificate https://binaries.soliditylang.org/wasm/soljson-v0.8.18+commit.87f61d96.js -O ./apps/remix-ide/src/assets/js/soljson.js",
-    "downloadsolc_assets_dist": "wget --no-check-certificate https://binaries.soliditylang.org/wasm/soljson-v0.8.18+commit.87f61d96.js -O ./dist/apps/remix-ide/assets/js/soljson.js",
     "make-mock-compiler": "node apps/remix-ide/ci/makeMockCompiler.js",
     "minify": "uglifyjs --in-source-map inline --source-map-inline -c warnings=false",
     "build:production": "NODE_ENV=production nx build remix-ide --configuration=production --skip-nx-cache",


### PR DESCRIPTION
copies the soljson.js from the remote list to the assets in webpack, no need to run the static package.json scripts