### PR TITLE
Quickfixes to add data location to constructor params, function params and variables

### DIFF
--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -75,7 +75,11 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
               break
             }
             case 9.1:
-            case 9.2: {
+            case 9.2:
+            case 10.1:
+            case 10.2: 
+            case 10.3: {
+              console.log('sssss')
               const lineContent: string = model.getValueInRange(error)
               const words = lineContent.split(' ')
               this.addQuickFix(actions, error, model.uri, {

--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -24,12 +24,14 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
       const errStrings: string[] = Object.keys(fixesList)
       const errStr: string = errStrings.find((es) => error.message.includes(es))
       if (errStr) {
+        console.log('error=========>', error)
         fixes = fixesList[errStr]
         const cursorPosition: number = this.props.editorAPI.getHoverPosition({
           lineNumber: error.startLineNumber,
           column: error.startColumn
         })
         const nodeAtPosition = await this.props.plugin.call('codeParser', 'definitionAtPosition', cursorPosition)
+        console.log('nodeAtPosition=========>', nodeAtPosition)
         // Check if a function is hovered
         if (nodeAtPosition && nodeAtPosition.nodeType === 'FunctionDefinition') {
           // Identify type of AST node
@@ -69,6 +71,17 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
                 title: fix.title,
                 range: error,
                 text: fix.message + lineContent
+              })
+              break
+            }
+            case 9.1:
+            case 9.2: {
+              const lineContent: string = model.getValueInRange(error)
+              const words = lineContent.split(' ')
+              this.addQuickFix(actions, error, model.uri, {
+                title: fix.title,
+                range: error,
+                text: words[0] + fix.message + words[1]
               })
               break
             }

--- a/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/codeActionProvider.ts
@@ -24,14 +24,12 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
       const errStrings: string[] = Object.keys(fixesList)
       const errStr: string = errStrings.find((es) => error.message.includes(es))
       if (errStr) {
-        console.log('error=========>', error)
         fixes = fixesList[errStr]
         const cursorPosition: number = this.props.editorAPI.getHoverPosition({
           lineNumber: error.startLineNumber,
           column: error.startColumn
         })
         const nodeAtPosition = await this.props.plugin.call('codeParser', 'definitionAtPosition', cursorPosition)
-        console.log('nodeAtPosition=========>', nodeAtPosition)
         // Check if a function is hovered
         if (nodeAtPosition && nodeAtPosition.nodeType === 'FunctionDefinition') {
           // Identify type of AST node
@@ -78,8 +76,10 @@ export class RemixCodeActionProvider implements monaco.languages.CodeActionProvi
             case 9.2:
             case 10.1:
             case 10.2: 
-            case 10.3: {
-              console.log('sssss')
+            case 10.3:
+            case 11.1:
+            case 11.2: {
+              // To add data location in constructor params, function params and variables
               const lineContent: string = model.getValueInRange(error)
               const words = lineContent.split(' ')
               this.addQuickFix(actions, error, model.uri, {

--- a/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
+++ b/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
@@ -129,5 +129,19 @@ export default {
       message: 'abstract ',
       nodeType: 'ContractDefinition'
     }
+  ],
+  'TypeError: Data location must be "storage" or "memory" for constructor parameter, but none was given.': [
+    {
+      id: 9.1,
+      title: "Add 'storage' to param",
+      message: ' storage ',
+      nodeType: 'ElementaryTypeName'
+    },
+    {
+      id: 9.2,
+      title: "Add 'memory' to param",
+      message: ' memory ',
+      nodeType: 'ElementaryTypeName'
+    }
   ]
 }

--- a/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
+++ b/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
@@ -134,14 +134,29 @@ export default {
     {
       id: 9.1,
       title: "Add 'storage' to param",
-      message: ' storage ',
-      nodeType: 'ElementaryTypeName'
+      message: ' storage '
     },
     {
       id: 9.2,
       title: "Add 'memory' to param",
-      message: ' memory ',
-      nodeType: 'ElementaryTypeName'
+      message: ' memory '
+    }
+  ],
+  'TypeError: Data location must be "storage", "memory" or "calldata" for variable, but none was given.': [
+    {
+      id: 10.1,
+      title: "Add 'storage' to param",
+      message: ' storage '
+    },
+    {
+      id: 10.2,
+      title: "Add 'memory' to param",
+      message: ' memory '
+    },
+    {
+      id: 10.3,
+      title: "Add 'calldata' to param",
+      message: ' calldata '
     }
   ]
 }

--- a/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
+++ b/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
@@ -145,16 +145,28 @@ export default {
   'TypeError: Data location must be "storage", "memory" or "calldata" for variable, but none was given.': [
     {
       id: 10.1,
-      title: "Add 'storage' to param",
+      title: "Add 'storage' to variable",
       message: ' storage '
     },
     {
       id: 10.2,
-      title: "Add 'memory' to param",
+      title: "Add 'memory' to variable",
       message: ' memory '
     },
     {
       id: 10.3,
+      title: "Add 'calldata' to variable",
+      message: ' calldata '
+    }
+  ],
+  'TypeError: Data location must be "memory" or "calldata" for parameter in function, but none was given.': [
+    {
+      id: 11.1,
+      title: "Add 'memory' to param",
+      message: ' memory '
+    },
+    {
+      id: 11.2,
       title: "Add 'calldata' to param",
       message: ' calldata '
     }


### PR DESCRIPTION
This shows quick fix for these compiler errors:

`TypeError: Data location must be "storage" or "memory" for constructor parameter, but none was given.`
`TypeError: Data location must be "storage", "memory" or "calldata" for variable, but none was given.`
`TypeError: Data location must be "memory" or "calldata" for parameter in function, but none was given.`

Related to #3927 

Use this code to reproduce above compiler errors:
```
contract Storage {
    string s;

    constructor(string str) {
        s = str;
    }

    function store(string str) public {
        string ss = str;
        s = ss; 
    }
}
```