### PR TITLE
fix parser: remappings

### DIFF
--- a/apps/remix-ide/src/app/plugins/parser/services/code-parser-compiler.ts
+++ b/apps/remix-ide/src/app/plugins/parser/services/code-parser-compiler.ts
@@ -142,6 +142,14 @@ export default class CodeParserCompiler {
         this.compiler.set('runs', state.runs)
         this.compiler.set('useFileConfiguration', true)
         this.compiler.set('compilerRetriggerMode', CompilerRetriggerMode.retrigger)
+
+        if (await this.plugin.call('fileManager', 'exists','remappings.txt')) {
+          const remappings = await this.plugin.call('fileManager', 'readFile','remappings.txt')
+          this.compiler.set('remappings', remappings.split('\n').filter(Boolean))
+        } else {
+          this.compiler.set('remappings', [])
+        }
+        
         const configFileContent = {
           "language": "Solidity",
           "settings": {


### PR DESCRIPTION
This allows our solidity parser to use the `remappings.txt` file.

To test it, create a workspace if type v4 periphery, update submodules, it will show an error in the editor at the top.