### PR TITLE
Chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     working_directory: ~/remix-project
     steps:
       - checkout
-      - run: wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+      - install-chrome-custom-linux
       - restore_cache:
           keys:
             - v1-deps-{{ checksum "yarn.lock" }}
@@ -398,3 +398,30 @@ commands:
 
             echo Done
             chromedriver -v
+  install-chrome-custom-linux:
+    description: Custom script to install chrome with better version support for linux
+    steps:
+      - run:
+          name: install-custom-linux
+          command: |
+            CHROME_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json' | jq '.channels.Stable.downloads.chrome[] | select(.platform == "linux64") | .url' | tr -d '"')
+            echo $CHROME_URL
+            ZIPFILEPATH="/tmp/chrome.zip"
+            echo "Downloading from $CHROME_URL"
+            curl -f --silent $CHROME_URL > "$ZIPFILEPATH"
+
+            BINFILEPATH="$HOME/bin/chrome-linux"
+            echo "Extracting to $BINFILEPATH"
+            unzip -p "$ZIPFILEPATH" chrome-linux64/chrome > "$BINFILEPATH"
+
+            echo Setting execute flag
+            chmod +x "$BINFILEPATH"
+
+            echo Updating symlink
+            ln -nfs "$BINFILEPATH" ~/bin/chrome
+
+            echo Removing ZIP file
+            rm "$ZIPFILEPATH"
+
+            echo Done
+            chrome -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,14 @@ jobs:
     resource_class:
       xlarge
     working_directory: ~/remix-project
-    steps:
+  steps:
+      - browser-tools/install-browser-tools:
+          install-firefox: false
+          install-chrome: true
+          install-chromedriver: false
+          install-geckodriver: false
       - checkout
-      - install-chrome-custom-linux
+
       - restore_cache:
           keys:
             - v1-deps-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - browser-tools/install-browser-tools:
           install-firefox: false
-          install-chrome: false
+          install-chrome: true
           install-chromedriver: false
           install-geckodriver: false
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,8 @@ jobs:
       - run: unzip ./persist/dist.zip
       - run: unzip ./persist/plugin-<< parameters.plugin >>.zip
       - run: yarn install --cwd ./apps/remix-ide-e2e --modules-folder ../../node_modules
-      - run: yarn selenium-standalone install --singleDriverInstall=chrome --drivers.chrome.version=116.0.5845.96 
+      - run: yarn run selenium-install || yarn run selenium-install
+      - run: cp ~/bin/chromedriver /home/circleci/remix-project/node_modules/selenium-standalone/.selenium/chromedriver/latest-x64/
       - run:
           name: Start Selenium
           command: yarn run selenium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ jobs:
 
       - run: ls -la ./dist/apps/remix-ide/assets/js
       - run: yarn run selenium-install || yarn run selenium-install
+      - run: cp ~/bin/chromedriver /home/circleci/remix-project/node_modules/selenium-standalone/.selenium/chromedriver/latest-x64/
       - run:
           name: Start Selenium
           command: yarn run selenium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,9 +144,10 @@ jobs:
           steps:
             - browser-tools/install-browser-tools:
                 install-firefox: false
-                install-chrome: true
+                install-chrome: false
                 install-chromedriver: false
                 install-geckodriver: false
+            - install-chrome-custom-linux
             - install-chromedriver-custom-linux
             - run: google-chrome --version
             - run: chromedriver --version
@@ -402,7 +403,7 @@ commands:
     description: Custom script to install chrome with better version support for linux
     steps:
       - run:
-          name: install-custom-linux
+          name: install-custom-chrome-linux
           command: |
             CHROME_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json' | jq '.channels.Stable.downloads.chrome[] | select(.platform == "linux64") | .url' | tr -d '"')
             echo $CHROME_URL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
       - run: unzip ./persist/dist.zip
       - run: unzip ./persist/plugin-<< parameters.plugin >>.zip
       - run: yarn install --cwd ./apps/remix-ide-e2e --modules-folder ../../node_modules
-      - run: yarn run selenium-install || yarn run selenium-install
+      - run: yarn selenium-standalone install --singleDriverInstall=chrome --drivers.chrome.version=116.0.5845.96 
       - run:
           name: Start Selenium
           command: yarn run selenium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ commands:
           command: |
             google-chrome --version > version.txt
             VERSION=$(grep -Eo '[0-9]+\.' < version.txt | head -1)
-            CHROMEDRIVER_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json' | jq '.channels.Stable.downloads.chromedriver[] | select(.platform == "linux64") | .url' | tr -d '"')
+            # CHROMEDRIVER_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json' | jq '.channels.Stable.downloads.chromedriver[] | select(.platform == "linux64") | .url' | tr -d '"')
             CHROMEDRIVER_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json' | jq --arg v "$VERSION" '.versions[] | select(.version | startswith($v)) | .downloads.chromedriver[] | select(.platform == "linux64") | .url' | tail -n1 | tr -d '"')
             echo $CHROMEDRIVER_URL
             ZIPFILEPATH="/tmp/chromedriver.zip"
@@ -397,6 +397,7 @@ commands:
 
             echo Removing ZIP file
             rm "$ZIPFILEPATH"
+            rm version.txt
 
             echo Done
             chromedriver -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,10 @@ jobs:
     resource_class:
       xlarge
     working_directory: ~/remix-project
-  steps:
+    steps:
       - browser-tools/install-browser-tools:
           install-firefox: false
-          install-chrome: true
+          install-chrome: false
           install-chromedriver: false
           install-geckodriver: false
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,11 @@ jobs:
 
       - run: ls -la ./dist/apps/remix-ide/assets/js
       - run: yarn run selenium-install || yarn run selenium-install
