### PR TITLE
fix using EthersStateManager with calls

### DIFF
--- a/libs/remix-simulator/src/methods/transactions.ts
+++ b/libs/remix-simulator/src/methods/transactions.ts
@@ -82,6 +82,7 @@ export class Transactions {
     if (payload.params && payload.params.length > 0 && payload.params[0].from) {
       payload.params[0].from = toChecksumAddress(payload.params[0].from)
     }
+    this.vmContext.web3().flagRecordEvmSteps(true)
     processTx(this.txRunnerInstance, payload, false, (error, result: VMexecutionResult) => {
       if (!error && result) {
         this.vmContext.addBlock(result.block)
@@ -155,7 +156,7 @@ export class Transactions {
 
     payload.params[0].gas = 10000000 * 10
 
-    this.vmContext.web3().flagNextAsDoNotRecordEvmSteps()
+    this.vmContext.web3().flagRecordEvmSteps(false)
     processTx(this.txRunnerInstance, payload, true, (error, value: VMexecutionResult) => {      
       if (error) return cb(error)
       const result: RunTxResult = value.result
@@ -203,9 +204,9 @@ export class Transactions {
 
     const tag = payload.params[0].timestamp // e2e reference
 
+    this.vmContext.web3().flagRecordEvmSteps(true)
     processTx(this.txRunnerInstance, payload, true, (error, result: VMexecutionResult) => {
       if (!error && result) {
-        this.vmContext.addBlock(result.block)
         const hash = '0x' + result.tx.hash().toString('hex')
         this.vmContext.trackTx(hash, result.block, result.tx)
         const returnValue = `0x${result.result.execResult.returnValue.toString('hex') || '0'}`


### PR DESCRIPTION
When doing gasEstimation is the VM, we run the tx and then revert the state (because the execution is done only to get the used gas).
The issue is that the EthersStateManager doesn't handle well being  `revert`.
This PR:
 - copy the VM instead of checkpointing / reverting (this is the fix)
 - this leads  to some changes regarding how `flagRecordEVMSteps` is managed. `flagRecordEVMSteps` is used to not record any EVM execution step during the execution used to determine the used gas (we don't need it).
 

To reproduce the issue:
use:
```
contract Campaign {
    uint public cake;
    function contribute() public payable {
        cake++;
    }
}
```

run `contribute` one time, cake would show `2`, it should show `1`