### PR TITLE
Pull from a github folder

### DIFF
--- a/apps/remix-ide-e2e/src/tests/url.test.ts
+++ b/apps/remix-ide-e2e/src/tests/url.test.ts
@@ -342,9 +342,10 @@ module.exports = {
     browser
       .url('http://127.0.0.1:8080/#ghfolder=https://github.com/ethereum/remix-project/tree/master/apps/remix-ide/contracts/hardhat')
       .refreshPage()
+      .waitForElementVisible('*[data-id="treeViewLitreeViewItemcontracts"]', 40000)
       .currentWorkspaceIs('code-sample')
       .openFile('contracts')
-      .openFile('Lock.sol')
+      .openFile('contracts/Lock.sol')
       .getEditorValue((content) => {
         browser.assert.ok(content.indexOf('contract Lock {') !== -1, 'content does contain "contract Lock {"')
       })      

--- a/apps/remix-ide-e2e/src/tests/url.test.ts
+++ b/apps/remix-ide-e2e/src/tests/url.test.ts
@@ -336,5 +336,17 @@ module.exports = {
       .waitForElementVisible('*[data-shared="tooltipPopup"]')
       .waitForElementContainsText('*[data-shared="tooltipPopup"]', 'initiating fileManager and calling "open" ...')
       .waitForElementContainsText('*[data-shared="tooltipPopup"]', 'initiating terminal and calling "log" ...')
+  },
+
+  'Import Github folder from URL params #group4': function (browser: NightwatchBrowser) {
+    browser
+      .url('http://127.0.0.1:8080/#ghfolder=https://github.com/ethereum/remix-project/tree/master/apps/remix-ide/contracts/hardhat')
+      .refreshPage()
+      .currentWorkspaceIs('code-sample')
+      .openFile('contracts')
+      .openFile('Lock.sol')
+      .getEditorValue((content) => {
+        browser.assert.ok(content.indexOf('contract Lock {') !== -1, 'content does contain "contract Lock {"')
+      })      
   }
 }

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -1,12 +1,12 @@
 'use strict'
 import { Plugin } from '@remixproject/engine'
-import { RemixURLResolver } from '@remix-project/remix-url-resolver'
+import { RemixURLResolver, githubFolderResolver } from '@remix-project/remix-url-resolver'
 
 const profile = {
   name: 'contentImport',
   displayName: 'content import',
   version: '0.0.1',
-  methods: ['resolve', 'resolveAndSave', 'isExternalUrl']
+  methods: ['resolve', 'resolveAndSave', 'isExternalUrl', 'resolveGithubFolder']
 }
 
 export type ResolvedImport = {
@@ -211,5 +211,12 @@ export class CompilerImports extends Plugin {
     } catch (e) {
       throw new Error(e)
     }
+  }
+
+  async resolveGithubFolder (url) {
+    const ghFolder = {}
+    const token = await this.call('settings', 'get', 'settings/gist-access-token')
+    await githubFolderResolver(url, ghFolder, token)
+    return ghFolder
   }
 }

--- a/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-content-imports.ts
@@ -215,8 +215,7 @@ export class CompilerImports extends Plugin {
 
   async resolveGithubFolder (url) {
     const ghFolder = {}
-    const token = await this.call('settings', 'get', 'settings/gist-access-token')
-    await githubFolderResolver(url, ghFolder, token)
+    await githubFolderResolver(url, ghFolder, 3)
     return ghFolder
   }
 }

