### PR TITLE
quickfixes for fallback and receive methods

### DIFF
--- a/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
+++ b/libs/remix-ui/editor/src/lib/providers/quickfixes.ts
@@ -170,5 +170,21 @@ export default {
       title: "Add 'calldata' to param",
       message: ' calldata '
     }
+  ],
+  'SyntaxError: No visibility specified. Did you intend to add "external': [
+    {
+      id: 12,
+      title: "Add visibility 'external'",
+      message: 'external ',
+      nodeType: 'FunctionDefinition'
+    }
+  ],
+  'DeclarationError: Receive ether function must be payable, but is "nonpayable".': [
+    {
+      id: 13,
+      title: "Make function 'payable'",
+      message: 'payable ',
+      nodeType: 'FunctionDefinition'
+    }
   ]
 }


### PR DESCRIPTION
Handles compiler errors like:
`SyntaxError: No visibility specified. Did you intend to add "external'`
`DeclarationError: Receive ether function must be payable, but is "nonpayable".`

Code to reproduce:
```
contract Storage {
    fallback() {}

    receive() {}
}
```

Related to #3927 