### PR TITLE
Insert function documentation in editor

### DIFF
--- a/apps/remix-ide/src/app/plugins/solcoderAI.tsx
+++ b/apps/remix-ide/src/app/plugins/solcoderAI.tsx
@@ -50,7 +50,7 @@ export class SolCoder extends Plugin {
   pushChatHistory(prompt, result){
     const chat:ChatEntry = [prompt, result.data[0]]
     this.solgpt_chat_history.push(chat)
-    if (this.solgpt_chat_history.length >this.max_history){this.solgpt_chat_history.shift()}
+    if (this.solgpt_chat_history.length > this.max_history){this.solgpt_chat_history.shift()}
   }
 
   async code_generation(prompt): Promise<any> {

--- a/apps/remix-ide/src/app/plugins/solcoderAI.tsx
+++ b/apps/remix-ide/src/app/plugins/solcoderAI.tsx
@@ -47,6 +47,12 @@ export class SolCoder extends Plugin {
     this.solgpt_chat_history = []
   }
 
+  pushChatHistory(prompt, result){
+    const chat:ChatEntry = [prompt, result.data[0]]
+    this.solgpt_chat_history.push(chat)
+    if (this.solgpt_chat_history.length >this.max_history){this.solgpt_chat_history.shift()}
+  }
+
   async code_generation(prompt): Promise<any> {
     this.emit("aiInfering")
     this.call('layout', 'maximizeTerminal')
@@ -105,9 +111,7 @@ export class SolCoder extends Plugin {
     }
     if (result) {
       this.call('terminal', 'log', { type: 'aitypewriterwarning', value: result.data[0] })
-      const chat:ChatEntry = [prompt, result.data[0]]
-      this.solgpt_chat_history.push(chat)
-      if (this.solgpt_chat_history.length >this.max_history){this.solgpt_chat_history.shift()}
+      this.pushChatHistory(prompt, result)
     } else if (result.error) {
       this.call('terminal', 'log', { type: 'aitypewriterwarning', value: "Error on request" })
     }
@@ -134,6 +138,7 @@ export class SolCoder extends Plugin {
       ).json()
       if (result) {
         this.call('terminal', 'log', { type: 'aitypewriterwarning', value: result.data[0] })
+        this.pushChatHistory(prompt, result)
       }
       return result.data[0]
     } catch (e) {
@@ -250,6 +255,7 @@ export class SolCoder extends Plugin {
       ).json()
       if (result) {
         this.call('terminal', 'log', { type: 'aitypewriterwarning', value: result.data[0] })
+        this.pushChatHistory(prompt, result)
       }
       return result.data[0]
     } catch (e) {

--- a/apps/remix-ide/src/app/tabs/locales/en/editor.json
+++ b/apps/remix-ide/src/app/tabs/locales/en/editor.json
@@ -21,7 +21,7 @@
   "editor.formatCode": "Format Code",
   "editor.generateDocumentation": "Generate documentation for this function",
   "editor.generateDocumentation2": "Generate documentation for the function \"{name}\"",
-  "editor.generateDocumentationByAI": "solidity code: {content}\n Generate the documentation for the function {currentFunction} using the Doxygen style syntax",
+  "editor.generateDocumentationByAI": "solidity code: {content}\n Generate the natspec documentation for the function {currentFunction} using the Doxygen style syntax",
   "editor.explainFunction": "Explain this function",
   "editor.explainFunctionSol": "Explain this code",
   "editor.explainFunction2": "Explain the function \"{name}\"",

--- a/apps/remix-ide/src/app/tabs/locales/en/editor.json
+++ b/apps/remix-ide/src/app/tabs/locales/en/editor.json
@@ -21,7 +21,7 @@
   "editor.formatCode": "Format Code",
   "editor.generateDocumentation": "Generate documentation for this function",
   "editor.generateDocumentation2": "Generate documentation for the function \"{name}\"",
-  "editor.generateDocumentationByAI": "solidity code: {content}\n Generate the natspec documentation for the function {currentFunction} using the Doxygen style syntax",
+  "editor.generateDocumentationByAI": "solidity code: {content}\n Generate the natspec documentation for the function {currentFunction} using the docstring style syntax. Only use docstring supported tags",
   "editor.explainFunction": "Explain this function",
   "editor.explainFunctionSol": "Explain this code",
   "editor.explainFunction2": "Explain the function \"{name}\"",

--- a/libs/remix-ui/editor/src/lib/providers/documentationProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/documentationProvider.ts
@@ -14,8 +14,6 @@ export class RemixSolidityDocumentationProvider implements monacoTypes.languages
     const item: monacoTypes.languages.InlineCompletion = {
       insertText: this.completion
     };
-    console.log("provided docu completion")
-
     return {
       items: [item],
       enableForwardStability: true

--- a/libs/remix-ui/editor/src/lib/providers/documentationProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/documentationProvider.ts
@@ -1,0 +1,34 @@
+/* eslint-disable no-control-regex */
+import { EditorUIProps, monacoTypes } from '@remix-ui/editor';
+
+export class RemixSolidityDocumentationProvider implements monacoTypes.languages.InlineCompletionsProvider{
+  props:EditorUIProps
+  monaco:any
+  completion:string
+
+  constructor(completion: any){
+    this.completion = completion
+  }
+
+  async provideInlineCompletions(model: monacoTypes.editor.ITextModel, position: monacoTypes.Position, context: monacoTypes.languages.InlineCompletionContext, token: monacoTypes.CancellationToken): Promise<monacoTypes.languages.InlineCompletions<monacoTypes.languages.InlineCompletion>> {
+    const item: monacoTypes.languages.InlineCompletion = {
+      insertText: this.completion
+    };
+    console.log("provided docu completion")
+
+    return {
+      items: [item],
+      enableForwardStability: true
+    }
+  }
+
+  handleItemDidShow?(completions: monacoTypes.languages.InlineCompletions<monacoTypes.languages.InlineCompletion>, item: monacoTypes.languages.InlineCompletion, updatedInsertText: string): void {
+
+  }
+  handlePartialAccept?(completions: monacoTypes.languages.InlineCompletions<monacoTypes.languages.InlineCompletion>, item: monacoTypes.languages.InlineCompletion, acceptedCharacters: number): void {
+
+  }
+  freeInlineCompletions(completions: monacoTypes.languages.InlineCompletions<monacoTypes.languages.InlineCompletion>): void {
+
+  }
+}

--- a/libs/remix-ui/editor/src/lib/providers/documentationProvider.ts
+++ b/libs/remix-ui/editor/src/lib/providers/documentationProvider.ts
@@ -31,4 +31,9 @@ export class RemixSolidityDocumentationProvider implements monacoTypes.languages
   freeInlineCompletions(completions: monacoTypes.languages.InlineCompletions<monacoTypes.languages.InlineCompletion>): void {
 
   }
+  groupId?: string;
+  yieldsToGroupIds?: string[];
+  toString?(): string {
+    throw new Error('Method not implemented.');
+  }
 }

--- a/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
+++ b/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
@@ -739,12 +739,12 @@ export const EditorUI = (props: EditorUIProps) => {
         const message = intl.formatMessage({ id: 'editor.generateDocumentationByAI' }, { content, currentFunction: currentFunction.current })
         const cm = await props.plugin.call('solcoder', 'code_explaining', message)
 
-        const natspecCom = "\n" + extractNatspecComments(cm)
+        const natSpecCom = "\n" + extractNatspecComments(cm)
         const cln = await props.plugin.call('codeParser', "getLineColumnOfNode", currenFunctionNode)
         const range = new monacoRef.current.Range(cln.start.line, cln.start.column, cln.start.line, cln.start.column)
 
-        const lines = natspecCom.split('\n')
-        const newnatspeccom = []
+        const lines = natSpecCom.split('\n')
+        const newNatSpecCom = []
 
         for (let i = 0; i < lines.length; i++) {
           let cont = false
@@ -757,8 +757,8 @@ export const EditorUI = (props: EditorUIProps) => {
           }
           if (cont) {continue}
 
-          if (i <= 1) { newnatspeccom.push(' '.repeat(cln.start.column) + lines[i].trimStart()) }
-          else { newnatspeccom.push(' '.repeat(cln.start.column + 1) + lines[i].trimStart()) }
+          if (i <= 1) { newNatSpecCom.push(' '.repeat(cln.start.column) + lines[i].trimStart()) }
+          else { newNatSpecCom.push(' '.repeat(cln.start.column + 1) + lines[i].trimStart()) }
         }
 
         // TODO: activate the provider to let the user accept the documentation suggestion
@@ -768,7 +768,7 @@ export const EditorUI = (props: EditorUIProps) => {
         editor.executeEdits('clipboard', [
           {
             range: range,
-            text: newnatspeccom.join('\n'),
+            text: newNatSpecCom.join('\n'),
             forceMoveMarkers: true,
           },
         ]);

--- a/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
+++ b/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
@@ -744,7 +744,7 @@ export const EditorUI = (props: EditorUIProps) => {
         const range = new monacoRef.current.Range(cln.start.line, cln.start.column, cln.start.line, cln.start.column)
 
         const lines = natspecCom.split('\n')
-        const newnatspeccom = [] //natspecCom.split('\n').map((line => ' '.repeat(cln.start.column) + line.trimStart())).join('\n')
+        const newnatspeccom = []
 
         for (let i = 0; i < lines.length; i++) {
           let cont = false

--- a/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
+++ b/libs/remix-ui/editor/src/lib/remix-ui-editor.tsx
@@ -16,6 +16,7 @@ import { retrieveNodesAtPosition } from './helpers/retrieveNodesAtPosition'
 import { RemixHoverProvider } from './providers/hoverProvider'
 import { RemixReferenceProvider } from './providers/referenceProvider'
 import { RemixCompletionProvider } from './providers/completionProvider'
+import { RemixSolidityDocumentationProvider } from './providers/documentationProvider'
 import { RemixHighLightProvider } from './providers/highlightProvider'
 import { RemixDefinitionProvider } from './providers/definitionProvider'
 import { RemixCodeActionProvider } from './providers/codeActionProvider'
@@ -23,6 +24,7 @@ import './remix-ui-editor.css'
 import { circomLanguageConfig, circomTokensProvider } from './syntaxes/circom'
 import { IPosition } from 'monaco-editor'
 import { RemixInLineCompletionProvider } from './providers/inlineCompletionProvider'
+import { providers } from 'ethers'
 const _paq = (window._paq = window._paq || [])
 
 enum MarkerSeverity {
@@ -174,6 +176,8 @@ export const EditorUI = (props: EditorUIProps) => {
   const currentFunction = useRef('')
   const currentFileRef = useRef('')
   const currentUrlRef = useRef('')
+  let currenFunctionNode = useRef('')
+
   // const currentDecorations = useRef({ sourceAnnotationsPerFile: {}, markerPerFile: {} }) // decorations that are currently in use by the editor
   // const registeredDecorations = useRef({}) // registered decorations
 
@@ -713,6 +717,12 @@ export const EditorUI = (props: EditorUIProps) => {
     }
 
     let gptGenerateDocumentationAction
+    const extractNatspecComments = (codeString: string): string => {
+      const natspecCommentRegex = /\/\*\*[\s\S]*?\*\//g;
+      const comments = codeString.match(natspecCommentRegex);
+      return comments ? comments[0] : "";
+    }
+
     const executeGptGenerateDocumentationAction = {
       id: 'generateDocumentation',
       label: intl.formatMessage({ id: 'editor.generateDocumentation' }),
@@ -726,7 +736,23 @@ export const EditorUI = (props: EditorUIProps) => {
         const file = await props.plugin.call('fileManager', 'getCurrentFile')
         const content = await props.plugin.call('fileManager', 'readFile', file)
         const message = intl.formatMessage({ id: 'editor.generateDocumentationByAI' }, { content, currentFunction: currentFunction.current })
-        await props.plugin.call('solcoder', 'code_explaining', message)
+        const cm = await props.plugin.call('solcoder', 'code_explaining', message)
+
+        const natspecCom = extractNatspecComments(cm)
+        const cln = await props.plugin.call('codeParser', "getLineColumnOfNode", currenFunctionNode)
+        const range = new monacoRef.current.Range(cln.start.line, cln.start.column, cln.start.line, cln.start.column)
+
+        // TODO: activate the provider to let the user accept the documentation suggestion
+        // const provider = new RemixSolidityDocumentationProvider(natspecCom)
+        // editor.inlineProviderDisposable = monacoRef.current.languages.registerInlineCompletionsProvider('remix-docu', provider)
+
+        editor.executeEdits('inlineCompletionDocu', [
+          {
+            range: range,
+            text: natspecCom,
+            forceMoveMarkers: true,
+          },
+        ]);
         _paq.push(['trackEvent', 'ai', 'solcoder', 'generateDocumentation'])
       },
     }
@@ -845,6 +871,8 @@ export const EditorUI = (props: EditorUIProps) => {
       const functionImpl = nodesAtPosition.find((node) => node.kind === 'function')
       if (functionImpl) {
         currentFunction.current = functionImpl.name
+        currenFunctionNode = functionImpl
+
         executeGptGenerateDocumentationAction.label = intl.formatMessage({ id: 'editor.generateDocumentation2' }, { name: functionImpl.name })
         gptGenerateDocumentationAction = editor.addAction(executeGptGenerateDocumentationAction)
         executegptExplainFunctionAction.label = intl.formatMessage({ id: 'editor.explainFunction2' }, { name: functionImpl.name })


### PR DESCRIPTION
From now on, when the user right click on any function, then select `generate documentation`, the generated documentation in fitted above the function

The user can now chat with the terminal outputs 