### PR TITLE
Fix estimateGas when maxFee is fluctuating

### DIFF
--- a/libs/remix-lib/src/execution/txRunnerWeb3.ts
+++ b/libs/remix-lib/src/execution/txRunnerWeb3.ts
@@ -113,7 +113,7 @@ export class TxRunnerWeb3 {
           // the sending stack (web3.js / metamask need to have the type defined)
           // this is to avoid the following issue: https://github.com/MetaMask/metamask-extension/issues/11824
           txCopy.type = '0x2'
-          txCopy.maxFeePerGas = Math.ceil(network.lastBlock.baseFeePerGas + network.lastBlock.baseFeePerGas / 3)
+          txCopy.maxFeePerGas = Math.ceil(network.lastBlock.baseFeePerGas + network.lastBlock.baseFeePerGas / 2)
         } else {
           txCopy.type = '0x1'
           txCopy.gasPrice = network.lastBlock.baseFeePerGas

--- a/libs/remix-lib/src/execution/txRunnerWeb3.ts
+++ b/libs/remix-lib/src/execution/txRunnerWeb3.ts
@@ -113,7 +113,7 @@ export class TxRunnerWeb3 {
           // the sending stack (web3.js / metamask need to have the type defined)
           // this is to avoid the following issue: https://github.com/MetaMask/metamask-extension/issues/11824
           txCopy.type = '0x2'
-          txCopy.maxFeePerGas = network.lastBlock.baseFeePerGas + 10000 // + priority fee
+          txCopy.maxFeePerGas = Math.ceil(network.lastBlock.baseFeePerGas + network.lastBlock.baseFeePerGas / 3)
         } else {
           txCopy.type = '0x1'
           txCopy.gasPrice = network.lastBlock.baseFeePerGas


### PR DESCRIPTION
When the `baseFeePerGas` is fluctuating too much, the `maxFeePerGas` used in the transaction to do the gas estimation is lower than the last `baseFeePerGas` which cause the gas estimation to fail.