### PR TITLE
Added shortcut Alt+S for Solidity Scan

### DIFF
--- a/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
+++ b/libs/remix-ui/solidity-compiler/src/lib/contract-selection.tsx
@@ -355,6 +355,21 @@ export const ContractSelection = (props: ContractSelectionProps) => {
     await (api as any).call('notification', 'modal', modal)
   }
 
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.altKey && event.key === 's') {
+        console.log('Running Static Analysis');
+        runSolidityScan();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
   return (
     // define swarm logo
     <>


### PR DESCRIPTION
Added ShortCut Alt + S for performing Solidity Scan after performing compilation. to solve #4993 

Below is the demo of same:
1. Press Ctrl + Shift + S to compile
2. Press Alt + S to perform Solidity Scan

[Screencast from 2024-07-13 18-42-23.webm](https://github.com/user-attachments/assets/8f339f78-562f-496f-b803-b9ca38ae0b4f)
