### PR TITLE
Quickfix to add 'virtual' and 'override' to function

### DIFF
--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -29,6 +29,7 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
           lineNumber: error.startLineNumber,
           column: error.startColumn
         })
+        console.log('cursorPosition------>', cursorPosition)
         const nodeAtPosition = await this.props.plugin.call('codeParser', 'definitionAtPosition', cursorPosition)
         console.log('nodeAtPosition------>', nodeAtPosition)
         console.log('error------>', error)
@@ -69,6 +70,16 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
                 title: fix.title,
                 range: fix.range,
                 text: msg
+              })
+            } else if (fix.id === 7) {
+              // To update pragma same as selected compiler version
+              const startIndex = error.message.indexOf('is')
+              const endIndex = error.message.indexOf('+')
+              const msg = error.message.substring(startIndex + 2, endIndex)
+              this.addQuickFix(actions, error, model.uri, {
+                title: `update pragma to ${msg}`,
+                range: error,
+                text: 'pragma solidity' + msg + ';'
               })
             } else
               this.addQuickFix(actions, error, model.uri, {

--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -29,10 +29,7 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
           lineNumber: error.startLineNumber,
           column: error.startColumn
         })
-        console.log('cursorPosition------>', cursorPosition)
         const nodeAtPosition = await this.props.plugin.call('codeParser', 'definitionAtPosition', cursorPosition)
-        console.log('nodeAtPosition------>', nodeAtPosition)
-        console.log('error------>', error)
         // Check if a function is hovered
         if (nodeAtPosition && nodeAtPosition.nodeType === 'FunctionDefinition') {
           // Identify type of AST node
@@ -49,18 +46,9 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
               text: msg
             })
           }
-        } else if (nodeAtPosition && nodeAtPosition.nodeType === 'ContractDefinition') {
-          for (const fix of fixes) {
-            const lineContent: string = model.getValueInRange(error)
-            this.addQuickFix(actions, error, model.uri, {
-              title: fix.title,
-              range: error,
-              text: fix.message + lineContent
-            })
-          }
         } else {
           for (const fix of fixes) {
-            if (fix && nodeAtPosition && fix.nodeType !== nodeAtPosition.nodeType) continue
+            if (fix && nodeAtPosition && fix.nodeType && fix.nodeType !== nodeAtPosition.nodeType) continue
             if (fix.id === 2) {
               // To add specific pragma based on error
               const startIndex = error.message.indexOf('pragma')
@@ -70,6 +58,13 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
                 title: fix.title,
                 range: fix.range,
                 text: msg
+              })
+            } else if (fix.id === 6) {
+              const lineContent: string = model.getValueInRange(error)
+              this.addQuickFix(actions, error, model.uri, {
+                title: fix.title,
+                range: error,
+                text: fix.message + lineContent
               })
             } else if (fix.id === 7) {
               // To update pragma same as selected compiler version

--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -78,7 +78,7 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
                 const endIndex = error.message.indexOf('+')
                 const msg = error.message.substring(startIndex + 2, endIndex)
                 this.addQuickFix(actions, error, model.uri, {
-                  title: `update pragma to ${msg}`,
+                  title: `Update pragma to ${msg}`,
                   range: error,
                   text: 'pragma solidity' + msg + ';'
                 })

--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -49,39 +49,48 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
         } else {
           for (const fix of fixes) {
             if (fix && nodeAtPosition && fix.nodeType && fix.nodeType !== nodeAtPosition.nodeType) continue
-            if (fix.id === 2) {
-              // To add specific pragma based on error
-              const startIndex = error.message.indexOf('pragma')
-              const endIndex = error.message.indexOf(';')
-              const msg = error.message.substring(startIndex, endIndex + 1)
-              this.addQuickFix(actions, error, model.uri, {
-                title: fix.title,
-                range: fix.range,
-                text: msg
-              })
-            } else if (fix.id === 6) {
-              const lineContent: string = model.getValueInRange(error)
-              this.addQuickFix(actions, error, model.uri, {
-                title: fix.title,
-                range: error,
-                text: fix.message + lineContent
-              })
-            } else if (fix.id === 7) {
-              // To update pragma same as selected compiler version
-              const startIndex = error.message.indexOf('is')
-              const endIndex = error.message.indexOf('+')
-              const msg = error.message.substring(startIndex + 2, endIndex)
-              this.addQuickFix(actions, error, model.uri, {
-                title: `update pragma to ${msg}`,
-                range: error,
-                text: 'pragma solidity' + msg + ';'
-              })
-            } else
-              this.addQuickFix(actions, error, model.uri, {
-                title: fix.title,
-                range: fix.range || error,
-                text: fix.message
-              })
+            switch (fix.id) {
+              case 2: {
+                // To add specific pragma based on error
+                const startIndex = error.message.indexOf('pragma')
+                const endIndex = error.message.indexOf(';')
+                const msg = error.message.substring(startIndex, endIndex + 1)
+                this.addQuickFix(actions, error, model.uri, {
+                  title: fix.title,
+                  range: fix.range,
+                  text: msg
+                })
+                break
+              }
+              case 6: {
+                // To add `abstract` in the contract
+                const lineContent: string = model.getValueInRange(error)
+                this.addQuickFix(actions, error, model.uri, {
+                  title: fix.title,
+                  range: error,
+                  text: fix.message + lineContent
+                })
+                break
+              }
+              case 7: {
+                // To update pragma same as selected compiler version
+                const startIndex = error.message.indexOf('is')
+                const endIndex = error.message.indexOf('+')
+                const msg = error.message.substring(startIndex + 2, endIndex)
+                this.addQuickFix(actions, error, model.uri, {
+                  title: `update pragma to ${msg}`,
+                  range: error,
+                  text: 'pragma solidity' + msg + ';'
+                })
+                break
+              }
+              default:
+                this.addQuickFix(actions, error, model.uri, {
+                  title: fix.title,
+                  range: fix.range || error,
+                  text: fix.message
+                })
+            }
           }
         }
       }

