### PR TITLE
always delete the code-sample workspace but propose to turn it into a normal workspace

### DIFF
--- a/apps/remix-ide-e2e/src/tests/url.test.ts
+++ b/apps/remix-ide-e2e/src/tests/url.test.ts
@@ -91,25 +91,12 @@ module.exports = {
       })
   },
 
-  'Should load Etherscan verified contracts from URL "address" param)': !function (browser: NightwatchBrowser) {
+  'Should load Etherscan verified contracts from URL "address" param)': function (browser: NightwatchBrowser) {
     browser
-
-      .url('http://127.0.0.1:8080/#address=0x56db08fb78bc6689a1ef66efd079083fed0e4915')
-      .refreshPage()
-
-      .currentWorkspaceIs('etherscan-code-sample')
-      .assert.elementPresent('*[data-id=treeViewLitreeViewItemropsten]')
-      .assert.elementPresent('*[data-id=treeViewLitreeViewItemrinkeby]')
-      .assert.elementPresent('*[data-id="treeViewLitreeViewItemrinkeby/0x56db08fb78bc6689a1ef66efd079083fed0e4915"]')
-      .assert.elementPresent('*[data-id="treeViewLitreeViewItemrinkeby/0x56db08fb78bc6689a1ef66efd079083fed0e4915/Sample.sol"]')
-      .getEditorValue((content) => {
-        browser.assert.ok(content && content.indexOf(
-          'contract Sample {') !== -1)
-      })
       .url('http://127.0.0.1:8080/#address=0xdac17f958d2ee523a2206206994597c13d831ec7')
       .refreshPage()
       .pause(7000)
-      .currentWorkspaceIs('etherscan-code-sample')
+      .currentWorkspaceIs('code-sample')
       .assert.elementPresent('*[data-id=treeViewLitreeViewItemmainnet]')
       .assert.elementPresent('*[data-id="treeViewLitreeViewItemmainnet/0xdac17f958d2ee523a2206206994597c13d831ec7"]')
       .assert.elementPresent('*[data-id="treeViewLitreeViewItemmainnet/0xdac17f958d2ee523a2206206994597c13d831ec7/TetherToken.sol"]')
@@ -136,6 +123,13 @@ module.exports = {
         browser.assert.ok(content && content.indexOf(
           'proposals.length = _numProposals;') !== -1,
           'code has been loaded')
+      })
+      .url('http://127.0.0.1:8080') // refresh without loading the code sample
+      .currentWorkspaceIs('default_workspace')
+      .execute(() => {
+        return document.querySelector('[data-id="dropdown-item-code-sample"]') === null
+      }, [], (result) => {
+        browser.assert.ok((result as any).value, 'sample template has not be persisted.') // code-sample should not be kept.
       })
   },
 

--- a/apps/remix-ide/src/app/files/workspaceFileProvider.js
+++ b/apps/remix-ide/src/app/files/workspaceFileProvider.js
@@ -9,6 +9,13 @@ class WorkspaceFileProvider extends FileProvider {
     this.workspacesPath = '.workspaces'
     this.workspace = null
     this.event = new EventManager()
+
+    try {
+      // make sure "code-sample" has been removed
+      window.remixFileSystem.unlink(this.workspacesPath + '/code-sample')    
+    } catch (e) {
+      console.error(e)
+    }    
   }
 
   setWorkspace (workspace) {

--- a/apps/remix-ide/src/app/files/workspaceFileProvider.js
+++ b/apps/remix-ide/src/app/files/workspaceFileProvider.js
@@ -14,7 +14,7 @@ class WorkspaceFileProvider extends FileProvider {
       // make sure "code-sample" has been removed
       window.remixFileSystem.unlink(this.workspacesPath + '/code-sample')    
     } catch (e) {
-      console.error(e)
+      // we don't need to log error if this throws an error
     }    
   }
 

