### PR TITLE
Enable proxy contract verification in Etherscan plugin

### DIFF
--- a/apps/etherscan/src/app/RemixPlugin.tsx
+++ b/apps/etherscan/src/app/RemixPlugin.tsx
@@ -9,7 +9,7 @@ export class RemixClient extends PluginClient {
     }
   
     async verify (apiKey: string, contractAddress: string, contractArguments: string, contractName: string, compilationResultParam: any) {
-        const result = await verify(apiKey, contractAddress, contractArguments, contractName, compilationResultParam, null, this,
+        const result = await verify(apiKey, contractAddress, contractArguments, contractName, compilationResultParam, null, false, null, this,
             (value: EtherScanReturn) => {}, (value: string) => {})    
         return result
     }

--- a/apps/etherscan/src/app/app.tsx
+++ b/apps/etherscan/src/app/app.tsx
@@ -103,19 +103,21 @@ const App = () => {
         for (const item of receiptsNotVerified) {          
           await new Promise(r => setTimeout(r, 500)) // avoid api rate limit exceed.
           let status
-          if (item.isProxyContract)
+          if (item.isProxyContract) {
             status = await getProxyContractReceiptStatus(
               item.guid,
               apiKey,
               getEtherScanApi(networkId)
             )
-          else 
+            status.details = status.result
+            status.result = 'Successfully Updated'
+          } else 
             status = await getReceiptStatus(
               item.guid,
               apiKey,
               getEtherScanApi(networkId)
             )
-          if (status.result === "Pass - Verified" || status.result === "Already Verified") {
+          if (status.result === "Pass - Verified" || status.result === "Already Verified" || status.result === "Successfully Updated") {
             newReceipts = newReceipts.map((currentReceipt: Receipt) => {
               if (currentReceipt.guid === item.guid) {
                 return {

--- a/apps/etherscan/src/app/app.tsx
+++ b/apps/etherscan/src/app/app.tsx
@@ -109,21 +109,26 @@ const App = () => {
               apiKey,
               getEtherScanApi(networkId)
             )
-            status.details = status.result
-            status.result = 'Successfully Updated'
+            if (status.status === '1') {
+              status.message = status.result
+              status.result = 'Successfully Updated'
+            }
           } else 
             status = await getReceiptStatus(
               item.guid,
               apiKey,
               getEtherScanApi(networkId)
             )
-          if (status.result === "Pass - Verified" || status.result === "Already Verified" || status.result === "Successfully Updated") {
+          if (status.result === "Pass - Verified" || status.result === "Already Verified" || 
+              status.result === "Successfully Updated") {
             newReceipts = newReceipts.map((currentReceipt: Receipt) => {
               if (currentReceipt.guid === item.guid) {
-                return {
+                let res = {
                   ...currentReceipt,
                   status: status.result,
                 }
+                if (currentReceipt.isProxyContract) res.message = status.message
+                return res
               }
               return currentReceipt
             })                      

--- a/apps/etherscan/src/app/app.tsx
+++ b/apps/etherscan/src/app/app.tsx
@@ -13,7 +13,7 @@ import { DisplayRoutes } from "./routes"
 
 import { useLocalStorage } from "./hooks/useLocalStorage"
 
-import { getReceiptStatus, getEtherScanApi, getNetworkName } from "./utils"
+import { getReceiptStatus, getEtherScanApi, getNetworkName, getProxyContractReceiptStatus } from "./utils"
 import { Receipt, ThemeType } from "./types"
 
 import "./App.css"
@@ -102,12 +102,19 @@ const App = () => {
         let newReceipts = receipts
         for (const item of receiptsNotVerified) {          
           await new Promise(r => setTimeout(r, 500)) // avoid api rate limit exceed.
-          console.log('checking receipt', item.guid)
-          const status = await getReceiptStatus(
-            item.guid,
-            apiKey,
-            getEtherScanApi(networkId)
-          )
+          let status
+          if (item.isProxyContract)
+            status = await getProxyContractReceiptStatus(
+              item.guid,
+              apiKey,
+              getEtherScanApi(networkId)
+            )
+          else 
+            status = await getReceiptStatus(
+              item.guid,
+              apiKey,
+              getEtherScanApi(networkId)
+            )
           if (status.result === "Pass - Verified" || status.result === "Already Verified") {
             newReceipts = newReceipts.map((currentReceipt: Receipt) => {
               if (currentReceipt.guid === item.guid) {

--- a/apps/etherscan/src/app/types/Receipt.ts
+++ b/apps/etherscan/src/app/types/Receipt.ts
@@ -1,4 +1,4 @@
-export type ReceiptStatus = "Pending in queue" | "Pass - Verified" | "Already Verified" | "Max rate limit reached"
+export type ReceiptStatus = "Pending in queue" | "Pass - Verified" | "Already Verified" | "Max rate limit reached" | "Successfully Updated"
 
 export interface Receipt {
   guid: string

--- a/apps/etherscan/src/app/types/Receipt.ts
+++ b/apps/etherscan/src/app/types/Receipt.ts
@@ -3,4 +3,7 @@ export type ReceiptStatus = "Pending in queue" | "Pass - Verified" | "Already Ve
 export interface Receipt {
   guid: string
   status: ReceiptStatus
+  isProxyContract: boolean
+  message?: string
+  succeed?: boolean
 }

--- a/apps/etherscan/src/app/utils/utilities.ts
+++ b/apps/etherscan/src/app/utils/utilities.ts
@@ -48,3 +48,22 @@ export const getReceiptStatus = async (
     console.error(error)
   }
 }
+
+export const getProxyContractReceiptStatus = async (
+  receiptGuid: string,
+  apiKey: string,
+  etherscanApi: string
+): Promise<receiptStatus> => {
+  const params = `guid=${receiptGuid}&module=contract&action=checkproxyverification&apiKey=${apiKey}`
+  try {
+    const response = await axios.get(`${etherscanApi}?${params}`)
+    const { result, message, status } = response.data
+    return {
+      result,
+      message,
+      status,
+    }
+  } catch (error) {
+    console.error(error)
+  }
+}

--- a/apps/etherscan/src/app/utils/verify.ts
+++ b/apps/etherscan/src/app/utils/verify.ts
@@ -121,6 +121,10 @@ export const verify = async (
             apiKeyParam,
             etherscanApi
           )
+          if (receiptStatus.status === '1') {
+            receiptStatus.message = receiptStatus.result
+            receiptStatus.result = 'Successfully Updated'
+          }
         } else receiptStatus = await getReceiptStatus(
           result,
           apiKeyParam,

--- a/apps/etherscan/src/app/utils/verify.ts
+++ b/apps/etherscan/src/app/utils/verify.ts
@@ -21,7 +21,9 @@ export const verify = async (
     contractArgumentsParam: string,
     contractName: string,
     compilationResultParam: CompilerAbstract,
-    chainRef: number | string, 
+    chainRef: number | string,
+    isProxyContract: boolean,
+    expectedImplAddress: string, 
     client: PluginClient,
     onVerifiedContract: (value: EtherScanReturn) => void,
     setResults: (value: string) => void
@@ -85,11 +87,18 @@ export const verify = async (
         module: "contract", // Do not change
         action: "verifysourcecode", // Do not change
         codeformat: "solidity-standard-json-input",
-        contractaddress: contractAddress, // Contract Address starts with 0x...
         sourceCode: JSON.stringify(jsonInput),
         contractname: fileName + ':' + contractName,
         compilerversion: `v${contractMetadataParsed.compiler.version}`, // see http://etherscan.io/solcversions for list of support versions
         constructorArguements: contractArgumentsParam ? contractArgumentsParam.replace('0x', '') : '', // if applicable
+      }
+
+      if (isProxyContract) {
+        data.action = "verifyproxycontract"
+        data.expectedimplementation = expectedImplAddress
+        data.address = contractAddress
+      } else {
+        data.contractaddress = contractAddress
       }
 
       const body = new FormData()

--- a/apps/etherscan/src/app/utils/verify.ts
+++ b/apps/etherscan/src/app/utils/verify.ts
@@ -131,7 +131,8 @@ export const verify = async (
             guid: result,
             status: receiptStatus.result,
             message: `Verification process started correctly. Receipt GUID ${result}`,
-            succeed: true
+            succeed: true,
+            isProxyContract
         }
         onVerifiedContract(returnValue)
         return returnValue
@@ -143,7 +144,8 @@ export const verify = async (
         })
         const returnValue = {
             message: result,
-            succeed: false
+            succeed: false,
+            isProxyContract
         }
         resetAfter10Seconds(client, setResults)
         return returnValue

--- a/apps/etherscan/src/app/utils/verify.ts
+++ b/apps/etherscan/src/app/utils/verify.ts
@@ -1,4 +1,4 @@
-import { getNetworkName, getEtherScanApi, getReceiptStatus } from "../utils"
+import { getNetworkName, getEtherScanApi, getReceiptStatus, getProxyContractReceiptStatus } from "../utils"
 import { CompilationResult } from "@remixproject/plugin-api"
 import { CompilerAbstract } from '@remix-project/remix-solidity'
 import axios from 'axios'
@@ -114,7 +114,14 @@ export const verify = async (
 
       if (message === "OK" && status === "1") {
         resetAfter10Seconds(client, setResults)
-        const receiptStatus = await getReceiptStatus(
+        let receiptStatus
+        if (isProxyContract) {
+          receiptStatus = await getProxyContractReceiptStatus(
+            result,
+            apiKeyParam,
+            etherscanApi
+          )
+        } else receiptStatus = await getReceiptStatus(
           result,
           apiKeyParam,
           etherscanApi

--- a/apps/etherscan/src/app/views/ReceiptsView.tsx
+++ b/apps/etherscan/src/app/views/ReceiptsView.tsx
@@ -171,10 +171,21 @@ const ReceiptsTable: React.FC<{ receipts: Receipt[] }> = ({ receipts }) => {
             receipts.map((item: Receipt, index) => {
               return (
                 <tr key={item.guid}>
-                  <td className={item.status === 'Pass - Verified' 
+                  <td className={(item.status === 'Pass - Verified' || item.status === 'Successfully Updated')
                   ? 'text-success' : (item.status === 'Pending in queue' 
                   ? 'text-warning' : (item.status === 'Already Verified'
-                  ? 'text-info': 'text-secondary'))}>{item.status}</td>
+                  ? 'text-info': 'text-secondary'))}>
+                    {item.status}
+                    {item.status === 'Successfully Updated' && <CustomTooltip
+                      placement={'bottom'}
+                      tooltipClasses="text-wrap"
+                      tooltipId="info-recorder"
+                      tooltipText={item.message}
+                    >
+                      <i style={{ fontSize: 'small' }} className={'ml-1 fal fa-info-circle align-self-center'} aria-hidden="true"></i>
+                    </CustomTooltip>
+                    }
+                  </td>
                   <td>{item.guid}</td>
                 </tr>
               )

--- a/apps/etherscan/src/app/views/ReceiptsView.tsx
+++ b/apps/etherscan/src/app/views/ReceiptsView.tsx
@@ -179,7 +179,7 @@ const ReceiptsTable: React.FC<{ receipts: Receipt[] }> = ({ receipts }) => {
                     {item.status === 'Successfully Updated' && <CustomTooltip
                       placement={'bottom'}
                       tooltipClasses="text-wrap"
-                      tooltipId="info-recorder"
+                      tooltipId="etherscan-receipt-proxy-status"
                       tooltipText={item.message}
                     >
                       <i style={{ fontSize: 'small' }} className={'ml-1 fal fa-info-circle align-self-center'} aria-hidden="true"></i>

--- a/apps/etherscan/src/app/views/ReceiptsView.tsx
+++ b/apps/etherscan/src/app/views/ReceiptsView.tsx
@@ -7,6 +7,7 @@ import { AppContext } from "../AppContext"
 import { SubmitButton } from "../components"
 import { Navigate } from "react-router-dom"
 import { Button } from "react-bootstrap"
+import { CustomTooltip } from '@remix-ui/helper'
 
 interface FormValues {
   receiptGuid: string
@@ -133,8 +134,14 @@ export const ReceiptsView: React.FC = () => {
               dangerouslySetInnerHTML={{ __html: results.message ? results.message : '' }}
             />
 
-            <ReceiptsTable receipts={receipts} />
-            <Button title="Clear the list of receipt" onClick={() => { setReceipts([]) }} >Clear</Button>
+            <ReceiptsTable receipts={receipts} /><br/>
+            <CustomTooltip
+              tooltipText="Clear the list of receipts"
+              tooltipId='etherscan-clear-receipts'
+              placement='bottom'
+            >
+              <Button onClick={() => { setReceipts([]) }} >Clear</Button>
+            </CustomTooltip>
           </div>
         )
       }
@@ -145,7 +152,7 @@ export const ReceiptsView: React.FC = () => {
 
 const ReceiptsTable: React.FC<{ receipts: Receipt[] }> = ({ receipts }) => {
   return (
-    <div className="table-responsive" style={{ fontSize: "0.7em" }}>
+    <div className="table-responsive" style={{ fontSize: "0.8em" }}>
       <h6>Receipts</h6>
       <table className="table table-sm">
         <thead>

--- a/apps/etherscan/src/app/views/ReceiptsView.tsx
+++ b/apps/etherscan/src/app/views/ReceiptsView.tsx
@@ -33,13 +33,17 @@ export const ReceiptsView: React.FC = () => {
       }
       const etherscanApi = getEtherScanApi(networkId)
       let result
-      if (isProxyContractReceipt)
+      if (isProxyContractReceipt) {
         result = await getProxyContractReceiptStatus(
           values.receiptGuid,
           apiKey,
           etherscanApi
         )
-      else
+        if (result.status === '1') {
+          result.message = result.result
+          result.result = 'Successfully Updated'
+        }
+      } else
         result = await getReceiptStatus(
           values.receiptGuid,
           apiKey,

--- a/apps/etherscan/src/app/views/ReceiptsView.tsx
+++ b/apps/etherscan/src/app/views/ReceiptsView.tsx
@@ -25,7 +25,7 @@ export const ReceiptsView: React.FC = () => {
         setResults({
           succeed: false,
           message: "Cannot verify in the selected network"
-      })
+        })
         return
       }
       const etherscanApi = getEtherScanApi(networkId)

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -224,12 +224,18 @@ export const VerifyView: React.FC<Props> = ({
 
             <div className={ isProxyContract ? 'form-group d-block': 'form-group d-none' }>
               <label htmlFor="expectedImplAddress">Expected Implementation Address (Optional)</label>
-              <Field
-                className="form-control"
-                type="text"
-                name="expectedImplAddress"
-                placeholder="e.g. 0x11b79afc03baf25c631dd70169bb6a3160b2706e"
-              />
+              <CustomTooltip
+              tooltipText='Providing expected implementation address enforces a check to ensure the returned implementation contract address is same as address picked up by the verifier'
+              tooltipId='etherscan-impl-address'
+              placement='top'
+              >
+                <Field
+                  className="form-control"
+                  type="text"
+                  name="expectedImplAddress"
+                  placeholder="e.g. 0x11b79afc03baf25c631dd70169bb6a3160b2706e"
+                />
+              </CustomTooltip>
             </div>
 
             <SubmitButton dataId="verify-contract" text="Verify" 

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -33,6 +33,7 @@ export const VerifyView: React.FC<Props> = ({
   const [results, setResults] = useState("")
   const [networkName, setNetworkName] = useState("Loading...")
   const [showConstructorArgs, setShowConstructorArgs] = useState(false)
+  const [isProxyContract, setIsProxyContract] = useState(false)
   const [constructorInputs, setConstructorInputs] = useState([])
   const verificationResult = useRef({})
 
@@ -210,10 +211,25 @@ export const VerifyView: React.FC<Props> = ({
               <Field
                 className="custom-control-input"
                 type="checkbox"
-                name="ifProxy"
-                id="ifProxy"
+                name="isProxy"
+                id="isProxy"
+                onChange={async (e) => {
+                  handleChange(e)
+                  if (e.target.checked) setIsProxyContract(true)
+                  else setIsProxyContract(false)
+              }}
               />
-              <label className="form-check-label custom-control-label" htmlFor="ifProxy">It's a proxy contract</label>
+              <label className="form-check-label custom-control-label" htmlFor="isProxy">It's a proxy contract</label>
+            </div>
+
+            <div className={ isProxyContract ? 'form-group d-block': 'form-group d-none' }>
+              <label htmlFor="expectedImplAddress">Expected Implementation Address (Optional)</label>
+              <Field
+                className="form-control"
+                type="text"
+                name="expectedImplAddress"
+                placeholder="e.g. 0x11b79afc03baf25c631dd70169bb6a3160b2706e"
+              />
             </div>
 
             <SubmitButton dataId="verify-contract" text="Verify" 

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -22,6 +22,7 @@ interface Props {
 interface FormValues {
   contractName: string
   contractAddress: string
+  expectedImplAddress?: string
 }
 
 export const VerifyView: React.FC<Props> = ({
@@ -75,6 +76,8 @@ export const VerifyView: React.FC<Props> = ({
       values.contractName,
       compilationResult,
       null,
+      isProxyContract,
+      values.expectedImplAddress,
       client,
       onVerifiedContract,
       setResults,
@@ -87,7 +90,7 @@ export const VerifyView: React.FC<Props> = ({
       <Formik
         initialValues={{
           contractName: "",
-          contractAddress: "",
+          contractAddress: ""
         }}
         validate={(values) => {
           const errors = {} as any

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -226,7 +226,7 @@ export const VerifyView: React.FC<Props> = ({
             </div>
 
             <div className={ isProxyContract ? 'form-group d-block': 'form-group d-none' }>
-              <label htmlFor="expectedImplAddress">Expected Implementation Address (Optional)</label>
+              <label htmlFor="expectedImplAddress">Expected Implementation Address</label>
               <CustomTooltip
               tooltipText='Providing expected implementation address enforces a check to ensure the returned implementation contract address is same as address picked up by the verifier'
               tooltipId='etherscan-impl-address'

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -206,6 +206,16 @@ export const VerifyView: React.FC<Props> = ({
               />
             </div>
 
+            <div className="d-flex mb-2 custom-control custom-checkbox">
+              <Field
+                className="custom-control-input"
+                type="checkbox"
+                name="ifProxy"
+                id="ifProxy"
+              />
+              <label className="form-check-label custom-control-label" htmlFor="ifProxy">It's a proxy contract</label>
+            </div>
+
             <SubmitButton dataId="verify-contract" text="Verify" 
               isSubmitting={isSubmitting} 
               disable={ !contracts.length || 

--- a/apps/etherscan/src/app/views/VerifyView.tsx
+++ b/apps/etherscan/src/app/views/VerifyView.tsx
@@ -228,9 +228,17 @@ export const VerifyView: React.FC<Props> = ({
             <div className={ isProxyContract ? 'form-group d-block': 'form-group d-none' }>
               <label htmlFor="expectedImplAddress">Expected Implementation Address</label>
               <CustomTooltip
+                placement={'top'}
+                tooltipClasses="text-wrap"
+                tooltipId="etherscan-impl-address-info"
+                tooltipText="Make sure implementation contract is already verified before proxy contract"
+              >
+                <i style={{ fontSize: 'small' }} className={'ml-1 fal fa-info-circle align-self-center'} aria-hidden="true"></i>
+              </CustomTooltip>
+              <CustomTooltip
               tooltipText='Providing expected implementation address enforces a check to ensure the returned implementation contract address is same as address picked up by the verifier'
               tooltipId='etherscan-impl-address'
-              placement='top'
+              placement='bottom'
               >
                 <Field
                   className="form-control"


### PR DESCRIPTION
Related to https://github.com/ethereum/remix-project/issues/3597#issuecomment-1497446036

This PR integrates the proxy contract verification and proxy contract verification receipt status API from Etherscan. Here is the related documentation: https://docs.etherscan.io/api-endpoints/contracts#verify-proxy-contract

As verification on Etherscan integrate proxy contract with its implementation, the response we get is like this:
```
// OK
{"status":"1","message":"OK","result":"The proxy's (0xbc46363a7669f6e12353fa95bb067aead3675c29) implementation contract is found at 0xe45a5176bc0f2c1198e2451c4e4501d4ed9b65a6 and is successfully updated."}
```

So on receipts status page, we show status as `Successfully updated` along with an info icon, hovering on it shows complete message on tooltip.

![Screenshot 2023-06-07 at 12 13 47 PM](https://github.com/ethereum/remix-project/assets/30843294/6a95b4a2-ebfd-4071-b0b3-6fe729946f85)

                                    