### PR TITLE
fix build - removing web3 types

### DIFF
--- a/libs/remix-tests/package.json
+++ b/libs/remix-tests/package.json
@@ -73,7 +73,6 @@
     "@types/commander": "^2.12.2",
     "@types/mocha": "^5.2.5",
     "@types/node": "^18.16.1",
-    "@types/web3": "^1.0.18",
     "mocha": "^5.1.0",
     "ts-node": "^8.0.2",
     "typescript": "^3.3.1"


### PR DESCRIPTION
The issue is that this dependency has under the hood a dep on `web3: *`. the * override all the web3 version we are using