### PR TITLE
Check for Zero Address

### DIFF
--- a/libs/remix-ws-templates/src/templates/remixDefault/contracts/2_Owner.sol
+++ b/libs/remix-ws-templates/src/templates/remixDefault/contracts/2_Owner.sol
@@ -40,6 +40,7 @@ contract Owner {
      * @param newOwner address of new owner
      */
     function changeOwner(address newOwner) public isOwner {
+        require(newOwner != address(0), "New owner should not be the zero address");
         emit OwnerSet(owner, newOwner);
         owner = newOwner;
     }


### PR DESCRIPTION
Added a require statement in the changeOwner function to ensure that the new owner is not set to the zero address. This prevents accidental loss of control over the contract.