### PR TITLE
Support for scientific notation for function arguments

### DIFF
--- a/libs/remix-lib/src/execution/txFormat.ts
+++ b/libs/remix-lib/src/execution/txFormat.ts
@@ -4,6 +4,7 @@ import { encodeParams as encodeParamsHelper, encodeFunctionId, makeFullTypeDefin
 import { eachOfSeries } from 'async'
 import { linkBytecode as linkBytecodeSolc } from 'solc/linker'
 import { isValidAddress, addHexPrefix } from '@ethereumjs/util'
+import { toBn } from "evm-bn"
 
 /**
   * build the transaction data
@@ -467,6 +468,12 @@ export function parseFunctionParams (params) {
       startIndex = isArrayOrStringStart(params, i + 1) ? -1 : i + 1
     }
   }
+  for(let i = 0; i < args.length; i++){
+    if (args[i].indexOf("e") > -1) {
+      args[i] = toBn(args[i]).toString();
+    }
+  }
+
   return args
 }
 

--- a/libs/remix-lib/src/execution/txFormat.ts
+++ b/libs/remix-lib/src/execution/txFormat.ts
@@ -468,7 +468,7 @@ export function parseFunctionParams (params) {
       startIndex = isArrayOrStringStart(params, i + 1) ? -1 : i + 1
     }
   }
-  for(let i = 0; i < args.length; i++){
+  for (let i = 0; i < args.length; i++){
     if (args[i].indexOf("e") > -1) {
       args[i] = toBn(args[i]).toString();
     }

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "eslint-config-prettier": "^8.5.0",
     "ethers": "^5.4.2",
     "ethjs-util": "^0.1.6",
+    "evm-bn": "^1.1.2",
     "express": "^4.18.2",
     "express-ws": "^5.0.2",
     "file-path-filter": "^3.0.2",


### PR DESCRIPTION
Converts scientific notation in function arguments to big numbers
- uses https://github.com/PaulRBerg/evm-bn for the conversion