### PR TITLE
Fix gist

### DIFF
--- a/apps/remix-ide-e2e/src/tests/gist.test.ts
+++ b/apps/remix-ide-e2e/src/tests/gist.test.ts
@@ -153,7 +153,7 @@ module.exports = {
         .url('http://127.0.0.1:8080/#gist=' + gistId)
         .refreshPage()
         .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 15000)
-        .waitForElementVisible(`div[data-path='code_sample/gist-${gistId}/README.txt']`)
+        .waitForElementVisible(`div[data-path='code-sample/gist-${gistId}/README.txt']`)
         .openFile(`gist-${gistId}/scripts/deploy_with_ethers.ts`)
         .getEditorValue((content) => {
           browser.assert.ok(content !== '')

--- a/apps/remix-ide-e2e/src/tests/gist.test.ts
+++ b/apps/remix-ide-e2e/src/tests/gist.test.ts
@@ -150,7 +150,7 @@ module.exports = {
     'Load Gist from URL and verify truncated files are loaded #group3': function (browser: NightwatchBrowser) {
       const gistId = '1b179bf1b92c8b0664b4cbe61774e15d'
       browser
-        .url('http://127.0.0.1:8080/#gistid=' + gistId)        
+        .url('http://127.0.0.1:8080/#gist=' + gistId)        
         .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 15000)
         .clickLaunchIcon('filePanel')
         .waitForElementVisible(`div[data-path='default_workspace/gist-${gistId}/README.txt']`)

--- a/apps/remix-ide-e2e/src/tests/gist.test.ts
+++ b/apps/remix-ide-e2e/src/tests/gist.test.ts
@@ -153,7 +153,6 @@ module.exports = {
         .url('http://127.0.0.1:8080/#gist=' + gistId)
         .refreshPage()
         .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 15000)
-        .clickLaunchIcon('filePanel')
         .waitForElementVisible(`div[data-path='default_workspace/gist-${gistId}/README.txt']`)
         .openFile(`gist-${gistId}/scripts/deploy_with_ethers.ts`)
         .getEditorValue((content) => {

--- a/apps/remix-ide-e2e/src/tests/gist.test.ts
+++ b/apps/remix-ide-e2e/src/tests/gist.test.ts
@@ -150,8 +150,9 @@ module.exports = {
     'Load Gist from URL and verify truncated files are loaded #group3': function (browser: NightwatchBrowser) {
       const gistId = '1b179bf1b92c8b0664b4cbe61774e15d'
       browser
-        .url('http://127.0.0.1:8080/#' + gistId)
+        .url('http://127.0.0.1:8080/#' + gistId)        
         .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 15000)
+        .clickLaunchIcon('filePanel')
         .waitForElementVisible(`div[data-path='default_workspace/gist-${gistId}/README.txt']`)
         .openFile(`gist-${gistId}/scripts/deploy_with_ethers.ts`)
         .getEditorValue((content) => {

--- a/apps/remix-ide-e2e/src/tests/gist.test.ts
+++ b/apps/remix-ide-e2e/src/tests/gist.test.ts
@@ -145,6 +145,17 @@ module.exports = {
       .openFile(`gist-${testData.validGistId}/README.txt`)
       .waitForElementVisible(`div[data-path='default_workspace/gist-${testData.validGistId}/README.txt']`)
       .assert.containsText(`div[data-path='default_workspace/gist-${testData.validGistId}/README.txt'] > span`, 'README.txt')
-      .end()
-  }
+    },
+
+    'Load Gist from URL and verify truncated files are loaded #group3': function (browser: NightwatchBrowser) {
+      const gistId = '1b179bf1b92c8b0664b4cbe61774e15d'
+      browser
+        .url('http://127.0.0.1:8080/#' + gistId)
+        .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 15000)
+        .waitForElementVisible(`div[data-path='default_workspace/gist-${gistId}/README.txt']`)
+        .openFile(`gist-${gistId}/scripts/deploy_with_ethers.ts`)
+        .getEditorValue((content) => {
+          browser.assert.ok(content !== '')
+        })
+      }
 }

--- a/apps/remix-ide-e2e/src/tests/gist.test.ts
+++ b/apps/remix-ide-e2e/src/tests/gist.test.ts
@@ -153,7 +153,7 @@ module.exports = {
         .url('http://127.0.0.1:8080/#gist=' + gistId)
         .refreshPage()
         .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 15000)
-        .waitForElementVisible(`div[data-path='default_workspace/gist-${gistId}/README.txt']`)
+        .waitForElementVisible(`div[data-path='code_sample/gist-${gistId}/README.txt']`)
         .openFile(`gist-${gistId}/scripts/deploy_with_ethers.ts`)
         .getEditorValue((content) => {
           browser.assert.ok(content !== '')

--- a/apps/remix-ide-e2e/src/tests/gist.test.ts
+++ b/apps/remix-ide-e2e/src/tests/gist.test.ts
@@ -150,7 +150,7 @@ module.exports = {
     'Load Gist from URL and verify truncated files are loaded #group3': function (browser: NightwatchBrowser) {
       const gistId = '1b179bf1b92c8b0664b4cbe61774e15d'
       browser
-        .url('http://127.0.0.1:8080/#' + gistId)        
+        .url('http://127.0.0.1:8080/#gistid=' + gistId)        
         .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 15000)
         .clickLaunchIcon('filePanel')
         .waitForElementVisible(`div[data-path='default_workspace/gist-${gistId}/README.txt']`)

--- a/apps/remix-ide-e2e/src/tests/gist.test.ts
+++ b/apps/remix-ide-e2e/src/tests/gist.test.ts
@@ -153,7 +153,7 @@ module.exports = {
         .url('http://127.0.0.1:8080/#gist=' + gistId)
         .refreshPage()
         .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 15000)
-        .waitForElementVisible(`div[data-path='code-sample/gist-${gistId}/README.txt']`, 30000)
+        .waitForElementVisible(`#fileExplorerView li[data-path='gist-${gistId}/README.txt']`, 30000)
         .openFile(`gist-${gistId}/scripts/deploy_with_ethers.ts`)
         .getEditorValue((content) => {
           browser.assert.ok(content !== '')

--- a/apps/remix-ide-e2e/src/tests/gist.test.ts
+++ b/apps/remix-ide-e2e/src/tests/gist.test.ts
@@ -150,7 +150,8 @@ module.exports = {
     'Load Gist from URL and verify truncated files are loaded #group3': function (browser: NightwatchBrowser) {
       const gistId = '1b179bf1b92c8b0664b4cbe61774e15d'
       browser
-        .url('http://127.0.0.1:8080/#gist=' + gistId)        
+        .url('http://127.0.0.1:8080/#gist=' + gistId)
+        .refreshPage()
         .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 15000)
         .clickLaunchIcon('filePanel')
         .waitForElementVisible(`div[data-path='default_workspace/gist-${gistId}/README.txt']`)

--- a/apps/remix-ide-e2e/src/tests/gist.test.ts
+++ b/apps/remix-ide-e2e/src/tests/gist.test.ts
@@ -153,7 +153,7 @@ module.exports = {
         .url('http://127.0.0.1:8080/#gist=' + gistId)
         .refreshPage()
         .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 15000)
-        .waitForElementVisible(`div[data-path='code-sample/gist-${gistId}/README.txt']`)
+        .waitForElementVisible(`div[data-path='code-sample/gist-${gistId}/README.txt']`, 30000)
         .openFile(`gist-${gistId}/scripts/deploy_with_ethers.ts`)
         .getEditorValue((content) => {
           browser.assert.ok(content !== '')

--- a/libs/remix-ui/workspace/src/lib/actions/index.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/index.ts
@@ -402,6 +402,7 @@ export const handleClickFile = async (path: string, type: 'file' | 'folder' | 'g
   if (type === 'file' && path.endsWith('.md')) {
     // just opening the preview
     await plugin.call('doc-viewer' as any, 'viewDocs', [path])
+    plugin.call('tabs' as any, 'focus', 'doc-viewer')
   } else {
     await plugin.fileManager.open(path)
     dispatch(focusElement([{ key: path, type }]))

--- a/libs/remix-ui/workspace/src/lib/actions/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/workspace.ts
@@ -314,7 +314,6 @@ export const loadWorkspacePreset = async (template: WorkspaceTemplate = 'remixDe
         if (data.files[element].truncated) {
           const response: AxiosResponse = await axios.get(data.files[element].raw_url)
           value = { content: response.data }
-          console.log(data.files[element], response)
         } else {
           value = { content: data.files[element].content }
         }


### PR DESCRIPTION
Sometimes gist truncates the content of a gist file. The `content` property is empty, in that case we need to fetch the content using the `raw_url`.
This also fix an issue with loading the MD preview.