### PR TITLE
fixing fe layout for long lists

### DIFF
--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -680,7 +680,7 @@ export function Workspace () {
         handleContextMenu(e.pageX, e.pageY, ROOT_PATH, "workspace", 'workspace')
       }
       }>
-        <div className='d-flex flex-column w-100 remixui_fileexplorer' data-id="remixUIWorkspaceExplorer" onClick={resetFocus}>
+        <div className='d-flex flex-column w-100 pb-4 mb-2 remixui_fileexplorer' data-id="remixUIWorkspaceExplorer" onClick={resetFocus}>
           <div>
             <header>
               <div className="mx-2 my-2 d-flex flex-column">


### PR DESCRIPTION
When we connect to localhost with a large amount of files the scrollable area of FE is bigger than the screen. so we can't see the last files.