--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -62,7 +62,7 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
               })
               break
             }
-            case 6: {
+            case 8: {
               // To add `abstract` in the contract
               const lineContent: string = model.getValueInRange(error)
               this.addQuickFix(actions, error, model.uri, {

--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -50,46 +50,46 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
           for (const fix of fixes) {
             if (fix && nodeAtPosition && fix.nodeType && fix.nodeType !== nodeAtPosition.nodeType) continue
             switch (fix.id) {
-              case 2: {
-                // To add specific pragma based on error
-                const startIndex = error.message.indexOf('pragma')
-                const endIndex = error.message.indexOf(';')
-                const msg = error.message.substring(startIndex, endIndex + 1)
-                this.addQuickFix(actions, error, model.uri, {
-                  title: fix.title,
-                  range: fix.range,
-                  text: msg
-                })
-                break
-              }
-              case 6: {
-                // To add `abstract` in the contract
-                const lineContent: string = model.getValueInRange(error)
-                this.addQuickFix(actions, error, model.uri, {
-                  title: fix.title,
-                  range: error,
-                  text: fix.message + lineContent
-                })
-                break
-              }
-              case 7: {
-                // To update pragma same as selected compiler version
-                const startIndex = error.message.indexOf('is')
-                const endIndex = error.message.indexOf('+')
-                const msg = error.message.substring(startIndex + 2, endIndex)
-                this.addQuickFix(actions, error, model.uri, {
-                  title: `Update pragma to ${msg}`,
-                  range: error,
-                  text: 'pragma solidity' + msg + ';'
-                })
-                break
-              }
-              default:
-                this.addQuickFix(actions, error, model.uri, {
-                  title: fix.title,
-                  range: fix.range || error,
-                  text: fix.message
-                })
+            case 2: {
+              // To add specific pragma based on error
+              const startIndex = error.message.indexOf('pragma')
+              const endIndex = error.message.indexOf(';')
+              const msg = error.message.substring(startIndex, endIndex + 1)
+              this.addQuickFix(actions, error, model.uri, {
+                title: fix.title,
+                range: fix.range,
+                text: msg
+              })
+              break
+            }
+            case 6: {
+              // To add `abstract` in the contract
+              const lineContent: string = model.getValueInRange(error)
+              this.addQuickFix(actions, error, model.uri, {
+                title: fix.title,
+                range: error,
+                text: fix.message + lineContent
+              })
+              break
+            }
+            case 7: {
+              // To update pragma same as selected compiler version
+              const startIndex = error.message.indexOf('is')
+              const endIndex = error.message.indexOf('+')
+              const msg = error.message.substring(startIndex + 2, endIndex)
+              this.addQuickFix(actions, error, model.uri, {
+                title: `Update pragma to ${msg}`,
+                range: error,
+                text: 'pragma solidity' + msg + ';'
+              })
+              break
+            }
+            default:
+              this.addQuickFix(actions, error, model.uri, {
+                title: fix.title,
+                range: fix.range || error,
+                text: fix.message
+              })
             }
           }
         }

--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -72,18 +72,6 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
               })
               break
             }
