### PR TITLE
fix class for tx details 'from'

### DIFF
--- a/libs/remix-ui/terminal/src/lib/components/Table.tsx
+++ b/libs/remix-ui/terminal/src/lib/components/Table.tsx
@@ -115,7 +115,7 @@ const showTable = (opts, showTableHash) => {
         ) : null}
         {opts.from ? (
           <tr className="remix_ui_terminal_tr">
-            <td className="td tableTitle" data-shared={`key_${opts.hash}`}>
+            <td className="remix_ui_terminal_td" data-shared={`key_${opts.hash}`}>
               from
             </td>
             <td


### PR DESCRIPTION
without this `from` label looks like this:

![Screenshot 2023-07-17 at 1 10 55 PM](https://github.com/ethereum/remix-project/assets/30843294/993a64cc-c9cc-4fc0-98fe-cab5283cd163)
