### PR TITLE
update workspace names

### DIFF
--- a/apps/remix-ide-e2e/src/commands/currentWorkspaceStartsWith.ts
+++ b/apps/remix-ide-e2e/src/commands/currentWorkspaceStartsWith.ts
@@ -1,0 +1,19 @@
+import { NightwatchBrowser } from 'nightwatch'
+import EventEmitter from 'events'
+
+class CurrentWorkspaceStartsWith extends EventEmitter {
+  command (this: NightwatchBrowser, name: string): NightwatchBrowser {
+    const browser = this.api
+
+    browser.getText('[data-id="workspacesSelect"]', function (result) {
+      browser.assert.ok((result.value as string).indexOf(name) === 0)
+    })
+    .perform((done) => {
+      done()
+      this.emit('complete')
+    })
+    return this
+  }
+}
+
+module.exports = CurrentWorkspaceStartsWith

--- a/apps/remix-ide-e2e/src/tests/url.test.ts
+++ b/apps/remix-ide-e2e/src/tests/url.test.ts
@@ -91,25 +91,13 @@ module.exports = {
       })
   },
 
-  'Should load Etherscan verified contracts from URL "address" param)': !function (browser: NightwatchBrowser) {
+  'Should load Etherscan verified contracts from URL "address" param) #group1': function (browser: NightwatchBrowser) {
     browser
 
-      .url('http://127.0.0.1:8080/#address=0x56db08fb78bc6689a1ef66efd079083fed0e4915')
-      .refreshPage()
-
-      .currentWorkspaceIs('etherscan-code-sample')
-      .assert.elementPresent('*[data-id=treeViewLitreeViewItemropsten]')
-      .assert.elementPresent('*[data-id=treeViewLitreeViewItemrinkeby]')
-      .assert.elementPresent('*[data-id="treeViewLitreeViewItemrinkeby/0x56db08fb78bc6689a1ef66efd079083fed0e4915"]')
-      .assert.elementPresent('*[data-id="treeViewLitreeViewItemrinkeby/0x56db08fb78bc6689a1ef66efd079083fed0e4915/Sample.sol"]')
-      .getEditorValue((content) => {
-        browser.assert.ok(content && content.indexOf(
-          'contract Sample {') !== -1)
-      })
       .url('http://127.0.0.1:8080/#address=0xdac17f958d2ee523a2206206994597c13d831ec7')
       .refreshPage()
       .pause(7000)
-      .currentWorkspaceIs('etherscan-code-sample')
+      .currentWorkspaceIs('Code-sample of 0xdac17f958d2ee523a2206206994597c13d831ec7')
       .assert.elementPresent('*[data-id=treeViewLitreeViewItemmainnet]')
       .assert.elementPresent('*[data-id="treeViewLitreeViewItemmainnet/0xdac17f958d2ee523a2206206994597c13d831ec7"]')
       .assert.elementPresent('*[data-id="treeViewLitreeViewItemmainnet/0xdac17f958d2ee523a2206206994597c13d831ec7/TetherToken.sol"]')

--- a/apps/remix-ide-e2e/src/tests/url.test.ts
+++ b/apps/remix-ide-e2e/src/tests/url.test.ts
@@ -66,7 +66,7 @@ module.exports = {
       .click('[for="autoCompile"]') // back to True in the local storage
       .assert.containsText('*[data-id="compilerContainerCompileBtn"]', 'contract-76747f6e19.sol')
       .clickLaunchIcon('filePanel')
-      .currentWorkspaceIs('code-sample')
+      .currentWorkspaceStartsWith('Code sample')
       .getEditorValue((content) => {
         browser.assert.ok(content && content.indexOf(
           'https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol') !== -1,
@@ -83,7 +83,7 @@ module.exports = {
         selector: `//li[@data-id="treeViewLitreeViewItemethereum/remix-project/apps/remix-ide/contracts/app/solidity/mode.sol"]`,
         locateStrategy: 'xpath'
       })
-      .currentWorkspaceIs('code-sample')
+      .currentWorkspaceStartsWith('Code sample')
       .getEditorValue((content) => {
         browser.assert.ok(content && content.indexOf(
           'proposals.length = _numProposals;') !== -1,
@@ -119,7 +119,7 @@ module.exports = {
         selector: `//li[@data-id="treeViewLitreeViewItemethereum/remix-project/apps/remix-ide/contracts/app/solidity/mode.sol"]`,
         locateStrategy: 'xpath'
       })
-      .currentWorkspaceIs('code-sample')
+      .currentWorkspaceStartsWith('Code sample')
       .getEditorValue((content) => {
         browser.assert.ok(content && content.indexOf(
           'proposals.length = _numProposals;') !== -1,
@@ -136,7 +136,7 @@ module.exports = {
 
       .clickLaunchIcon('filePanel')
       .waitForElementVisible('*[data-id="treeViewLitreeViewItemcontract-eaa022e37e.yul"]')
-      .currentWorkspaceIs('code-sample')
+      .currentWorkspaceStartsWith('Code sample')
       .openFile('contract-eaa022e37e.yul')
       .getEditorValue((content) => {
         browser.assert.ok(content && content.indexOf(

--- a/apps/remix-ide-e2e/src/types/index.d.ts
+++ b/apps/remix-ide-e2e/src/types/index.d.ts
@@ -60,6 +60,7 @@ declare module 'nightwatch' {
     checkAnnotationsNotPresent(type: string): NightwatchBrowser
     getLastTransactionHash(callback: (hash: string) => void)
     currentWorkspaceIs(name: string): NightwatchBrowser
+    currentWorkspaceStartsWith(name: string): NightwatchBrowser
     addLocalPlugin(this: NightwatchBrowser, profile: Profile & LocationProfile & ExternalProfile): NightwatchBrowser
     acceptAndRemember(this: NightwatchBrowser, remember: boolean, accept: boolean): NightwatchBrowser
     clearConsole(this: NightwatchBrowser): NightwatchBrowser

--- a/libs/remix-ui/helper/src/lib/components/custom-dropdown.tsx
+++ b/libs/remix-ui/helper/src/lib/components/custom-dropdown.tsx
@@ -29,7 +29,7 @@ export const CustomToggle = React.forwardRef(
       className={className.replace('dropdown-toggle', '')}
     >
       <div className="d-flex">
-        <div className="mr-auto text-nowrap">{children}</div>
+        <div className="mr-auto text-nowrap overflow-hidden">{children}</div>
         {icon && (
           <div className="pr-1">
             <i className={`${icon} pr-1`}></i>

--- a/libs/remix-ui/workspace/src/lib/actions/index.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/index.ts
@@ -55,14 +55,18 @@ export const initWorkspace = (filePanelPlugin) => async (reducerDispatch: React.
     const workspaces = await getWorkspaces() || []
     dispatch(setWorkspaces(workspaces))
     if (params.gist) {
-      await createWorkspaceTemplate('gist-sample', 'gist-template')
-      plugin.setWorkspace({ name: 'gist-sample', isLocalhost: false })
-      dispatch(setCurrentWorkspace({ name: 'gist-sample', isGitRepo: false }))
+      const workspaceName = 'Gist sample ' + params.gist
+      await createWorkspaceTemplate(workspaceName, 'gist-template')
+      plugin.setWorkspace({ name: workspaceName, isLocalhost: false })
+      dispatch(setCurrentWorkspace({ name: workspaceName, isGitRepo: false }))
       await loadWorkspacePreset('gist-template')
     } else if (params.code || params.url) {
-      await createWorkspaceTemplate('code-sample', 'code-template')
-      plugin.setWorkspace({ name: 'code-sample', isLocalhost: false })
-      dispatch(setCurrentWorkspace({ name: 'code-sample', isGitRepo: false }))
+      const d = new Date()
+      const dateOptions = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' }
+      const workspaceName = 'Code sample\'s creation date ' + d.toLocaleDateString(undefined, dateOptions as any) + ' ' + Date.now()
+      await createWorkspaceTemplate(workspaceName, 'code-template')
+      plugin.setWorkspace({ name: workspaceName, isLocalhost: false })
+      dispatch(setCurrentWorkspace({ name: workspaceName, isGitRepo: false }))
       const filePath = await loadWorkspacePreset('code-template')
       plugin.on('editor', 'editorMounted', async () => await plugin.fileManager.openFile(filePath))
     } else if (params.address) {
@@ -82,7 +86,7 @@ export const initWorkspace = (filePanelPlugin) => async (reducerDispatch: React.
             {id: 5, name: 'goerli'}
           ]
           let found = false
-          const workspaceName = 'etherscan-code-sample'
+          const workspaceName = 'Code sample of ' + params.address
           let filePath
           const foundOnNetworks = []
           for (const network of networks) {

--- a/libs/remix-ui/workspace/src/lib/actions/index.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/index.ts
@@ -63,7 +63,7 @@ export const initWorkspace = (filePanelPlugin) => async (reducerDispatch: React.
     } else if (params.code || params.url) {
       const d = new Date()
       const dateOptions = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' }
-      const workspaceName = 'Code sample\'s creation date ' + d.toLocaleDateString(undefined, dateOptions as any) + ' ' + Date.now()
+      const workspaceName = 'Code sample creation date ' + d.toLocaleDateString(undefined, dateOptions as any) + ' ' + d.toLocaleTimeString().replace(/:/g, '-')
       await createWorkspaceTemplate(workspaceName, 'code-template')
       plugin.setWorkspace({ name: workspaceName, isLocalhost: false })
       dispatch(setCurrentWorkspace({ name: workspaceName, isGitRepo: false }))


### PR DESCRIPTION
using a different workspace name, each time we load a code-template.
That way dependencies doesn't get messed up in between workspace.