-            case 7: {
-              // To update pragma same as selected compiler version
-              const startIndex = error.message.indexOf('is')
-              const endIndex = error.message.indexOf('+')
-              const msg = error.message.substring(startIndex + 2, endIndex)
-              this.addQuickFix(actions, error, model.uri, {
-                title: `Update pragma to ${msg}`,
-                range: error,
-                text: 'pragma solidity' + msg + ';'
-              })
-              break
-            }
             default:
               this.addQuickFix(actions, error, model.uri, {
                 title: fix.title,

--- a/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
+++ b/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
@@ -113,5 +113,11 @@ export default {
       message: 'abstract ',
       nodeType: 'ContractDefinition'
     }
+  ],
+  'ParserError: Source file requires different compiler version (current compiler' : [
+    {
+      id: 7,
+      nodeType: 'PragmaDirective'
+    }
   ]
 }

--- a/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
+++ b/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
@@ -109,16 +109,16 @@ export default {
   'TypeError: Trying to override non-virtual function. Did you forget to add "virtual"':[
     {
       id: 6,
-      title: "Add 'virtual' to function",
-      message: 'virtual ',
+      title: "Add 'virtual' specifier",
+      message: 'virtual',
       nodeType: 'FunctionDefinition'
     }
   ],
   'TypeError: Overriding function is missing "override" specifier':[
     {
       id: 7,
-      title: "Add 'override' to function",
-      message: 'override ',
+      title: "Add 'override' specifier",
+      message: 'override',
       nodeType: 'FunctionDefinition'
     }
   ],

--- a/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
+++ b/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
@@ -106,9 +106,25 @@ export default {
       nodeType: 'FunctionDefinition'
     }
   ],
-  'should be marked as abstract': [
+  'TypeError: Trying to override non-virtual function. Did you forget to add "virtual"':[
     {
       id: 6,
+      title: "Add 'virtual' to function",
+      message: 'virtual ',
+      nodeType: 'FunctionDefinition'
+    }
+  ],
+  'TypeError: Overriding function is missing "override" specifier':[
+    {
+      id: 7,
+      title: "Add 'override' to function",
+      message: 'override ',
+      nodeType: 'FunctionDefinition'
+    }
+  ],
+  'should be marked as abstract': [
+    {
+      id: 8,
       title: "Add 'abstract' to contract",
       message: 'abstract ',
       nodeType: 'ContractDefinition'

--- a/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
+++ b/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
@@ -113,11 +113,5 @@ export default {
       message: 'abstract ',
       nodeType: 'ContractDefinition'
     }
-  ],
-  'ParserError: Source file requires different compiler version (current compiler' : [
-    {
-      id: 7,
-      nodeType: 'PragmaDirective'
-    }
   ]
 }


### PR DESCRIPTION
related to #3927 

It shows quickfix for compilation errors like:
`TypeError: Trying to override non-virtual function. Did you forget to add "virtual"` 
&
`TypeError: Overriding function is missing "override" specifier`

code to reproduce these errors:
```
pragma solidity 0.8.18;

contract Store {
    function store(uint256 num) public {
        num = num + 1;
    }
}

contract Storage is Store {
    function store(uint256 num) public {
        num = num + 2;
    }
}
```

This PR also involves some code refactoring