### PR TITLE
fallback for webdriver

### DIFF
--- a/apps/remix-ide-e2e/install-webdriver.sh
+++ b/apps/remix-ide-e2e/install-webdriver.sh
@@ -39,4 +39,4 @@ fi
 
 
 yarn init -y --cwd "$directory" || exit 1
-yarn add -D chromedriver@$MAJORVERSION geckodriver --cwd  "$directory" ||  yarn add -D chromedriver@$MAJORVERSION geckodriver --cwd  "$directory" || exit 1
+yarn add -D chromedriver@$MAJORVERSION geckodriver --cwd  "$directory" ||  yarn add -D chromedriver@$MAJORVERSION geckodriver --cwd  "$directory" || yarn add -D chromedriver geckodriver --cwd  "$directory" || exit 1


### PR DESCRIPTION
installs the latest chromedriver if the chrome on the host is not available on npm. it can happen the browser is newer than the version published on npm.... :(