### PR TITLE
remove empty lines from remappings

### DIFF
--- a/libs/remix-ui/solidity-compiler/src/lib/logic/compileTabLogic.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/logic/compileTabLogic.ts
@@ -112,7 +112,7 @@ export class CompileTabLogic {
         this.event.emit('startingCompilation')
         if(await this.api.fileExists('remappings.txt')) {
           this.api.readFile('remappings.txt').then(remappings => {
-            this.compiler.set('remappings', remappings.split('\n'))
+            this.compiler.set('remappings', remappings.split('\n').filter(Boolean))
           })
         } else this.compiler.set('remappings', [])
         if (this.configFilePath) {


### PR DESCRIPTION
without this, it shows error: `Invalid remapping: ""`