### PR TITLE
Fix estimateGas being not accurate

### DIFF
--- a/libs/remix-lib/src/execution/txRunnerVM.ts
+++ b/libs/remix-lib/src/execution/txRunnerVM.ts
@@ -140,9 +140,9 @@ export class TxRunnerVM {
           callback(err, result)
         })
       } else {
-        await this.getVMObject().vm.evm.journal.checkpoint()
-        this.runTxInVm(tx, block, async (err, result) => {
-          await this.getVMObject().vm.evm.journal.revert()
+        const root = await this.getVMObject().stateManager.getStateRoot()
+        this.runBlockInVm(tx, block, async (err, result) => {
+          await this.getVMObject().stateManager.setStateRoot(root)
           callback(err, result)
         })
       }


### PR DESCRIPTION
using runTxInVm for the gas estimation isn't accurate because it doesn't take in account block.number, block.timestamp, etc...
to test, run:
```
contract test {
 uint number;
 function set() public {
   number = block.timestamp;
 }
}
```

The fix make the estimateGas to also use `runBlockinVm`, and implement a way to rollback the state proposed by ethereumjs team.