### PR TITLE
beta: fix importing solidity files

### DIFF
--- a/libs/remix-solidity/src/compiler/compiler.ts
+++ b/libs/remix-solidity/src/compiler/compiler.ts
@@ -367,20 +367,6 @@ export class Compiler {
 
   gatherImports(files: Source, importHints?: string[], cb?: gatherImportsCallbackInterface): void {
     importHints = importHints || []
-    // FIXME: This will only match imports if the file begins with one '.'
-    // It should tokenize by lines and check each.
-    const importRegex = /^\s*import\s*['"]([^'"]+)['"];/g
-    for (const fileName in files) {
-      let match: RegExpExecArray | null
-      while ((match = importRegex.exec(files[fileName].content))) {
-        let importFilePath = match[1]
-        if (importFilePath.startsWith('./')) {
-          const path: RegExpExecArray | null = /(.*\/).*/.exec(fileName)
-          importFilePath = path ? importFilePath.replace('./', path[1]) : importFilePath.slice(2)
-        }
-        if (!importHints.includes(importFilePath)) importHints.push(importFilePath)
-      }
-    }
     while (importHints.length > 0) {
       const m: string = importHints.pop() as string
       if (m && m in files) continue


### PR DESCRIPTION
This fix the case where one have a solidity file like:

````
import "../folder/someFile.sol" // add this file to the file system.

contract test {
}
````

The compiler will error with `cannot read/write outside of the workspace`.