### PR TITLE
CI: Upgrade from node.js 14 to node.js 16.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/node:14.17.6-browsers
+      - image: cimg/node:16.20.0-browsers
 
     resource_class:
       xlarge
@@ -43,7 +43,7 @@ jobs:
 
   build-plugin:
       docker:
-      - image: cimg/node:14.17.6-browsers
+      - image: cimg/node:16.20.0-browsers
       resource_class:
         xlarge
       working_directory: ~/remix-project
@@ -69,7 +69,7 @@ jobs:
 
   lint:
     docker:
-      - image: cimg/node:14.17.6-browsers
+      - image: cimg/node:16.20.0-browsers
     resource_class:
       xlarge
     working_directory: ~/remix-project
@@ -86,7 +86,7 @@ jobs:
           command: node ./apps/remix-ide/ci/lint-targets.js
   remix-libs:
     docker:
-      - image: cimg/node:14.17.6-browsers
+      - image: cimg/node:16.20.0-browsers
     resource_class:
       xlarge
     working_directory: ~/remix-project
@@ -111,7 +111,7 @@ jobs:
 
   remix-ide-browser:
     docker:
-      - image: cimg/node:14.17.6-browsers
+      - image: cimg/node:16.20.0-browsers
     resource_class:
       xlarge
     working_directory: ~/remix-project
@@ -175,7 +175,7 @@ jobs:
 
   remix-test-plugins:
     docker:
-      - image: cimg/node:14.17.6-browsers
+      - image: cimg/node:16.20.0-browsers
     resource_class:
       xlarge
     working_directory: ~/remix-project
@@ -216,7 +216,7 @@ jobs:
 
   predeploy:
     docker:
-      - image: cimg/node:14.17.6-browsers
+      - image: cimg/node:16.20.0-browsers
     resource_class:
       xlarge
     working_directory: ~/remix-project
@@ -240,7 +240,7 @@ jobs:
 
   deploy-build:
     docker:
-      - image: cimg/node:14.17.6-browsers
+      - image: cimg/node:16.20.0-browsers
 
     resource_class:
       xlarge


### PR DESCRIPTION
Node.js 14 will be unsupported and cease to receive security updates in 6 days. It is necessary to upgrade. https://github.com/nodejs/Release, https://endoflife.date/nodejs