### PR TITLE
Fix Solidity Compiler Version Issue in Webpack

### DIFF
--- a/libs/remix-solidity/package.json
+++ b/libs/remix-solidity/package.json
@@ -26,7 +26,7 @@
     "ethjs-util": "^0.1.6",
     "minixhr": "^3.2.2",
     "semver": "^6.3.0",
-    "solc": "^0.7.4",
+    "solc": "^0.8.20",
     "string-similarity": "^4.0.4",
     "web3": "^1.5.1",
     "webworkify-webpack": "^2.1.5"


### PR DESCRIPTION
This pull request addresses a compatibility issue between the Solidity compiler and Webpack. Currently, the Solidity compiler version used in the project package remix-solidity is incompatible, resulting in compilation errors during the build process.

To resolve this issue, the pull request includes the following changes:

Update the Solidity compiler version to the compatible version.