### PR TITLE
add custom endpoint for AI suggestion

### DIFF
--- a/apps/remix-ide/src/app/plugins/copilot/suggestion-service/copilot-suggestion.ts
+++ b/apps/remix-ide/src/app/plugins/copilot/suggestion-service/copilot-suggestion.ts
@@ -1,18 +1,20 @@
 import {Plugin} from '@remixproject/engine'
 import {SuggestionService, SuggestOptions} from './suggestion-service'
+import axios, {AxiosResponse} from 'axios'
 const _paq = (window._paq = window._paq || []) //eslint-disable-line
 
 const profile = {
   name: 'copilot-suggestion',
   displayName: 'copilot-suggestion',
   description: 'Get Solidity suggestions in editor',
-  methods: ['suggest', 'init', 'uninstall', 'status', 'isActivate'],
+  methods: ['suggest', 'init', 'uninstall', 'status', 'isActivate', 'useRemoteService', 'discardRemoteService'],
   version: '0.1.0-alpha',
   maintainedBy: "Remix"
 }
 
 export class CopilotSuggestion extends Plugin {
   service: SuggestionService
+  remoteService: string
   context: string
   ready: boolean
   constructor() {
@@ -27,6 +29,14 @@ export class CopilotSuggestion extends Plugin {
     this.service.events.on('ready', (data) => {
       this.ready = true
     })    
+  }
+
+  useRemoteService(service: string) {
+    this.remoteService = service
+  }
+
+  discardRemoteService() {
+    this.remoteService = null
   }
 
   status () {
@@ -53,7 +63,14 @@ export class CopilotSuggestion extends Plugin {
       temperature: temperature || 0,
       max_new_tokens: max_new_tokens || 0
     }
-    return this.service.suggest(this.context ? this.context + '\n\n' + content : content, options)
+
+    if (this.remoteService) {
+      const {data} = await axios.post(this.remoteService, {context: content, max_new_words: options.max_new_tokens, temperature: options.temperature})
+      const parsedData = JSON.parse(data).trimStart()
+      return {output: [{generated_text: parsedData}]}
+    } else {
+      return this.service.suggest(this.context ? this.context + '\n\n' + content : content, options)
+    }
   }
 
   async loadModeContent() {

--- a/libs/remix-ui/editor/src/lib/providers/inlineCompletionProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/inlineCompletionProvider.ts
@@ -70,7 +70,11 @@ export class RemixInLineCompletionProvider implements monacoTypes.languages.Inli
 
     const generatedText = (result as any).output[0].generated_text as string
     // the generated text remove a space from the context...
-    const clean = generatedText.replace('@custom:dev-run-script', '@custom:dev-run-script ').replace(word, '')
+    let clean = generatedText
+    if (generatedText.indexOf('@custom:dev-run-script./') !== -1) {
+      clean = generatedText.replace('@custom:dev-run-script', '@custom:dev-run-script ')
+    }
+    clean = clean.replace(word, '')
     const item: monacoTypes.languages.InlineCompletion = {
       insertText: clean
     };


### PR DESCRIPTION
create a script in Remix:
like
```
(async () => {
  try {
    remix.call('copilot-suggestion' as any, 'useRemoteService', 'http://replit.remixcompletion.pro/infer')
    console.log('done')
  } catch (e) {
    console.log(e.message)
  }
})()
```
and run it to use a remote endpoint instead of the in-browser model.