--- a/libs/remix-ui/workspace/src/lib/actions/index.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/index.ts
@@ -29,6 +29,7 @@ export type UrlParametersType = {
   address: string
   opendir: string,
   blockscout: string,
+  ghfolder: string
 }
 
 const basicWorkspaceInit = async (workspaces: { name: string; isGitRepo: boolean; }[], workspaceProvider) => {
@@ -80,7 +81,7 @@ export const initWorkspace = (filePanelPlugin) => async (reducerDispatch: React.
       plugin.setWorkspace({ name, isLocalhost: false })
       dispatch(setCurrentWorkspace({ name, isGitRepo: false }))
       await loadWorkspacePreset('gist-template')
-    } else if (params.code || params.url || params.shareCode) {
+    } else if (params.code || params.url || params.shareCode || params.ghfolder) {
       await createWorkspaceTemplate('code-sample', 'code-template')
       plugin.setWorkspace({ name: 'code-sample', isLocalhost: false })
       dispatch(setCurrentWorkspace({ name: 'code-sample', isGitRepo: false }))

--- a/libs/remix-ui/workspace/src/lib/actions/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/workspace.ts
@@ -309,11 +309,11 @@ export const loadWorkspacePreset = async (template: WorkspaceTemplate = 'remixDe
       if (params.ghfolder) {
         const files = await plugin.call('contentImport', 'resolveGithubFolder', params.ghfolder)
         console.log(files)
-        for (const [path, content] of  Object.entries(files)) {
+        for (const [path, content] of Object.entries(files)) {
           await workspaceProvider.set(path, content)
         }
-      }       
-      
+      }
+
       return path
     } catch (e) {
       console.error(e)

--- a/libs/remix-ui/workspace/src/lib/actions/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/workspace.ts
@@ -307,10 +307,13 @@ export const loadWorkspacePreset = async (template: WorkspaceTemplate = 'remixDe
         }
       }
       if (params.ghfolder) {
-        const files = await plugin.call('contentImport', 'resolveGithubFolder', params.ghfolder)
-        console.log(files)
-        for (const [path, content] of Object.entries(files)) {
-          await workspaceProvider.set(path, content)
+        try {
+          const files = await plugin.call('contentImport', 'resolveGithubFolder', params.ghfolder)
+          for (const [path, content] of Object.entries(files)) {
+            await workspaceProvider.set(path, content)
+          }
+        } catch (e) {
+          console.log(e)
         }
       }
 

--- a/libs/remix-ui/workspace/src/lib/actions/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/workspace.ts
@@ -285,35 +285,35 @@ export const loadWorkspacePreset = async (template: WorkspaceTemplate = 'remixDe
         await workspaceProvider.set(path, content)
       }
       if (params.url) {
-        if (params.ghfolder === 'true') {
-          const files = await plugin.call('contentImport', 'resolveGithubFolder', params.url)
-          console.log(files)
-          for (const [path, content] of  Object.entries(files)) {
-            await workspaceProvider.set(path, content)
-          }
-        } else {
-          const data = await plugin.call('contentImport', 'resolve', params.url)
-          path = data.cleanUrl
-          content = data.content
-          try {
-            content = JSON.parse(content) as any
-            if (content.language && content.language === 'Solidity' && content.sources) {
-              const standardInput: JSONStandardInput = content as JSONStandardInput
-              for (const [fname, source] of Object.entries(standardInput.sources)) {
-                await workspaceProvider.set(fname, source.content)
-              }
-              return Object.keys(standardInput.sources)[0]
-            } else {
-              // preserve JSON whitespace if this isn't a Solidity compiler JSON-input-output file
-              content = data.content
-              await workspaceProvider.set(path, content)
+        const data = await plugin.call('contentImport', 'resolve', params.url)
+        path = data.cleanUrl
+        content = data.content
+        try {
+          content = JSON.parse(content) as any
+          if (content.language && content.language === 'Solidity' && content.sources) {
+            const standardInput: JSONStandardInput = content as JSONStandardInput
+            for (const [fname, source] of Object.entries(standardInput.sources)) {
+              await workspaceProvider.set(fname, source.content)
             }
-          } catch (e) {
-            console.log(e)
+            return Object.keys(standardInput.sources)[0]
+          } else {
+            // preserve JSON whitespace if this isn't a Solidity compiler JSON-input-output file
+            content = data.content
             await workspaceProvider.set(path, content)
           }
-        }        
+        } catch (e) {
+          console.log(e)
+          await workspaceProvider.set(path, content)
+        }
       }
+      if (params.ghfolder) {
+        const files = await plugin.call('contentImport', 'resolveGithubFolder', params.ghfolder)
+        console.log(files)
+        for (const [path, content] of  Object.entries(files)) {
+          await workspaceProvider.set(path, content)
+        }
+      }       
+      
       return path
     } catch (e) {
       console.error(e)

--- a/libs/remix-ui/workspace/src/lib/actions/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/workspace.ts
@@ -238,6 +238,7 @@ export type UrlParametersType = {
   shareCode: string
   url: string
   language: string
+  ghfolder: string
 }
 
 export const loadWorkspacePreset = async (template: WorkspaceTemplate = 'remixDefault', opts?) => {
@@ -284,28 +285,34 @@ export const loadWorkspacePreset = async (template: WorkspaceTemplate = 'remixDe
         await workspaceProvider.set(path, content)
       }
       if (params.url) {
-        const data = await plugin.call('contentImport', 'resolve', params.url)
-
-        path = data.cleanUrl
-        content = data.content
-
-        try {
-          content = JSON.parse(content) as any
-          if (content.language && content.language === 'Solidity' && content.sources) {
-            const standardInput: JSONStandardInput = content as JSONStandardInput
-            for (const [fname, source] of Object.entries(standardInput.sources)) {
-              await workspaceProvider.set(fname, source.content)
-            }
-            return Object.keys(standardInput.sources)[0]
-          } else {
-            // preserve JSON whitespace if this isn't a Solidity compiler JSON-input-output file
-            content = data.content
+        if (params.ghfolder === 'true') {
+          const files = await plugin.call('contentImport', 'resolveGithubFolder', params.url)
+          console.log(files)
+          for (const [path, content] of  Object.entries(files)) {
             await workspaceProvider.set(path, content)
           }
-        } catch (e) {
-          console.log(e)
-          await workspaceProvider.set(path, content)
-        }
+        } else {
+          const data = await plugin.call('contentImport', 'resolve', params.url)
+          path = data.cleanUrl
+          content = data.content
+          try {
+            content = JSON.parse(content) as any
+            if (content.language && content.language === 'Solidity' && content.sources) {
+              const standardInput: JSONStandardInput = content as JSONStandardInput
+              for (const [fname, source] of Object.entries(standardInput.sources)) {
+                await workspaceProvider.set(fname, source.content)
+              }
+              return Object.keys(standardInput.sources)[0]
+            } else {
+              // preserve JSON whitespace if this isn't a Solidity compiler JSON-input-output file
+              content = data.content
+              await workspaceProvider.set(path, content)
+            }
+          } catch (e) {
+            console.log(e)
+            await workspaceProvider.set(path, content)
+          }
+        }        
       }
       return path
     } catch (e) {

--- a/libs/remix-url-resolver/src/github-folder-resolver.ts
+++ b/libs/remix-url-resolver/src/github-folder-resolver.ts
@@ -1,6 +1,23 @@
 // eslint-disable-next-line no-unused-vars
 import axios, { AxiosResponse } from 'axios'
 
+export type GithubItem = {
+  name: string
+  path: string
+  sha: string
+  size: number
+  url: string
+  html_url: string
+  git_url: string
+  download_url: string | null
+  type: 'dir' | 'file'
+  _links: {
+    self: string
+    git: string
+    html: string
+  }
+}
+
 export const githubFolderResolver = async (url, obj = {}, maxDepth, depth?, rootPath?) => {
   depth = depth ? depth : 0
   const child = await pullFolder(url)
@@ -10,9 +27,11 @@ export const githubFolderResolver = async (url, obj = {}, maxDepth, depth?, root
   const pathParts = pathname.split('/');
   const folderPath = pathParts.slice(5).join('/');
   rootPath = rootPath || folderPath
+
+  if (!Array.isArray(child)) return obj
   for (const item of child) {
     if (item.type === 'file') {
-      const response: AxiosResponse = await axios.get(item.download_url, { transformResponse: res => res })
+      const response: AxiosResponse = await axios.get(item.download_url)
       obj[item.path.replace(rootPath, '')] = response.data
     } else if (maxDepth > depth) {
       // dir
@@ -24,7 +43,7 @@ export const githubFolderResolver = async (url, obj = {}, maxDepth, depth?, root
 
 const pullFolder = async (url) => {
   const response = await axios.get('https://ghfolderpull.remixproject.org', { params: { ghfolder: url } });
-  const data = await response.data;
+  const data: Array<GithubItem> = await response.data;
   return data
 }
 

--- a/libs/remix-url-resolver/src/github-folder-resolver.ts
+++ b/libs/remix-url-resolver/src/github-folder-resolver.ts
@@ -1,35 +1,29 @@
 // eslint-disable-next-line no-unused-vars
 import axios, { AxiosResponse } from 'axios'
 
-export const githubFolderResolver = async (url, obj = {}, token) => {
-  const child = await pullFolder(url, token)
+export const githubFolderResolver = async (url, obj = {}, maxDepth, depth?, rootPath?) => {
+  depth = depth ? depth : 0
+  const child = await pullFolder(url)
+  depth = depth++
+  const urlObj = new URL(url);
+  const pathname = urlObj.pathname;
+  const pathParts = pathname.split('/');
+  const folderPath = pathParts.slice(5).join('/');
+  rootPath =  rootPath || folderPath
   for (const item of child) {
-    console.log(item)
     if (item.type === 'file') {
       const response: AxiosResponse = await axios.get(item.download_url, { transformResponse: res => res })
-      obj[item.path] = response.data
-    } else {
+      obj[item.path.replace(rootPath, '')] = response.data
+    } else if (maxDepth > depth) {
       // dir
-      await githubFolderResolver(item.html_url, obj, token)
+      await githubFolderResolver(item.html_url, obj, maxDepth, depth, rootPath)
     }
   }
   return obj
 }
 
-const pullFolder = async (url, token) => {
-  url = new URL(url);
-  const pathname = url.pathname;
-  const pathParts = pathname.split('/');
-  const username = pathParts[1];
-  const repo = pathParts[2];
-  const folderPath = pathParts.slice(5).join('/');
-  const apiUrl = `https://api.github.com/repos/${username}/${repo}/contents/${folderPath}`;
-  const response = await axios.get(apiUrl,
-    { 
-      headers: {
-        Authorization: `Bearer ${token}`
-      } 
-    });
+const pullFolder = async (url) => {
+  const response = await axios.get('https://ghfolderpull.remixproject.org', { params: { ghfolder: url } });
   const data = await response.data;
   return data
 }

--- a/libs/remix-url-resolver/src/github-folder-resolver.ts
+++ b/libs/remix-url-resolver/src/github-folder-resolver.ts
@@ -9,7 +9,7 @@ export const githubFolderResolver = async (url, obj = {}, maxDepth, depth?, root
   const pathname = urlObj.pathname;
   const pathParts = pathname.split('/');
   const folderPath = pathParts.slice(5).join('/');
-  rootPath =  rootPath || folderPath
+  rootPath = rootPath || folderPath
   for (const item of child) {
     if (item.type === 'file') {
       const response: AxiosResponse = await axios.get(item.download_url, { transformResponse: res => res })

--- a/libs/remix-url-resolver/src/github-folder-resolver.ts
+++ b/libs/remix-url-resolver/src/github-folder-resolver.ts
@@ -17,20 +17,20 @@ export const githubFolderResolver = async (url, obj = {}, token) => {
 }
 
 const pullFolder = async (url, token) => {
-    url = new URL(url);
-    const pathname = url.pathname;
-    const pathParts = pathname.split('/');
-    const username = pathParts[1];
-    const repo = pathParts[2];
-    const folderPath = pathParts.slice(5).join('/');
-    const apiUrl = `https://api.github.com/repos/${username}/${repo}/contents/${folderPath}`;
-    const response = await axios.get(apiUrl,
-      { 
-        headers: {
-          Authorization: `Bearer ${token}`
-        } 
-      });
-    const data = await response.data;
-    return data 
+  url = new URL(url);
+  const pathname = url.pathname;
+  const pathParts = pathname.split('/');
+  const username = pathParts[1];
+  const repo = pathParts[2];
+  const folderPath = pathParts.slice(5).join('/');
+  const apiUrl = `https://api.github.com/repos/${username}/${repo}/contents/${folderPath}`;
+  const response = await axios.get(apiUrl,
+    { 
+      headers: {
+        Authorization: `Bearer ${token}`
+      } 
+    });
+  const data = await response.data;
+  return data
 }
 

--- a/libs/remix-url-resolver/src/github-folder-resolver.ts
+++ b/libs/remix-url-resolver/src/github-folder-resolver.ts
@@ -1,0 +1,36 @@
+// eslint-disable-next-line no-unused-vars
+import axios, { AxiosResponse } from 'axios'
+
+export const githubFolderResolver = async (url, obj = {}, token) => {
+  const child = await pullFolder(url, token)
+  for (const item of child) {
+    console.log(item)
+    if (item.type === 'file') {
+      const response: AxiosResponse = await axios.get(item.download_url, { transformResponse: res => res })
+      obj[item.path] = response.data
+    } else {
+      // dir
+      await githubFolderResolver(item.html_url, obj, token)
+    }
+  }
+  return obj
+}
+
+const pullFolder = async (url, token) => {
+    url = new URL(url);
+    const pathname = url.pathname;
+    const pathParts = pathname.split('/');
+    const username = pathParts[1];
+    const repo = pathParts[2];
+    const folderPath = pathParts.slice(5).join('/');
+    const apiUrl = `https://api.github.com/repos/${username}/${repo}/contents/${folderPath}`;
+    const response = await axios.get(apiUrl,
+      { 
+        headers: {
+          Authorization: `Bearer ${token}`
+        } 
+      });
+    const data = await response.data;
+    return data 
+}
+

--- a/libs/remix-url-resolver/src/index.ts
+++ b/libs/remix-url-resolver/src/index.ts
@@ -1,1 +1,2 @@
 export { RemixURLResolver } from './resolve'
+export { githubFolderResolver } from './github-folder-resolver'


### PR DESCRIPTION
fix https://github.com/ethereum/remix-project/issues/4345

Some issues still remains:
 -  ~~it still need a gh token otherwise it quickly reach the api rate limit.~~
 - ~~it actually add the current folder in remix. eg for https://github.com/yann300/ethereumjs-vm/tree/master/examples , it creates the `examples` folder.~~
 - ~~it puts everything under the `code-sample` workspace.~~ => not an issue as it seems

You may try by adding the url param `ghfolder=https://github.com/ethereum/remix-project/tree/master/apps/remix-ide/contracts/hardhat` 