### PR TITLE
Show textbox for constructor arguments conditionally

### DIFF
--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -82,7 +82,7 @@ export const VerifyView: React.FC<Props> = ({
         }}
         onSubmit={(values) => onVerifyContract(values)}
       >
-        {({ errors, touched, handleSubmit, isSubmitting }) => {
+        {({ errors, touched, handleSubmit, handleChange, isSubmitting }) => {
           if (client) {
             client.on("blockchain" as any, 'networkStatus', (result) => {
               setNetworkName(result.network.name)
@@ -113,6 +113,7 @@ export const VerifyView: React.FC<Props> = ({
                 }
                 name="contractName"
                 onChange={async (e) => {
+                    handleChange(e)
                     const {artefact} = await client.call("compilerArtefacts" as any, "getArtefactsByContractName", e.target.value)
                     if (artefact && artefact.abi && artefact.abi[0] && artefact.abi[0].type && artefact.abi[0].type === 'constructor') setShowConstructorArgs(true)
                     else setShowConstructorArgs(false)

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -30,7 +30,7 @@ export const VerifyView: React.FC<Props> = ({
   onVerifiedContract,
 }) => {
   const [results, setResults] = useState("")
-  const [networkName, setNetworkName] = useState("")
+  const [networkName, setNetworkName] = useState("Loading...")
   const [showConstructorArgs, setShowConstructorArgs] = useState(false)
   const verificationResult = useRef({})
 
@@ -86,7 +86,6 @@ export const VerifyView: React.FC<Props> = ({
           if (client) {
             client.on("blockchain" as any, 'networkStatus', (result) => {
               setNetworkName(result.network.name)
-              client.off("blockchain" as any, 'networkStatus')
             })
           }
           return (<form onSubmit={handleSubmit}>

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -134,7 +134,7 @@ export const VerifyView: React.FC<Props> = ({
               />
             </div>
 
-            <div className="form-group" style={{display: showConstructorArgs ? 'block': 'none'}}>
+            <div className={ showConstructorArgs ? 'form-group d-block': 'form-group d-none' } >
               <label htmlFor="contractArguments">Constructor Arguments</label>
               <Field
                 className={

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -83,7 +83,7 @@ export const VerifyView: React.FC<Props> = ({
         onSubmit={(values) => onVerifyContract(values)}
       >
         {({ errors, touched, handleSubmit, handleChange, isSubmitting }) => {
-          if (client) {
+          if (client && client.on) {
             client.on("blockchain" as any, 'networkStatus', (result) => {
               setNetworkName(result.network.name)
             })

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -98,7 +98,10 @@ export const VerifyView: React.FC<Props> = ({
                 name="network"
                 value={networkName}
                 disabled={true}
-              />  
+              /> 
+            </div>
+            
+            <div className="form-group">
               <label htmlFor="contractName">Contract Name</label>              
               <Field
                 as="select"
@@ -110,7 +113,7 @@ export const VerifyView: React.FC<Props> = ({
                 name="contractName"
                 onChange={async (e) => {
                     const {artefact} = await client.call("compilerArtefacts" as any, "getArtefactsByContractName", e.target.value)
-                    if(artefact && artefact.abi && artefact.abi[0].type && artefact.abi[0].type === 'constructor') setShowConstructorArgs(true)
+                    if (artefact && artefact.abi && artefact.abi[0].type && artefact.abi[0].type === 'constructor') setShowConstructorArgs(true)
                     else setShowConstructorArgs(false)
                 }}
               >

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -114,7 +114,7 @@ export const VerifyView: React.FC<Props> = ({
                 name="contractName"
                 onChange={async (e) => {
                     const {artefact} = await client.call("compilerArtefacts" as any, "getArtefactsByContractName", e.target.value)
-                    if (artefact && artefact.abi && artefact.abi[0].type && artefact.abi[0].type === 'constructor') setShowConstructorArgs(true)
+                    if (artefact && artefact.abi && artefact.abi[0] && artefact.abi[0].type && artefact.abi[0].type === 'constructor') setShowConstructorArgs(true)
                     else setShowConstructorArgs(false)
                 }}
               >

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -107,7 +107,7 @@ export const VerifyView: React.FC<Props> = ({
                 as="select"
                 className={
                   errors.contractName && touched.contractName && contracts.length
-                    ? "form-control  is-invalid"
+                    ? "form-control is-invalid"
                     : "form-control"
                 }
                 name="contractName"
@@ -139,7 +139,7 @@ export const VerifyView: React.FC<Props> = ({
               <Field
                 className={
                   errors.contractArguments && touched.contractArguments
-                    ? "form-control  is-invalid"
+                    ? "form-control is-invalid"
                     : "form-control"
                 }
                 type="text"
@@ -158,7 +158,7 @@ export const VerifyView: React.FC<Props> = ({
               <Field
                 className={
                   errors.contractAddress && touched.contractAddress
-                    ? "form-control  is-invalid"
+                    ? "form-control is-invalid"
                     : "form-control"
                 }
                 type="text"

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -31,6 +31,7 @@ export const VerifyView: React.FC<Props> = ({
 }) => {
   const [results, setResults] = useState("")
   const [networkName, setNetworkName] = useState("")
+  const [showConstructorArgs, setShowConstructorArgs] = useState(false)
   const verificationResult = useRef({})
 
   const onVerifyContract = async (values: FormValues) => {
@@ -107,6 +108,11 @@ export const VerifyView: React.FC<Props> = ({
                     : "form-control form-control-sm"
                 }
                 name="contractName"
+                onChange={async (e) => {
+                    const {artefact} = await client.call("compilerArtefacts" as any, "getArtefactsByContractName", e.target.value)
+                    if(artefact && artefact.abi && artefact.abi[0].type && artefact.abi[0].type === 'constructor') setShowConstructorArgs(true)
+                    else setShowConstructorArgs(false)
+                }}
               >
                 <option disabled={true} value="">
                   Select a contract
@@ -124,7 +130,7 @@ export const VerifyView: React.FC<Props> = ({
               />
             </div>
 
-            <div className="form-group">
+            <div className="form-group" style={{display: showConstructorArgs ? 'block': 'none'}}>
               <label htmlFor="contractArguments">Constructor Arguments</label>
               <Field
                 className={

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -94,7 +94,7 @@ export const VerifyView: React.FC<Props> = ({
             <div className="form-group">
               <label htmlFor="network">Selected Network</label> 
               <Field
-                className="form-control form-control-sm"
+                className="form-control"
                 type="text"
                 name="network"
                 value={networkName}
@@ -108,8 +108,8 @@ export const VerifyView: React.FC<Props> = ({
                 as="select"
                 className={
                   errors.contractName && touched.contractName && contracts.length
-                    ? "form-control form-control-sm is-invalid"
-                    : "form-control form-control-sm"
+                    ? "form-control  is-invalid"
+                    : "form-control"
                 }
                 name="contractName"
                 onChange={async (e) => {
@@ -140,8 +140,8 @@ export const VerifyView: React.FC<Props> = ({
               <Field
                 className={
                   errors.contractArguments && touched.contractArguments
-                    ? "form-control form-control-sm is-invalid"
-                    : "form-control form-control-sm"
+                    ? "form-control  is-invalid"
+                    : "form-control"
                 }
                 type="text"
                 name="contractArguments"
@@ -159,8 +159,8 @@ export const VerifyView: React.FC<Props> = ({
               <Field
                 className={
                   errors.contractAddress && touched.contractAddress
-                    ? "form-control form-control-sm is-invalid"
-                    : "form-control form-control-sm"
+                    ? "form-control  is-invalid"
+                    : "form-control"
                 }
                 type="text"
                 name="contractAddress"

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -86,6 +86,7 @@ export const VerifyView: React.FC<Props> = ({
           if (client) {
             client.on("blockchain" as any, 'networkStatus', (result) => {
               setNetworkName(result.network.name)
+              client.off("blockchain" as any, 'networkStatus')
             })
           }
           return (<form onSubmit={handleSubmit}>
@@ -100,7 +101,7 @@ export const VerifyView: React.FC<Props> = ({
                 disabled={true}
               /> 
             </div>
-            
+
             <div className="form-group">
               <label htmlFor="contractName">Contract Name</label>              
               <Field


### PR DESCRIPTION
part of https://github.com/ethereum/remix-project/issues/3597

Textbox for constructor arguments should only appear if a contract with constructor is selected for Etherscan verification plugin