### PR TITLE
chore: fix typos and link broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@
 
 ![Remix screenshot](https://github.com/ethereum/remix-project/raw/master/apps/remix-ide/remix-screenshot-400h.png)
 
-**VSCode extension**, see: [Ethereum-Remix](https://marketplace.visualstudio.com/items?itemName=RemixProject.ethereum-remix)
 
 ## Remix libraries 
 Remix libraries are essential for Remix IDE's native plugins. Read more about libraries [here](libs/README.md)

--- a/apps/remix-ide/webpack.config.js
+++ b/apps/remix-ide/webpack.config.js
@@ -170,7 +170,7 @@ class CopyFileAfterBuild {
   apply(compiler) {
     const onEnd = async () => {
       try {
-        console.log('runnning CopyFileAfterBuild')
+        console.log('running CopyFileAfterBuild')
         // This copy the raw-loader files used by the etherscan plugin to the remix-ide root folder.
         // This is needed because by default the etherscan resources are served from the /plugins/etherscan/ folder,
         // but the raw-loader try to access the resources from the root folder.

--- a/libs/remix-ui/solidity-compiler/src/lib/logic/compileTabLogic.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/logic/compileTabLogic.ts
@@ -104,7 +104,7 @@ export class CompileTabLogic {
    * @param {string} target the path to the file to compile
    */
   compileFile (target) {
-    if (!target) throw new Error('No target provided for compiliation')
+    if (!target) throw new Error('No target provided for compilation')
     return new Promise((resolve, reject) => {
       this.api.readFile(target).then(async(content) => {
         const sources = { [target]: { content } }


### PR DESCRIPTION
Fix some typos and Removed the VS Code plugin-related content because there is no longer any support for the VS Code Remix extension