### PR TITLE
Fix `.sindriignore` file location when adding Sindri ZK scripts

### DIFF
--- a/libs/remix-ws-templates/src/script-templates/sindri/index.ts
+++ b/libs/remix-ws-templates/src/script-templates/sindri/index.ts
@@ -29,7 +29,7 @@ export const sindriScripts = async (plugin: any) => {
 
   // Write out all of the static files if they don't exist.
   // @ts-ignore
-  await writeIfNotExists('scripts/.sindriignore', (await import('!!raw-loader!./.sindriignore')).default)
+  await writeIfNotExists('.sindriignore', (await import('!!raw-loader!./.sindriignore')).default)
   // @ts-ignore
   await writeIfNotExists('scripts/sindri/README.md', (await import('!!raw-loader!./README.md')).default)
   // @ts-ignore


### PR DESCRIPTION
@yann300 This is a one-line bug fix for #4527. The `.sindriignore` file was being added in the `scripts` directory when it should instead be in the root directory.