--- a/apps/remix-ide/src/app/panels/file-panel.js
+++ b/apps/remix-ide/src/app/panels/file-panel.js
@@ -180,6 +180,7 @@ module.exports = class Filepanel extends ViewPlugin {
   }
 
   saveRecent(workspaceName) {
+    if (workspaceName === 'code-sample') return
     if (!localStorage.getItem('recentWorkspaces')) {
       localStorage.setItem('recentWorkspaces', JSON.stringify([ workspaceName ]))
     } else {

--- a/apps/remix-ide/src/app/panels/file-panel.js
+++ b/apps/remix-ide/src/app/panels/file-panel.js
@@ -119,10 +119,10 @@ module.exports = class Filepanel extends ViewPlugin {
     return this.workspaces
   }
 
-  getAvailableWorkspaceName(name) {
+  getAvailableWorkspaceName(name) {    
     if (!this.workspaces) return name
     let index = 1
-    let workspace = this.workspaces.find((workspace) => workspace.name === name + ' - ' + index)
+    let workspace = this.workspaces.find((workspace) => workspace.name === name + ' - ' + index)    
     while (workspace) {
       index++
       workspace = this.workspaces.find((workspace) => workspace.name === name + ' - ' + index)

--- a/apps/remix-ide/src/app/tabs/locales/en/filePanel.json
+++ b/apps/remix-ide/src/app/tabs/locales/en/filePanel.json
@@ -8,6 +8,7 @@
   "filePanel.restore": "Restore",
   "filePanel.workspace.create": "Create Workspace",
   "filePanel.workspace.rename": "Rename Workspace",
+  "filePanel.workspace.save_workspace": "Save Workspace",
   "filePanel.workspace.delete": "Delete Workspace",
   "filePanel.workspace.deleteConfirm": "Are you sure to delete the current workspace?",
   "filePanel.workspace.download": "Download Workspace",
@@ -129,5 +130,5 @@
   "filePanel.movingFolderFailed": "Moving Folder Failed",
   "filePanel.movingFolderFailedMsg": "Unexpected error while moving folder: {src}",
   "filePanel.workspaceActions": "Workspace actions",
-  "filePanel.saveCodeSample": "This code sample will not be persisted. Please click here to save this code as a persisted workspace."
+  "filePanel.saveCodeSample": "This code-sample workspace will not be persisted. Click here to save it."
 }

--- a/apps/remix-ide/src/app/tabs/locales/en/filePanel.json
+++ b/apps/remix-ide/src/app/tabs/locales/en/filePanel.json
@@ -128,5 +128,6 @@
   "filePanel.movingFileFailedMsg": "Unexpected error while moving file: {src}",
   "filePanel.movingFolderFailed": "Moving Folder Failed",
   "filePanel.movingFolderFailedMsg": "Unexpected error while moving folder: {src}",
-  "filePanel.workspaceActions": "Workspace actions"
+  "filePanel.workspaceActions": "Workspace actions",
+  "filePanel.saveCodeSample": "This code sample will not be persisted. Please click here to save this code as a persisted workspace."
 }

--- a/libs/remix-ui/workspace/src/lib/actions/index.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/index.ts
@@ -55,9 +55,9 @@ export const initWorkspace = (filePanelPlugin) => async (reducerDispatch: React.
     const workspaces = await getWorkspaces() || []
     dispatch(setWorkspaces(workspaces))
     if (params.gist) {
-      await createWorkspaceTemplate('gist-sample', 'gist-template')
-      plugin.setWorkspace({ name: 'gist-sample', isLocalhost: false })
-      dispatch(setCurrentWorkspace({ name: 'gist-sample', isGitRepo: false }))
+      await createWorkspaceTemplate('code-sample', 'gist-template')
+      plugin.setWorkspace({ name: 'code-sample', isLocalhost: false })
+      dispatch(setCurrentWorkspace({ name: 'code-sample', isGitRepo: false }))
       await loadWorkspacePreset('gist-template')
     } else if (params.code || params.url) {
       await createWorkspaceTemplate('code-sample', 'code-template')
@@ -82,7 +82,7 @@ export const initWorkspace = (filePanelPlugin) => async (reducerDispatch: React.
             {id: 5, name: 'goerli'}
           ]
           let found = false
-          const workspaceName = 'etherscan-code-sample'
+          const workspaceName = 'code-sample'
           let filePath
           const foundOnNetworks = []
           for (const network of networks) {

--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useEffect, useRef, useContext, ChangeEvent} from 'react' // eslint-disable-line
 import {FormattedMessage, useIntl} from 'react-intl'
 import {Dropdown} from 'react-bootstrap'
-import {CustomIconsToggle, CustomMenu, CustomToggle, extractNameFromKey, extractParentFromKey} from '@remix-ui/helper'
+import {CustomIconsToggle, CustomMenu, CustomToggle, CustomTooltip, extractNameFromKey, extractParentFromKey} from '@remix-ui/helper'
 import {FileExplorer} from './components/file-explorer' // eslint-disable-line
 import {FileSystemContext} from './contexts'
 import './css/remix-ui-workspace.css'
@@ -943,6 +943,14 @@ export function Workspace() {
                     <label className="pl-2 form-check-label" style={{wordBreak: 'keep-all'}}>
                       <FormattedMessage id='filePanel.workspace' />
                     </label>
+                    {selectedWorkspace && selectedWorkspace.name === 'code-sample' && <CustomTooltip
+                      placement="right"
+                      tooltipId="saveCodeSample"
+                      tooltipClasses="text-nowrap"
+                      tooltipText={<FormattedMessage id="filePanel.saveCodeSample" />}
+                    >
+                      <i onClick={() => renameCurrentWorkspace()} className="far fa-exclamation-triangle text-info ml-2 mt-1" aria-hidden="true"></i>
+                    </CustomTooltip>}
                   </span>                  
                 </div>
                 <div className='mx-2'>

--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -949,7 +949,7 @@ export function Workspace() {
                       tooltipClasses="text-nowrap"
                       tooltipText={<FormattedMessage id="filePanel.saveCodeSample" />}
                     >
-                      <i onClick={() => renameCurrentWorkspace()} className="far fa-exclamation-triangle text-warning ml-2 mt-1" aria-hidden="true"></i>
+                      <i onClick={() => renameCurrentWorkspace()} className="far fa-exclamation-triangle text-warning ml-2 align-self-center" aria-hidden="true"></i>
                     </CustomTooltip>}
                   </span>                  
                 </div>

--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -949,7 +949,7 @@ export function Workspace() {
                       tooltipClasses="text-nowrap"
                       tooltipText={<FormattedMessage id="filePanel.saveCodeSample" />}
                     >
-                      <i onClick={() => renameCurrentWorkspace()} className="far fa-exclamation-triangle text-info ml-2 mt-1" aria-hidden="true"></i>
+                      <i onClick={() => renameCurrentWorkspace()} className="far fa-exclamation-triangle text-warning ml-2 mt-1" aria-hidden="true"></i>
                     </CustomTooltip>}
                   </span>                  
                 </div>

--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -153,6 +153,17 @@ export function Workspace() {
     )
   }
 
+  const saveSampleCodeWorkspace = () => {
+    const workspaceName = global.plugin.getAvailableWorkspaceName('code-sample')
+    global.modal(
+      intl.formatMessage({id: 'filePanel.workspace.save_workspace'}),
+      renameModalMessage(workspaceName),
+      intl.formatMessage({id: 'filePanel.ok'}),
+      onFinishRenameWorkspace,
+      intl.formatMessage({id: 'filePanel.cancel'})
+    )
+  }
+
   const downloadCurrentWorkspace = () => {
     global.modal(
       intl.formatMessage({id: 'filePanel.workspace.download'}),
@@ -861,10 +872,10 @@ export function Workspace() {
     )
   }
 
-  const renameModalMessage = () => {
+  const renameModalMessage = (workspaceName?: string) => {
     return (
       <>
-        <input type="text" data-id="modalDialogCustomPromptTextRename" defaultValue={currentWorkspace} ref={workspaceRenameInput} className="form-control" />
+        <input type="text" data-id="modalDialogCustomPromptTextRename" defaultValue={workspaceName || currentWorkspace} ref={workspaceRenameInput} className="form-control" />
       </>
     )
   }
@@ -949,7 +960,7 @@ export function Workspace() {
                       tooltipClasses="text-nowrap"
                       tooltipText={<FormattedMessage id="filePanel.saveCodeSample" />}
                     >
-                      <i onClick={() => renameCurrentWorkspace()} className="far fa-exclamation-triangle text-warning ml-2 align-self-center" aria-hidden="true"></i>
+                      <i onClick={() => saveSampleCodeWorkspace()} className="far fa-exclamation-triangle text-warning ml-2 align-self-center" aria-hidden="true"></i>
                     </CustomTooltip>}
                   </span>                  
                 </div>


### PR DESCRIPTION
 - load remix using a url params.
 - this will open the file in the `code-sample` workspace.
 - a warning icon (top of the FE) signigy that the workspace won't be persisted. 
 - click here will rename the workspace to persist the file.
 - reload remix, the `code-sample` workspace should be removed.