### PR TITLE
Show Solidity Scan Summary

### DIFF
--- a/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
@@ -312,7 +312,6 @@ export const ContractSelection = (props: ContractSelectionProps) => {
           const url = data.payload.scan_details.link
 
           const { data: scanData } = await axios.post('https://solidityscan.remixproject.org/downloadResult', { url })
-          console.log('scan data--->', scanData)
           const scanReport: ScanReport = scanData.scan_report
 
           if (scanReport?.multi_file_scan_details?.length) {
@@ -339,7 +338,7 @@ export const ContractSelection = (props: ContractSelectionProps) => {
       title: <FormattedMessage id="solidity.solScan.modalTitle" />,
       message: <div className='d-flex flex-column'>
         <span><FormattedMessage id="solidity.solScan.modalMessage" />
-          <a href={'https://solidityscan.com'}
+          <a href={'https://solidityscan.com/?utm_campaign=remix&utm_source=remix'}
             target="_blank"
             onClick={() => _paq.push(['trackEvent', 'solidityCompiler', 'solidityScan', 'learnMore'])}>
               Learn more

--- a/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect} from 'react' // eslint-disable-line
 import { FormattedMessage, useIntl } from 'react-intl'
-import { ContractPropertyName, ContractSelectionProps } from './types'
+import { ContractPropertyName, ContractSelectionProps, ScanReport } from './types'
 import {PublishToStorage} from '@remix-ui/publish-to-storage' // eslint-disable-line
 import {TreeView, TreeViewItem} from '@remix-ui/tree-view' // eslint-disable-line
 import {CopyToClipboard} from '@remix-ui/clipboard' // eslint-disable-line
@@ -312,10 +312,11 @@ export const ContractSelection = (props: ContractSelectionProps) => {
           const url = data.payload.scan_details.link
 
           const { data: scanData } = await axios.post('https://solidityscan.remixproject.org/downloadResult', { url })
-          const scanDetails: Record<string, any>[] = scanData.scan_report.multi_file_scan_details
+          console.log('scan data--->', scanData)
+          const scanReport: ScanReport = scanData.scan_report
 
-          if (scanDetails && scanDetails.length) {
-            await plugin.call('terminal', 'logHtml', <SolScanTable scanDetails={scanDetails} fileName={fileName}/>)
+          if (scanReport?.multi_file_scan_details?.length) {
+            await plugin.call('terminal', 'logHtml', <SolScanTable scanReport={scanReport} fileName={fileName}/>)
           } else {
             const modal: AppModal = {
               id: 'SolidityScanError',

--- a/libs/remix-ui/solidity-compiler/src/lib/solScanTable.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/solScanTable.tsx
@@ -54,7 +54,7 @@ export function SolScanTable(props: SolScanTableProps) {
           <p>&emsp; Scan Score: {multi_file_scan_summary.score_v2}</p>
           <p>&emsp; Issue Distribution: { JSON.stringify(multi_file_scan_summary.issue_severity_distribution, null, 1)} </p>
           <p>For more details,&nbsp;
-            <a href="https://solidityscan.com/signup"
+            <a href="https://solidityscan.com/?utm_campaign=remix&utm_source=remix"
               target='_blank'
               onClick={() => _paq.push(['trackEvent', 'solidityCompiler', 'solidityScan', 'goToSolidityScan'])}>
               go to SolidityScan.

--- a/libs/remix-ui/solidity-compiler/src/lib/solScanTable.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/solScanTable.tsx
@@ -1,27 +1,22 @@
 // eslint-disable-next-line no-use-before-define
 import React from 'react'
 import parse from 'html-react-parser'
+import { ScanReport } from './types'
 const _paq = (window._paq = window._paq || [])
 
 interface SolScanTableProps {
-  scanDetails: Record<string, any>[],
+  scanReport: ScanReport
   fileName: string
 }
 
 export function SolScanTable(props: SolScanTableProps) {
-  const { scanDetails, fileName } = props
+  const { scanReport, fileName } = props
+  const { multi_file_scan_details, multi_file_scan_summary } = scanReport
 
   return (
     <>
       <br/>
       <h6>SolidityScan result for <b>{fileName}</b>:</h6>
-      <p className='text-success'><b>{scanDetails.length} warnings </b> found. See the warning details below. For more details,&nbsp;
-        <a href="https://solidityscan.com/signup"
-          target='_blank'
-          onClick={() => _paq.push(['trackEvent', 'solidityCompiler', 'solidityScan', 'goToSolidityScan'])}>
-            go to SolidityScan.
-        </a>
-      </p>
       <table className="table table-bordered table-hover">
         <thead>
           <tr>
@@ -35,7 +30,7 @@ export function SolScanTable(props: SolScanTableProps) {
         </thead>
         <tbody>
           {
-            Array.from(scanDetails, (template, index) => {
+            Array.from(multi_file_scan_details, (template, index) => {
               return (
                 <tr key={template.template_details.issue_id}>
                   <td scope="col">{index + 1}.</td>
@@ -51,6 +46,13 @@ export function SolScanTable(props: SolScanTableProps) {
 
         </tbody>
       </table>
+      <p className='text-success'><b> warnings </b> found. See the warning details below. For more details,&nbsp;
+        <a href="https://solidityscan.com/signup"
+          target='_blank'
+          onClick={() => _paq.push(['trackEvent', 'solidityCompiler', 'solidityScan', 'goToSolidityScan'])}>
+            go to SolidityScan.
+        </a>
+      </p>
     </>
   )
 }

--- a/libs/remix-ui/solidity-compiler/src/lib/solScanTable.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/solScanTable.tsx
@@ -46,13 +46,22 @@ export function SolScanTable(props: SolScanTableProps) {
 
         </tbody>
       </table>
-      <p className='text-success'><b> warnings </b> found. See the warning details below. For more details,&nbsp;
-        <a href="https://solidityscan.com/signup"
-          target='_blank'
-          onClick={() => _paq.push(['trackEvent', 'solidityCompiler', 'solidityScan', 'goToSolidityScan'])}>
-            go to SolidityScan.
-        </a>
-      </p>
+
+      { multi_file_scan_summary ? (
+        <>
+        <p className='text-success'><b>Scan Summary: </b></p>
+        <p>&emsp; Lines Analyzed: {multi_file_scan_summary.lines_analyzed_count}</p>
+        <p>&emsp; Scan Score: {multi_file_scan_summary.score_v2}</p>
+        <p>&emsp; Issue Distribution: { JSON.stringify(multi_file_scan_summary.issue_severity_distribution, null, 1)} </p>
+        <p>For more details,&nbsp;
+          <a href="https://solidityscan.com/signup"
+            target='_blank'
+            onClick={() => _paq.push(['trackEvent', 'solidityCompiler', 'solidityScan', 'goToSolidityScan'])}>
+              go to SolidityScan.
+          </a>
+        </p>
+        </>
+      ): null}
     </>
   )
 }

--- a/libs/remix-ui/solidity-compiler/src/lib/solScanTable.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/solScanTable.tsx
@@ -49,17 +49,17 @@ export function SolScanTable(props: SolScanTableProps) {
 
       { multi_file_scan_summary ? (
         <>
-        <p className='text-success'><b>Scan Summary: </b></p>
-        <p>&emsp; Lines Analyzed: {multi_file_scan_summary.lines_analyzed_count}</p>
-        <p>&emsp; Scan Score: {multi_file_scan_summary.score_v2}</p>
-        <p>&emsp; Issue Distribution: { JSON.stringify(multi_file_scan_summary.issue_severity_distribution, null, 1)} </p>
-        <p>For more details,&nbsp;
-          <a href="https://solidityscan.com/signup"
-            target='_blank'
-            onClick={() => _paq.push(['trackEvent', 'solidityCompiler', 'solidityScan', 'goToSolidityScan'])}>
+          <p className='text-success'><b>Scan Summary: </b></p>
+          <p>&emsp; Lines Analyzed: {multi_file_scan_summary.lines_analyzed_count}</p>
+          <p>&emsp; Scan Score: {multi_file_scan_summary.score_v2}</p>
+          <p>&emsp; Issue Distribution: { JSON.stringify(multi_file_scan_summary.issue_severity_distribution, null, 1)} </p>
+          <p>For more details,&nbsp;
+            <a href="https://solidityscan.com/signup"
+              target='_blank'
+              onClick={() => _paq.push(['trackEvent', 'solidityCompiler', 'solidityScan', 'goToSolidityScan'])}>
               go to SolidityScan.
-          </a>
-        </p>
+            </a>
+          </p>
         </>
       ): null}
     </>

--- a/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
@@ -2,6 +2,40 @@ import { ICompilerApi, ConfigurationSettings, iSolJsonBinData } from '@remix-pro
 import { CompileTabLogic } from '../logic/compileTabLogic'
 export type onCurrentFileChanged = (fileName: string) => void
 
+//// SolidityScan Types 
+
+export interface ScanTemplate {
+  issue_id: string
+  issue_name: string
+  issue_remediation?: string
+  issue_severity: string
+  issue_status: string
+  static_issue_description: string
+  issue_description?: string
+  issue_confidence: string
+  metric_wise_aggregated_findings?: Record<string, any>[]
+}
+
+export interface ScanDetails {
+  issue_id: string
+  no_of_findings: string
+  template_details: ScanTemplate
+}
+
+export interface ScanReport {
+  details_enabled: boolean
+  file_url_list: string[]
+  multi_file_scan_details: ScanDetails[]
+  multi_file_scan_summary: Record<string, any>
+  multi_file_scan_status: string
+  scan_id: string
+  scan_status: string
+  scan_type: string
+  // others
+}
+
+//// SolidityScan Types 
+
 export interface SolidityCompilerProps {
   api: ICompilerApi
 }

--- a/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
@@ -2,7 +2,7 @@ import { ICompilerApi, ConfigurationSettings, iSolJsonBinData } from '@remix-pro
 import { CompileTabLogic } from '../logic/compileTabLogic'
 export type onCurrentFileChanged = (fileName: string) => void
 
-//// SolidityScan Types 
+//// SolidityScan Types
 
 export interface ScanTemplate {
   issue_id: string
@@ -34,7 +34,7 @@ export interface ScanReport {
   // others
 }
 
-//// SolidityScan Types 
+//// SolidityScan Types
 
 export interface SolidityCompilerProps {
   api: ICompilerApi


### PR DESCRIPTION
part of #4967 

It is shown at the end of report
<img width="846" alt="Screenshot 2024-07-08 at 8 40 38 PM" src="https://github.com/ethereum/remix-project/assets/30843294/6dea40f8-955a-4b8a-a739-24afa365a0cb">

Updated URL to redirect to Solidity Scan
