### PR TITLE
show lines for warnings where available, in Solidity Scan report

### DIFF
--- a/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
@@ -313,8 +313,19 @@ export const ContractSelection = (props: ContractSelectionProps) => {
 
           const { data: scanData } = await axios.post('https://solidityscan.remixproject.org/downloadResult', { url })
           const scanReport: ScanReport = scanData.scan_report
-
           if (scanReport?.multi_file_scan_details?.length) {
+            for (const template of scanReport.multi_file_scan_details) {
+              if (template.metric_wise_aggregated_findings?.length) {
+                const { metric_wise_aggregated_findings } = template
+                let positions = []
+                for (const details of metric_wise_aggregated_findings) {
+                  const { findings } = details
+                  for (const f of findings)
+                    positions.push(`${f.line_nos_start[0]}:${f.line_nos_end[0]}`)
+                }
+                template.positions = JSON.stringify(positions)
+              }
+            }
             await plugin.call('terminal', 'logHtml', <SolScanTable scanReport={scanReport} fileName={fileName}/>)
           } else {
             const modal: AppModal = {

--- a/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
@@ -317,7 +317,7 @@ export const ContractSelection = (props: ContractSelectionProps) => {
             for (const template of scanReport.multi_file_scan_details) {
               if (template.metric_wise_aggregated_findings?.length) {
                 const { metric_wise_aggregated_findings } = template
-                let positions = []
+                const positions = []
                 for (const details of metric_wise_aggregated_findings) {
                   const { findings } = details
                   for (const f of findings)

--- a/libs/remix-ui/solidity-compiler/src/lib/solScanTable.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/solScanTable.tsx
@@ -37,7 +37,7 @@ export function SolScanTable(props: SolScanTableProps) {
                   <td scope="col">{template.template_details.issue_name}</td>
                   <td scope="col">{template.template_details.issue_severity}</td>
                   <td scope="col">{template.template_details.issue_confidence}</td>
-                  <td scope="col">{parse(template.template_details.static_issue_description)}</td>
+                  <td scope="col">{parse(template.template_details.static_issue_description)} {template.positions ? `Lines: ${template.positions}`: ''}</td>
                   <td scope="col">{template.template_details.issue_remediation ? parse(template.template_details.issue_remediation) : 'Not Available' }</td>
                 </tr>
               )

--- a/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
+++ b/libs/remix-ui/solidity-compiler/src/lib/types/index.ts
@@ -19,6 +19,8 @@ export interface ScanTemplate {
 export interface ScanDetails {
   issue_id: string
   no_of_findings: string
+  metric_wise_aggregated_findings?: Record<string, any>[]
+  positions?: string
   template_details: ScanTemplate
 }
 


### PR DESCRIPTION
Fixes #4967 

It shows warning lines for `gas` issues in the report 

<img width="880" alt="Screenshot 2024-07-10 at 5 01 23 PM" src="https://github.com/ethereum/remix-project/assets/30843294/f001e63c-f5e3-473a-ad2d-68ea99d281d1">

and highlights same lines in editor
<img width="618" alt="Screenshot 2024-07-12 at 11 11 22 AM" src="https://github.com/user-attachments/assets/682767e3-e6cc-43de-8ef0-1bdfc29e83bb">
