### PR TITLE
fix method write multiple

### DIFF
--- a/apps/remix-ide-e2e/src/tests/fileManager_api.test.ts
+++ b/apps/remix-ide-e2e/src/tests/fileManager_api.test.ts
@@ -42,6 +42,25 @@ module.exports = {
       })
   },
 
+  'Should execute `writeMultipleFiles` api from file manager external api #group1': function (browser: NightwatchBrowser) {
+    browser
+      .addFile('writeMultipleFiles.js', { content: executeWriteMultipleFiles })
+      .executeScriptInTerminal('remix.exeCurrent()')
+      .pause(2000)
+      .openFile('new_contract_1.sol')
+      .getEditorValue((content) => {
+        browser.assert.ok(content.indexOf('pragma solidity ^0.6.0') !== -1, 'content does not contain "pragma solidity ^0.6.0"')
+      })
+      .openFile('new_contract_2.sol')
+      .getEditorValue((content) => {
+        browser.assert.ok(content.indexOf('pragma solidity ^0.8.0') !== -1, 'content does not contain "pragma solidity ^0.8.0"')
+      })
+      .openFile('testing.txt')
+      .getEditorValue((content) => {
+        browser.assert.ok(content.indexOf('test') !== -1, 'content does not contain "test"')
+      })
+  },
+
   'Should execute `readFile` api from file manager external api #group2': function (browser: NightwatchBrowser) {
     browser
       .addFile('writeFile.js', { content: executeWriteFile })
@@ -138,6 +157,14 @@ const executeOpen = `
 const executeWriteFile = `
   const run = async () => {
     await remix.call('fileManager', 'writeFile', 'new_contract.sol', 'pragma solidity ^0.6.0')
+  }
+
+  run()
+`
+
+const executeWriteMultipleFiles = `
+  const run = async () => {
+    await remix.call('fileManager', 'writeMultipleFiles', ['new_contract_1.sol', 'new_contract_2.sol', 'testing.txt'], ['pragma solidity ^0.6.0', 'pragma solidity ^0.80', 'test'], '/')
   }
 
   run()

--- a/apps/remix-ide-e2e/src/tests/fileManager_api.test.ts
+++ b/apps/remix-ide-e2e/src/tests/fileManager_api.test.ts
@@ -47,7 +47,7 @@ module.exports = {
       .addFile('writeMultipleFiles.js', { content: executeWriteMultipleFiles })
       .executeScriptInTerminal('remix.exeCurrent()')
       .pause(2000)
-      .openFile('new_contract_1.sol')
+      .openFile('contracts/new_contract_1.sol')
       .getEditorValue((content) => {
         browser.assert.ok(content.indexOf('pragma solidity ^0.6.0') !== -1, 'content does not contain "pragma solidity ^0.6.0"')
       })
@@ -164,7 +164,7 @@ const executeWriteFile = `
 
 const executeWriteMultipleFiles = `
   const run = async () => {
-    await remix.call('fileManager', 'writeMultipleFiles', ['new_contract_1.sol', 'new_contract_2.sol', 'testing.txt'], ['pragma solidity ^0.6.0', 'pragma solidity ^0.80', 'test'], '/')
+    await remix.call('fileManager', 'writeMultipleFiles', ['contracts/new_contract_1.sol', 'new_contract_2.sol', 'testing.txt'], ['pragma solidity ^0.6.0', 'pragma solidity ^0.8.0', 'test'], '/')
   }
 
   run()

--- a/apps/remix-ide/src/app/files/fileManager.ts
+++ b/apps/remix-ide/src/app/files/fileManager.ts
@@ -244,7 +244,6 @@ class FileManager extends Plugin {
           await this._setFileInternal(path, fileData[i])
           this.emit('fileAdded', path)
         }
-        alert = false
       }
     } catch (e) {
       throw new Error(e)

--- a/apps/remix-ide/src/app/files/fileManager.ts
+++ b/apps/remix-ide/src/app/files/fileManager.ts
@@ -234,7 +234,6 @@ class FileManager extends Plugin {
       }
     }
     try {
-      let alert = true
       for (let i = 0; i < filePaths.length; i++) {
         const installPath = folderPath + "/" + filePaths[i]
 

--- a/apps/remix-ide/src/app/files/fileManager.ts
+++ b/apps/remix-ide/src/app/files/fileManager.ts
@@ -225,7 +225,7 @@ class FileManager extends Plugin {
   * @param {string} folderPath base folder path
   * @returns {void}
   */
-  async writeMultipleFiles(filePaths, fileData, folderPath) {
+  async writeMultipleFiles(filePaths: string[], fileData: string[], folderPath: string) {
     if (this.currentRequest) {
       const canCall = await this.askUserPermission(`writeFile`, `will write multiple files to ${folderPath}...`)
       const required = this.appManager.isRequired(this.currentRequest.from)


### PR DESCRIPTION
- This calls the permission modal on the writeMultipleFiles only once per call
- removed some clutter we don't need
- added a test for the API method

TO TEST:
go to the cookbook plugin and run a protocol import it should write multiple files at once after permissions
