### PR TITLE
Preserve whitespace when loading a JSON file through a `url` querystring parameter

### DIFF
--- a/libs/remix-ui/workspace/src/lib/actions/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/workspace.ts
@@ -298,7 +298,9 @@ export const loadWorkspacePreset = async (template: WorkspaceTemplate = 'remixDe
             }
             return Object.keys(standardInput.sources)[0]
           } else {
-            await workspaceProvider.set(path, JSON.stringify(content))
+            // preserve JSON whitepsace if this isn't a Solidity compiler output file
+            content = data.content
+            await workspaceProvider.set(path, content)
           }
         } catch (e) {
           console.log(e)

--- a/libs/remix-ui/workspace/src/lib/actions/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/workspace.ts
@@ -298,7 +298,7 @@ export const loadWorkspacePreset = async (template: WorkspaceTemplate = 'remixDe
             }
             return Object.keys(standardInput.sources)[0]
           } else {
-            // preserve JSON whitepsace if this isn't a Solidity compiler output file
+            // preserve JSON whitepsace if this isn't a Solidity compiler JSON-input-output file
             content = data.content
             await workspaceProvider.set(path, content)
           }


### PR DESCRIPTION
When specifying a JSON file using a `url` querystring parameter, all whitespace is stripped from the file because the JSON is first parsed and then reserialized with `JSON.stringify(content)` if the content is not a Solidity compiler JSON-input-output file. If the purpose of the link is to open a human-readable JSON file in the editor, then removing the whitespace makes the file significantly less readable. This PR updates the logic to preserve the original formatting of the JSON file.

An example of the current behavior is [opening a Sindri Manifest file in the editor](https://remix.ethereum.org/#url=https://github.com/Sindri-Labs/sindri-resources/blob/36dd551c4be6546b0a7c4a79a71ef4adc8e38e10/circuit_tutorials/gnark/v0.9.0/compress/circuit/sindri.json).