-      - run: cp ~/bin/chromedriver /home/circleci/remix-project/node_modules/selenium-standalone/.selenium/chromedriver/latest-x64/
+      - when:
+          condition:
+              equal: [ "chrome", << parameters.browser >> ]
+          steps:
+            - run: cp ~/bin/chromedriver /home/circleci/remix-project/node_modules/selenium-standalone/.selenium/chromedriver/latest-x64/
       - run:
           name: Start Selenium
           command: yarn run selenium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,6 +377,7 @@ commands:
           name: install-chromedriver-custom-linux
           command: |
             CHROMEDRIVER_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json' | jq '.channels.Stable.downloads.chromedriver[] | select(.platform == "linux64") | .url' | tr -d '"')
+            CHROMEDRIVER_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json' | jq '.versions[] | select(.version | startswith("116")) | .downloads.chrome[] | select(.platform == "linux64") | .url' | tail -n1 | tr -d '"')
             echo $CHROMEDRIVER_URL
             ZIPFILEPATH="/tmp/chromedriver.zip"
             echo "Downloading from $CHROMEDRIVER_URL"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,10 +418,10 @@ commands:
             chmod +x "$BINFILEPATH"
 
             echo Updating symlink
-            ln -nfs "$BINFILEPATH" ~/bin/chrome
+            ln -nfs "$BINFILEPATH" ~/bin/google-chrome
 
             echo Removing ZIP file
             rm "$ZIPFILEPATH"
 
             echo Done
-            chrome -v
+            google-chrome --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,8 +376,10 @@ commands:
       - run:
           name: install-chromedriver-custom-linux
           command: |
+            google-chrome --version > version.txt
+            VERSION=$(grep -Eo '[0-9]+\.' < version.txt | head -1)
             CHROMEDRIVER_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json' | jq '.channels.Stable.downloads.chromedriver[] | select(.platform == "linux64") | .url' | tr -d '"')
-            CHROMEDRIVER_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json' | jq '.versions[] | select(.version | startswith("116")) | .downloads.chrome[] | select(.platform == "linux64") | .url' | tail -n1 | tr -d '"')
+            CHROMEDRIVER_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json' | jq --arg v "$VERSION" '.versions[] | select(.version | startswith($v)) | .downloads.chromedriver[] | select(.platform == "linux64") | .url' | tail -n1 | tr -d '"')
             echo $CHROMEDRIVER_URL
             ZIPFILEPATH="/tmp/chromedriver.zip"
             echo "Downloading from $CHROMEDRIVER_URL"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
     working_directory: ~/remix-project
     steps:
       - checkout
+      - run: wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
       - restore_cache:
           keys:
             - v1-deps-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,7 @@ jobs:
       xlarge
     working_directory: ~/remix-project
     steps:
-      - browser-tools/install-browser-tools:
-          install-firefox: false
-          install-chrome: true
-          install-chromedriver: false
-          install-geckodriver: false
       - checkout
-
       - restore_cache:
           keys:
             - v1-deps-{{ checksum "yarn.lock" }}
@@ -149,10 +143,9 @@ jobs:
           steps:
             - browser-tools/install-browser-tools:
                 install-firefox: false
-                install-chrome: false
+                install-chrome: true
                 install-chromedriver: false
                 install-geckodriver: false
-            - install-chrome-custom-linux
             - install-chromedriver-custom-linux
             - run: google-chrome --version
             - run: chromedriver --version
@@ -404,30 +397,3 @@ commands:
 
             echo Done
             chromedriver -v
-  install-chrome-custom-linux:
-    description: Custom script to install chrome with better version support for linux
-    steps:
-      - run:
-          name: install-custom-chrome-linux
-          command: |
-            CHROME_URL=$(curl -s 'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json' | jq '.channels.Stable.downloads.chrome[] | select(.platform == "linux64") | .url' | tr -d '"')
-            echo $CHROME_URL
-            ZIPFILEPATH="/tmp/chrome.zip"
-            echo "Downloading from $CHROME_URL"
-            curl -f --silent $CHROME_URL > "$ZIPFILEPATH"
-
-            BINFILEPATH="$HOME/bin/chrome-linux"
-            echo "Extracting to $BINFILEPATH"
-            unzip -p "$ZIPFILEPATH" chrome-linux64/chrome > "$BINFILEPATH"
-
-            echo Setting execute flag
-            chmod +x "$BINFILEPATH"
-
-            echo Updating symlink
-            ln -nfs "$BINFILEPATH" ~/bin/google-chrome
-
-            echo Removing ZIP file
-            rm "$ZIPFILEPATH"
-
-            echo Done
-            google-chrome --version

--- a/apps/remix-ide-e2e/nightwatch.ts
+++ b/apps/remix-ide-e2e/nightwatch.ts
@@ -35,7 +35,6 @@ module.exports = {
             '--no-sandbox',
             '--headless',
             '--verbose',
-            '--disable-dev-shm-usage',
             '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36'
           ]
         }

--- a/apps/remix-ide-e2e/nightwatch.ts
+++ b/apps/remix-ide-e2e/nightwatch.ts
@@ -35,6 +35,7 @@ module.exports = {
             '--no-sandbox',
             '--headless',
             '--verbose',
+            '--disable-dev-shm-usage',
             '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36'
           ]
         }


### PR DESCRIPTION
- the chromedriver is matched with the chrome version after chrome is installed, downloading it via the official json feed
- Then it is copied to the node_modules because the selenium standalone install module doesn't seem to correctly download and install the specified chromedriver version, even if you specify a version it doesn't correctly download it.  