### PR TITLE
updated v4-periphery to v4-template in workspaces module

### DIFF
--- a/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
+++ b/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
@@ -382,13 +382,11 @@ module.exports = {
       .execute(function () { (document.querySelector('[data-id="fileSystemModalDialogModalFooter-react"] .modal-ok') as HTMLElement).click() })
       .pause(100)
       .waitForElementVisible('*[data-id="treeViewLitreeViewItemcontracts"]')
-      .openFile('contracts')
-      .openFile('contracts/hooks')
-      .openFile('contracts/hooks/examples')
-      .openFile('contracts/hooks/examples/FullRange.sol')
+      .openFile('src')
+      .openFile('src/Counter.sol')
       .pause(1000)
       .getEditorValue((content) => {
-        browser.assert.ok(content.indexOf(`contract FullRange is BaseHook`) !== -1,
+        browser.assert.ok(content.indexOf(`contract Counter is BaseHook {`) !== -1,
           'Incorrect content')
       })
   }, 

--- a/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
+++ b/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
@@ -381,7 +381,7 @@ module.exports = {
       .waitForElementPresent('[data-id="fileSystemModalDialogModalFooter-react"] .modal-ok')
       .execute(function () { (document.querySelector('[data-id="fileSystemModalDialogModalFooter-react"] .modal-ok') as HTMLElement).click() })
       .pause(100)
-      .waitForElementVisible('*[data-id="treeViewLitreeViewItemcontracts"]')
+      .waitForElementVisible('*[data-id="treeViewLitreeViewItemsrc"]')
       .openFile('src')
       .openFile('src/Counter.sol')
       .pause(1000)

--- a/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
+++ b/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
@@ -386,7 +386,7 @@ module.exports = {
       .openFile('src/Counter.sol')
       .pause(1000)
       .getEditorValue((content) => {
-        browser.assert.ok(content.indexOf(`contract Counter is BaseHook {`) !== -1,
+        browser.assert.ok(content.indexOf(`contract Counter is BaseHook { `) !== -1,
           'Incorrect content')
       })
   }, 

--- a/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
+++ b/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
@@ -370,14 +370,14 @@ module.exports = {
 
    // GIT WORKSPACE E2E STARTS
 
-   'Should create a git workspace (uniswapV4Periphery) #group4': function (browser: NightwatchBrowser) {
+   'Should create a git workspace (uniswapV4Template) #group4': function (browser: NightwatchBrowser) {
     browser
       .click('*[data-id="workspacesMenuDropdown"]')
       .click('*[data-id="workspacecreate"]')
       .waitForElementVisible('*[data-id="modalDialogCustomPromptTextCreate"]')
       .waitForElementVisible('[data-id="fileSystemModalDialogModalFooter-react"] > button')
       .click('select[id="wstemplate"]')
-      .click('select[id="wstemplate"] option[value=uniswapV4Periphery]')
+      .click('select[id="wstemplate"] option[value=uniswapV4Template]')
       .waitForElementPresent('[data-id="fileSystemModalDialogModalFooter-react"] .modal-ok')
       .execute(function () { (document.querySelector('[data-id="fileSystemModalDialogModalFooter-react"] .modal-ok') as HTMLElement).click() })
       .pause(100)

--- a/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
+++ b/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
@@ -386,7 +386,7 @@ module.exports = {
       .openFile('src/Counter.sol')
       .pause(1000)
       .getEditorValue((content) => {
-        browser.assert.ok(content.indexOf(`contract Counter is BaseHook { `) !== -1,
+        browser.assert.ok(content.indexOf(`contract Counter is BaseHook {`) !== -1,
           'Incorrect content')
       })
   }, 

--- a/apps/remix-ide/src/app/tabs/locales/en/filePanel.json
+++ b/apps/remix-ide/src/app/tabs/locales/en/filePanel.json
@@ -113,7 +113,7 @@
   "filePanel.hashchecker": "Hash Checker",
   "filePanel.rln": "Rate-Limiting Nullifier",
   "filePanel.breakthroughLabsUniswapv4Hooks": "Breakthrough-Labs Hooks",
-  "filePanel.uniswapV4Periphery": "v4 Periphery",
+  "filePanel.uniswapV4Template": "v4 Template",
   "filePanel.uniswapV4HookBookMultiSigSwapHook": "HookBook MultiSigSwapHook",
   "filePanel.transparent": "Transparent",
   "filePanel.initGitRepoTitle": "Check option to initialize workspace as a new git repository",

--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -791,8 +791,8 @@ export function Workspace() {
             </option>
           </optgroup>
           <optgroup style={{fontSize: 'medium'}} label="Uniswap V4">
-            <option style={{fontSize: 'small'}} value="uniswapV4Periphery">
-              {intl.formatMessage({id: 'filePanel.uniswapV4Periphery'})}
+            <option style={{fontSize: 'small'}} value="uniswapV4Template">
+              {intl.formatMessage({id: 'filePanel.uniswapV4Template'})}
             </option>
             <option style={{fontSize: 'small'}} value="breakthroughLabsUniswapv4Hooks">
               {intl.formatMessage({id: 'filePanel.breakthroughLabsUniswapv4Hooks'})}

--- a/libs/remix-ui/workspace/src/lib/types/index.ts
+++ b/libs/remix-ui/workspace/src/lib/types/index.ts
@@ -19,7 +19,7 @@ export interface JSONStandardInput {
   }
 }
 export type MenuItems = action[]
-export type WorkspaceTemplate = 'gist-template' | 'code-template' | 'remixDefault' | 'blank' | 'ozerc20' | 'zeroxErc20' | 'ozerc721' | 'playground' | 'semaphore' | 'hashchecker' | 'rln' | 'breakthroughLabsUniswapv4Hooks' | 'uniswapV4Periphery' | 'uniswapV4HookBookMultiSigSwapHook'
+export type WorkspaceTemplate = 'gist-template' | 'code-template' | 'remixDefault' | 'blank' | 'ozerc20' | 'zeroxErc20' | 'ozerc721' | 'playground' | 'semaphore' | 'hashchecker' | 'rln' | 'breakthroughLabsUniswapv4Hooks' | 'uniswapV4Template' | 'uniswapV4HookBookMultiSigSwapHook'
 export interface WorkspaceProps {
   plugin: FilePanelType
 }

--- a/libs/remix-ui/workspace/src/lib/utils/constants.ts
+++ b/libs/remix-ui/workspace/src/lib/utils/constants.ts
@@ -87,7 +87,7 @@ export const TEMPLATE_NAMES = {
   'hashchecker': 'Hash Checker',
   'rln': 'Rate-Limiting Nullifier',
   'breakthroughLabsUniswapv4Hooks': 'Breakthrough-Labs Uniswapv4Hooks',
-  'uniswapV4Periphery': 'Uniswap v4 Periphery',
+  'uniswapV4Template': 'Uniswap v4 Template',
   'uniswapV4HookBookMultiSigSwapHook': 'Uniswap V4 HookBook MultiSigSwapHook',
 }
 
@@ -97,9 +97,9 @@ export const TEMPLATE_METADATA: Record<string, TemplateType> = {
     url: 'https://github.com/Breakthrough-Labs/Uniswapv4Hooks',
     branch: 'foundry_pure'
   },
-  'uniswapV4Periphery': {
+  'uniswapV4Template': {
     type: 'git',
-    url: 'https://github.com/Uniswap/v4-periphery',
+    url: 'https://github.com/Breakthrough-Labs/v4-template',
     branch: 'main'
   },
   'uniswapV4HookBookMultiSigSwapHook': {


### PR DESCRIPTION
Rename v4-periphery to v4-template through out the repo and then change the url in the metadata for the workspace. 