### PR TITLE
Patch Prettier Linting Rules

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-  "*.{tsx,ts,js,jsx,mjs,cjs}": ["prettier --write","eslint --fix"]
+  "**/*.{tsx,ts,js,jsx,mjs,cjs}": ["prettier --write","eslint --fix"]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,12 +3,5 @@
   "useTabs": false,
   "printWidth": 180,
   "semi": false,
-  "singleQuote": true,
-  "quoteProps": "consistent",
-  "jsxSingleQuote": false,
-  "bracketSpacing": false,
-  "trailingComma": "none",
-  "jsxBracketSameLine": false,
-  "arrowParens": "always",
-  "singleAttributePerLine": false
+  "singleQuote": true
 }

--- a/libs/remix-ws-templates/src/script-templates/contract-deployer/create2-factory-deploy.ts
+++ b/libs/remix-ws-templates/src/script-templates/contract-deployer/create2-factory-deploy.ts
@@ -1,8 +1,7 @@
 import { ethers } from 'ethers'
 
 // https://etherscan.io/address/0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2#code
-export const CREATE2_DEPLOYER_ADDRESS =
-  "0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2";
+export const CREATE2_DEPLOYER_ADDRESS = '0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2'
 
 /**
  * Deploy the given contract using a factory
@@ -13,20 +12,19 @@ export const CREATE2_DEPLOYER_ADDRESS =
  * @param {number} accountIndex account index from the exposed account
  * @return {string} deployed contract address
  */
-export const deploy = async (contractName: string, args: Array<any>, salt: string, accountIndex?: number): Promise<string> => {    
-
+export const deploy = async (contractName: string, args: Array<any>, salt: string, accountIndex?: number): Promise<string> => {
   console.log(`deploying ${contractName}`)
-    
-  const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner(accountIndex)
 
-  const factory = new ethers.Contract(CREATE2_DEPLOYER_ADDRESS, contractDeployerAbi, signer);
+  const signer = new ethers.providers.Web3Provider(web3Provider).getSigner(accountIndex)
 
+  const factory = new ethers.Contract(CREATE2_DEPLOYER_ADDRESS, contractDeployerAbi, signer)
+  //@ts-ignore
   const contract = await ethers.getContractFactory(contractName)
   const initCode = contract.getDeployTransaction(args)
 
   const codeHash = ethers.utils.keccak256(initCode.data)
   const saltBytes = ethers.utils.id(salt)
-  const deployedAddress =  await factory.computeAddress(saltBytes, codeHash)
+  const deployedAddress = await factory.computeAddress(saltBytes, codeHash)
   try {
     const tx = await factory.deploy(0, saltBytes, initCode.data)
     await tx.wait()
@@ -40,219 +38,219 @@ export const deploy = async (contractName: string, args: Array<any>, salt: strin
 
 export const contractDeployerAbi = [
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
+        indexed: true,
+        internalType: 'address',
+        name: 'previousOwner',
+        type: 'address',
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
+        indexed: true,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
     ],
-    "name": "OwnershipTransferred",
-    "type": "event"
+    name: 'OwnershipTransferred',
+    type: 'event',
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
+        indexed: false,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
     ],
-    "name": "Paused",
-    "type": "event"
+    name: 'Paused',
+    type: 'event',
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
+        indexed: false,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
     ],
-    "name": "Unpaused",
-    "type": "event"
+    name: 'Unpaused',
+    type: 'event',
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "salt",
-        "type": "bytes32"
+        internalType: 'bytes32',
+        name: 'salt',
+        type: 'bytes32',
       },
       {
-        "internalType": "bytes32",
-        "name": "codeHash",
-        "type": "bytes32"
-      }
+        internalType: 'bytes32',
+        name: 'codeHash',
+        type: 'bytes32',
+      },
     ],
-    "name": "computeAddress",
-    "outputs": [
+    name: 'computeAddress',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "salt",
-        "type": "bytes32"
+        internalType: 'bytes32',
+        name: 'salt',
+        type: 'bytes32',
       },
       {
-        "internalType": "bytes32",
-        "name": "codeHash",
-        "type": "bytes32"
+        internalType: 'bytes32',
+        name: 'codeHash',
+        type: 'bytes32',
       },
       {
-        "internalType": "address",
-        "name": "deployer",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: 'deployer',
+        type: 'address',
+      },
     ],
-    "name": "computeAddressWithDeployer",
-    "outputs": [
+    name: 'computeAddressWithDeployer',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "pure",
-    "type": "function"
+    stateMutability: 'pure',
+    type: 'function',
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint256",
-        "name": "value",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
       },
       {
-        "internalType": "bytes32",
-        "name": "salt",
-        "type": "bytes32"
+        internalType: 'bytes32',
+        name: 'salt',
+        type: 'bytes32',
       },
       {
-        "internalType": "bytes",
-        "name": "code",
-        "type": "bytes"
-      }
+        internalType: 'bytes',
+        name: 'code',
+        type: 'bytes',
+      },
     ],
-    "name": "deploy",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'deploy',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "uint256",
-        "name": "value",
-        "type": "uint256"
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
       },
       {
-        "internalType": "bytes32",
-        "name": "salt",
-        "type": "bytes32"
-      }
+        internalType: 'bytes32',
+        name: 'salt',
+        type: 'bytes32',
+      },
     ],
-    "name": "deployERC1820Implementer",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'deployERC1820Implementer',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "address payable",
-        "name": "payoutAddress",
-        "type": "address"
-      }
+        internalType: 'address payable',
+        name: 'payoutAddress',
+        type: 'address',
+      },
     ],
-    "name": "killCreate2Deployer",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'killCreate2Deployer',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
+    inputs: [],
+    name: 'owner',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "pause",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    inputs: [],
+    name: 'pause',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "paused",
-    "outputs": [
+    inputs: [],
+    name: 'paused',
+    outputs: [
       {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "renounceOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
     ],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: 'transferOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "unpause",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    inputs: [],
+    name: 'unpause',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
   },
   {
-    "stateMutability": "payable",
-    "type": "receive"
-  }
+    stateMutability: 'payable',
+    type: 'receive',
+  },
 ]


### PR DESCRIPTION
This pr basically updates the glob pattern for lint-staged so it goes through every folder with a {.js,.ts,.tsx} file and runs prettier on it. I also simplified the prettier rules so it adds basically 5 rules: 

- enforce the use of spaces and not tabs
- tab should use 2 spaces
- code wrapping
- remove semi colons
- use single quotes

Most of the noise we have from linting previously had to do with bracket spacing, adding brackets and many other rules which I have stripped out in this pr. This should help us keep things clean.