### PR TITLE
support log transaction from iframe plugin

### DIFF
--- a/libs/remix-lib/src/execution/typeConversion.ts
+++ b/libs/remix-lib/src/execution/typeConversion.ts
@@ -24,6 +24,8 @@ function convertToString (v) {
       return ret
     } else if (BN.isBN(v) || (v.constructor && v.constructor.name === 'BigNumber') || isBigInt(v)) {
       return v.toString(10)
+    } else if (v._isBigNumber) {
+      return toInt(v._hex)
     } else if (v._isBuffer) {
       return bufferToHex(v)
     } else if (typeof v === 'object') {

--- a/libs/remix-ui/terminal/src/lib/components/Context.tsx
+++ b/libs/remix-ui/terminal/src/lib/components/Context.tsx
@@ -16,7 +16,7 @@ const Context = ({opts, provider}: {opts; provider: string}) => {
   const i = data.receipt ? data.transactionIndex : data.transactionIndex
   const value = val ? typeConversion.toInt(val) : 0
 
-  if (provider.startsWith('vm')) {
+  if (provider && provider.startsWith('vm')) {
     return (
       <div>
         <span>

--- a/libs/remix-ui/terminal/src/lib/remix-ui-terminal.tsx
+++ b/libs/remix-ui/terminal/src/lib/remix-ui-terminal.tsx
@@ -116,7 +116,7 @@ export const RemixUiTerminal = (props: RemixUiTerminalProps) => {
         }
         scriptRunnerDispatch({
           type: message.type ? message.type : 'log',
-          payload: { message: [message.value], provider: message.provider },
+          payload: { message: [message.value] },
         })
       },
     })

--- a/libs/remix-ui/terminal/src/lib/remix-ui-terminal.tsx
+++ b/libs/remix-ui/terminal/src/lib/remix-ui-terminal.tsx
@@ -116,7 +116,7 @@ export const RemixUiTerminal = (props: RemixUiTerminalProps) => {
         }
         scriptRunnerDispatch({
           type: message.type ? message.type : 'log',
-          payload: { message: [message.value] },
+          payload: { message: [message.value], provider: message.provider },
         })
       },
     })


### PR DESCRIPTION
I'm developing an iframe plugin for xinghuo bif, and I want to send a transaction log, and I got some issues.

### Here is the first one.
![image](https://github.com/ethereum/remix-project/assets/18543527/a655cb56-dfd1-4781-9a38-d786c8924fd8)
Check the code here - https://github.com/ethereum/remix-project/blob/master/libs/remix-ui/terminal/src/lib/components/Context.tsx#L19

`provider` will be missing if the transaction log is called from iframe plugin. 
### Here is another one.
The decoded input does not convert correctly when it's BigNumber. 
![image](https://github.com/ethereum/remix-project/assets/18543527/85b7b3e4-528e-494a-ae67-2802c739cc45)
Here is the correct convert result. 
![image](https://github.com/ethereum/remix-project/assets/18543527/be4f9703-0069-4c12-92f3-97d191a605d2)
BigNumber will turn to a ordinary object if it's passed through postMessage. 

@Aniket-Engg @ryestew 