### PR TITLE
quickfix to mark a contract abstract

### DIFF
--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -30,6 +30,8 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
           column: error.startColumn
         })
         const nodeAtPosition = await this.props.plugin.call('codeParser', 'definitionAtPosition', cursorPosition)
+        console.log('nodeAtPosition------>', nodeAtPosition)
+        console.log('error------>', error)
         // Check if a function is hovered
         if (nodeAtPosition && nodeAtPosition.nodeType === 'FunctionDefinition') {
           // Identify type of AST node
@@ -44,6 +46,15 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
               title: fix.title,
               range: fix.range,
               text: msg
+            })
+          }
+        } else if (nodeAtPosition && nodeAtPosition.nodeType === 'ContractDefinition') {
+          for (const fix of fixes) {
+            const lineContent: string = model.getValueInRange(error)
+            this.addQuickFix(actions, error, model.uri, {
+              title: fix.title,
+              range: error,
+              text: fix.message + lineContent
             })
           }
         } else {

--- a/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
+++ b/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
@@ -106,5 +106,13 @@ export default {
       message: 'pure ',
       nodeType: 'FunctionDefinition'
     }
+  ],
+  'should be marked as abstract': [
+    {
+      id: 6,
+      title: "Add 'abstract' to contract",
+      message: 'abstract ',
+      nodeType: 'ContractDefinition'
+    }
   ]
 }


### PR DESCRIPTION
This adds a quickfix for compiler error: `TypeError: Contract "ContractName" should be marked as abstract.`

related to #3927 

Use this code to reproduce that compiler error:
```
interface Store {
    function store(uint256 num) external;
}

contract Storage is Store {

    uint256 number;
}
```