### PR TITLE
add toml syntax highlighting for monaco

### DIFF
--- a/apps/remix-ide/src/app/editor/editor.js
+++ b/apps/remix-ide/src/app/editor/editor.js
@@ -53,7 +53,8 @@ class Editor extends Plugin {
       ts: 'typescript',
       move: 'move',
       circom: 'circom',
-      nr: 'rust'
+      nr: 'rust',
+      toml: 'toml'
     }
 
     this.activated = false

--- a/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
+++ b/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
@@ -9,6 +9,7 @@ import { solidityTokensProvider, solidityLanguageConfig } from './syntaxes/solid
 import { cairoTokensProvider, cairoLanguageConfig } from './syntaxes/cairo'
 import { zokratesTokensProvider, zokratesLanguageConfig } from './syntaxes/zokrates'
 import { moveTokenProvider, moveLanguageConfig } from './syntaxes/move'
+import { tomlLanguageConfig, tomlTokenProvider } from './syntaxes/toml'
 import { monacoTypes } from '@remix-ui/editor'
 import { loadTypes } from './web-types'
 import { retrieveNodesAtPosition } from './helpers/retrieveNodesAtPosition'
@@ -344,6 +345,8 @@ export const EditorUI = (props: EditorUIProps) => {
       monacoRef.current.editor.setModelLanguage(file.model, 'remix-move')
     } else if (file.language === 'circom') {
       monacoRef.current.editor.setModelLanguage(file.model, 'remix-circom')
+    } else if (file.language === 'toml') {
+      monacoRef.current.editor.setModelLanguage(file.model, 'remix-toml')
     }
   }, [props.currentFile])
 
@@ -888,6 +891,7 @@ export const EditorUI = (props: EditorUIProps) => {
     monacoRef.current.languages.register({ id: 'remix-zokrates' })
     monacoRef.current.languages.register({ id: 'remix-move' })
     monacoRef.current.languages.register({ id: 'remix-circom' })
+    monacoRef.current.languages.register({ id: 'remix-toml' })
 
     // Allow JSON schema requests
     monacoRef.current.languages.json.jsonDefaults.setDiagnosticsOptions({ enableSchemaRequest: true })
@@ -907,6 +911,9 @@ export const EditorUI = (props: EditorUIProps) => {
 
     monacoRef.current.languages.setMonarchTokensProvider('remix-circom', circomTokensProvider as any)
     monacoRef.current.languages.setLanguageConfiguration('remix-circom', circomLanguageConfig(monacoRef.current) as any)
+
+    monacoRef.current.languages.setMonarchTokensProvider('remix-toml', tomlTokenProvider as any)
+    monacoRef.current.languages.setLanguageConfiguration('remix-toml', tomlLanguageConfig as any)
 
     monacoRef.current.languages.registerDefinitionProvider('remix-solidity', new RemixDefinitionProvider(props, monaco))
     monacoRef.current.languages.registerDocumentHighlightProvider('remix-solidity', new RemixHighLightProvider(props, monaco))

--- a/libs/remix-ui/editor/src/lib/syntaxes/toml.ts
+++ b/libs/remix-ui/editor/src/lib/syntaxes/toml.ts
@@ -1,0 +1,62 @@
+/* eslint-disable no-useless-escape */
+export const tomlLanguageConfig = {
+  comments: {
+    lineComment: "#",
+  },
+  brackets: [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+  ],
+  autoClosingPairs: [
+    { open: "{", close: "}" },
+    { open: "[", close: "]" },
+    { open: "(", close: ")" },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+  ],
+  surroundingPairs: [
+    { open: "{", close: "}" },
+    { open: "[", close: "]" },
+    { open: "(", close: ")" },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+  ],
+}
+
+export const tomlTokenProvider = {
+  defaultToken: "",
+  tokenPostfix: ".toml",
+
+  escapes:
+    /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+
+  tokenizer: {
+    root: [
+      [/([a-zA-Z0-9_-]+)(\s*)(=)/, ["variable.name", "operators", ""]],
+      [/\[[a-zA-Z0-9_.-]+\]/, "type.identifier"],
+      [/\s*((#).*)$/, "comment"],
+
+      [/\d*\.\d+([eE][\-+]?\d+)?/, "number.float"],
+      [/0[xX][0-9a-fA-F]+/, "number.hex"],
+      [/\d+/, "number"],
+
+      [/"([^"\\]|\\.)*$/, "string.invalid"],
+      [/'([^'\\]|\\.)*$/, "string.invalid"],
+      [/"/, "string", "@string_double"],
+      [/'/, "string", "@string_single"],
+    ],
+    string_double: [
+      [/[^\\"]+/, "string"],
+      [/@escapes/, "string.escape"],
+      [/\\./, "string.escape.invalid"],
+      [/"/, "string", "@pop"],
+    ],
+    string_single: [
+      [/[^\\']+/, "string"],
+      [/@escapes/, "string.escape"],
+      [/\\./, "string.escape.invalid"],
+      [/'/, "string", "@pop"],
+    ],
+  },
+}


### PR DESCRIPTION
Hello,
I'm developing [CODE BY WELLDONE STUDIO plugin](https://docs.welldonestudio.io/code/getting-started) for multi-chain development.
I added TOML syntax highlighting to Monaco for the Move language-based chain.


![toml](https://github.com/ethereum/remix-project/assets/110001241/3688e900-916d-481c-9ffa-4dc76f6b2db3)
