### PR TITLE
Additional Require Check to prevent out-of-bounds errors

### DIFF
--- a/apps/remix-ide/contracts/ballot.sol
+++ b/apps/remix-ide/contracts/ballot.sol
@@ -101,6 +101,7 @@ contract Ballot {
         Voter storage sender = voters[msg.sender];
         require(sender.weight != 0, "Has no right to vote");
         require(!sender.voted, "Already voted.");
+        require(proposal < proposals.length, "Invalid proposal index.");
         sender.voted = true;
         sender.vote = proposal;
 


### PR DESCRIPTION
Added a check in the vote function to ensure that the proposal index is within the range of the proposals array. This prevents out-of-bounds errors.