### PR TITLE
Ensure url is consistent for circom dev deps

### DIFF
--- a/apps/circuit-compiler/src/app/services/circomPluginClient.ts
+++ b/apps/circuit-compiler/src/app/services/circomPluginClient.ts
@@ -256,6 +256,7 @@ export class CircomPluginClient extends PluginClient {
               if (depPath) {
                 // if depPath is provided, try to resolve include import from './deps' folder in remix
                 path = pathModule.resolve(depPath.slice(0, depPath.lastIndexOf('/')), include)
+                path = path.replace('https:/', 'https://')
                 if (path.indexOf('/') === 0) path = path.slice(1)
                 dependencyContent = await this.call('contentImport', 'resolveAndSave', path, null)
               } else {


### PR DESCRIPTION
Should fix dependency imports for circom.
<img width="705" alt="Screenshot_2023-11-02_at_8 21 48_PM" src="https://github.com/ethereum/remix-project/assets/23282059/888b9083-6018-4730-99ee-66759aa707a9">
