### PR TITLE
Renamebug

### DIFF
--- a/libs/remix-ui/workspace/src/lib/components/file-label.tsx
+++ b/libs/remix-ui/workspace/src/lib/components/file-label.tsx
@@ -52,6 +52,10 @@ export const FileLabel = (props: FileLabelProps) => {
       editModeOff(labelRef.current.innerText)
       labelRef.current.innerText = file.name
     }
+    if (event.which === 27) {
+      event.preventDefault()
+      editModeOff(labelRef.current.innerText)
+    }
   }
 
   const handleEditBlur = (event: React.SyntheticEvent) => {

--- a/libs/remix-ui/workspace/src/lib/components/file-label.tsx
+++ b/libs/remix-ui/workspace/src/lib/components/file-label.tsx
@@ -54,7 +54,8 @@ export const FileLabel = (props: FileLabelProps) => {
     }
     if (event.which === 27) {
       event.preventDefault()
-      editModeOff(labelRef.current.innerText)
+      // don't change it
+      editModeOff(file.name)
     }
   }
 

--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -469,7 +469,7 @@ export function Workspace() {
       return {
         ...prevState,
         focusContext: {element: path, x: pageX, y: pageY, type},
-        focusEdit: {...prevState.focusEdit, lastEdit: content},
+        focusEdit: {...prevState.focusEdit, element: null, lastEdit: content},
         showContextMenu: prevState.focusEdit.element !== path
       }
     })


### PR DESCRIPTION
bug: fixes renaming, if you'd right click on a file, rename but you click outside of it you can't right click on anything anymore
it also adds ESC to not do renaming