### PR TITLE
FE tooltips are back.

### DIFF
--- a/libs/remix-ui/vertical-icons-panel/src/lib/components/Icon.tsx
+++ b/libs/remix-ui/vertical-icons-panel/src/lib/components/Icon.tsx
@@ -86,7 +86,11 @@ const Icon = ({iconRecord, verticalIconPlugin, contextMenuAction, theme}: IconPr
 
   return (
     <>
-      <CustomTooltip placement={name === 'settings' ? 'right' : name === 'search' ? 'top' : name === 'udapp' ? 'bottom' : 'top'} tooltipText={title} delay={{show: 1000, hide: 0}}>
+      <CustomTooltip
+        placement={name === 'settings' ? 'right' : name === 'search' ? 'top' : name === 'udapp' ? 'bottom' : 'top'}
+        tooltipText={title}
+        delay={{show: 1000, hide: 0}}
+      >
         <div
           className={`remixui_icon m-2  pt-1`}
           onClick={() => {

--- a/libs/remix-ui/workspace/src/lib/components/file-label.tsx
+++ b/libs/remix-ui/workspace/src/lib/components/file-label.tsx
@@ -67,14 +67,14 @@ export const FileLabel = (props: FileLabelProps) => {
 
   return (
     <div
-      className="remixui_items d-inline-block w-100 text-break"
+      className="remixui_items d-inline-block w-100"
       ref={isEditable ? labelRef : null}
       suppressContentEditableWarning={true}
       contentEditable={isEditable}
       onKeyDown={handleEditInput}
       onBlur={handleEditBlur}
     >
-      <span className={`text-nowrap remixui_label ${fileStateClasses} ` + (file.isDirectory ? 'folder' : 'remixui_leaf')} data-path={file.path}>
+      <span className={`remixui_label ${fileStateClasses} ` + (file.isDirectory ? 'folder' : 'remixui_leaf')} data-path={file.path}>
         {file.name}
       </span>
     </div>

--- a/libs/remix-ui/workspace/src/lib/components/file-label.tsx
+++ b/libs/remix-ui/workspace/src/lib/components/file-label.tsx
@@ -81,7 +81,7 @@ export const FileLabel = (props: FileLabelProps) => {
       <CustomTooltip
         placement="top"
         delay={{show: 1000, hide: 0}}
-        tooltipText={`${file.name}`}
+        tooltipText={`${file.path}`}
         tooltipId={`fileExplorer.${file.path}`}
         tooltipClasses="text-nowrap"
       >

--- a/libs/remix-ui/workspace/src/lib/components/file-label.tsx
+++ b/libs/remix-ui/workspace/src/lib/components/file-label.tsx
@@ -1,5 +1,7 @@
 // eslint-disable-next-line no-use-before-define
 import {fileDecoration} from '@remix-ui/file-decorators'
+import {CustomTooltip} from '@remix-ui/helper'
+import {FormattedMessage} from 'react-intl'
 import React, {useEffect, useRef, useState} from 'react'
 import {FileType} from '../types'
 export interface FileLabelProps {
@@ -65,6 +67,8 @@ export const FileLabel = (props: FileLabelProps) => {
     labelRef.current.innerText = file.name
   }
 
+  // The tooltip is setted up on the label and not the whole line to avoid unnecessary tooltips on the short filenames.
+  // It has the delay for the same reason.
   return (
     <div
       className="remixui_items d-inline-block w-100"
@@ -74,9 +78,17 @@ export const FileLabel = (props: FileLabelProps) => {
       onKeyDown={handleEditInput}
       onBlur={handleEditBlur}
     >
-      <span className={`remixui_label ${fileStateClasses} ` + (file.isDirectory ? 'folder' : 'remixui_leaf')} data-path={file.path}>
-        {file.name}
-      </span>
+      <CustomTooltip
+        placement="top"
+        delay={{show: 1000, hide: 0}}
+        tooltipText={`${file.name}`}
+        tooltipId={`fileExplorer.${file.path}`}
+        tooltipClasses="text-nowrap"
+      >
+        <span className={`remixui_label ${fileStateClasses} ` + (file.isDirectory ? 'folder' : 'remixui_leaf')} data-path={file.path}>
+          {file.name}
+        </span>
+      </CustomTooltip>
     </div>
   )
 }

--- a/libs/remix-ui/workspace/src/lib/css/file-explorer.css
+++ b/libs/remix-ui/workspace/src/lib/css/file-explorer.css
@@ -33,7 +33,11 @@ input[type="file"] {
     margin-left       : 20px;
 }
 .remixui_items              {
-    display           : inline
+    display           : inline;
+    white-space       : nowrap;
+    overflow          : hidden;
+    text-overflow     : ellipsis;
+    max-width         : 90%;
 }
 .remixui_remove             {
     margin-left       : auto;

--- a/libs/remix-ui/workspace/src/lib/css/remix-ui-workspace.css
+++ b/libs/remix-ui/workspace/src/lib/css/remix-ui-workspace.css
@@ -40,7 +40,7 @@
     cursor            : pointer;
   }
   .remixui_treeview {
-    overflow-y        : auto;
+    overflow-x        : hidden;
   }
   .remixui_dialog {
     display: flex;


### PR DESCRIPTION
We have a path now instead of names, and we show the tooltip with a delay.
Besides it is on the label and not the line, so when the user is hovering they will not see tooltips on short names.

The issue is part of  https://github.com/ethereum/remix-project/issues/4046