### PR TITLE
Fix bug to maximise plugin side panel

### DIFF
--- a/apps/remix-ide/src/app/panels/layout.ts
+++ b/apps/remix-ide/src/app/panels/layout.ts
@@ -65,7 +65,6 @@ export class Layout extends Plugin {
       this.event.emit('change', null)
     })
     this.on('tabs', 'openDiff', () => {
-      console.log('openDiff')
       this.panels.editor.active = true
       this.panels.main.active = false
       this.event.emit('change', null)
@@ -79,7 +78,6 @@ export class Layout extends Plugin {
     })
     this.on('sidePanel', 'focusChanged', async (name) => {
       const current = await this.call('sidePanel', 'currentFocus')
-      console.log('focusChanged', current, this.maximised)
       if (this.maximised[current]) {
         this.event.emit('maximisesidepanel')
       } else {
@@ -127,16 +125,15 @@ export class Layout extends Plugin {
   }
 
   async maximiseSidePanel () {
-    this.event.emit('maximisesidepanel')
     const current = await this.call('sidePanel', 'currentFocus')
     this.maximised[current] = true
-    console.log('maximised', this.maximised, current)
+    this.event.emit('maximisesidepanel')
   }
 
   async maximisePinnedPanel () {
-    this.event.emit('maximisepinnedpanel')
     const current = await this.call('pinnedPanel', 'currentFocus')
     this.maximised[current] = true
+    this.event.emit('maximisepinnedpanel')
   }
 
   async maximizeTerminal() {
@@ -146,15 +143,14 @@ export class Layout extends Plugin {
   }
 
   async resetSidePanel () {
-    this.event.emit('resetsidepanel')
     const current = await this.call('sidePanel', 'currentFocus')
     this.maximised[current] = false
-    console.log('reset max', this.maximised, current)
+    this.event.emit('resetsidepanel')
   }
 
   async resetPinnedPanel () {
-    this.event.emit('resetpinnedpanel')
     const current = await this.call('pinnedPanel', 'currentFocus')
     this.maximised[current] = false
+    this.event.emit('resetpinnedpanel')
   }
 }

--- a/apps/remix-ide/src/app/panels/layout.ts
+++ b/apps/remix-ide/src/app/panels/layout.ts
@@ -33,7 +33,9 @@ export class Layout extends Plugin {
   maximised: { [key: string]: boolean }
   constructor () {
     super(profile)
-    this.maximised = {}
+    this.maximised = {
+      'dgit': true
+    }
     this.event = new EventEmitter()
   }
 

--- a/apps/remix-ide/src/app/panels/layout.ts
+++ b/apps/remix-ide/src/app/panels/layout.ts
@@ -79,6 +79,7 @@ export class Layout extends Plugin {
     })
     this.on('sidePanel', 'focusChanged', async (name) => {
       const current = await this.call('sidePanel', 'currentFocus')
+      console.log('focusChanged', current, this.maximised)
       if (this.maximised[current]) {
         this.event.emit('maximisesidepanel')
       } else {
@@ -129,6 +130,7 @@ export class Layout extends Plugin {
     this.event.emit('maximisesidepanel')
     const current = await this.call('sidePanel', 'currentFocus')
     this.maximised[current] = true
+    console.log('maximised', this.maximised, current)
   }
 
   async maximisePinnedPanel () {
@@ -147,6 +149,7 @@ export class Layout extends Plugin {
     this.event.emit('resetsidepanel')
     const current = await this.call('sidePanel', 'currentFocus')
     this.maximised[current] = false
+    console.log('reset max', this.maximised, current)
   }
 
   async resetPinnedPanel () {

--- a/libs/remix-ui/app/src/lib/remix-app/components/dragbar/dragbar.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/components/dragbar/dragbar.tsx
@@ -121,7 +121,7 @@ const DragBar = (props: IRemixDragBarUi) => {
         }, 300)
       }
     }
-    
+
   }
 
   function startDrag() {

--- a/libs/remix-ui/app/src/lib/remix-app/components/dragbar/dragbar.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/components/dragbar/dragbar.tsx
@@ -41,7 +41,6 @@ const DragBar = (props: IRemixDragBarUi) => {
   }, [props.hidden, offset])
 
   useEffect(() => {
-    initialWidth.current = props.refObject.current.clientWidth
     if (props.maximiseTrigger > 0) {
       if (props.layoutPosition === 'left') {
         const width = 0.4 * window.innerWidth
@@ -106,6 +105,7 @@ const DragBar = (props: IRemixDragBarUi) => {
         setTimeout(() => {
           props.setHideStatus(false)
           setDragBarPosX(offset + props.refObject.current.offsetWidth)
+          initialWidth.current = props.refObject.current.clientWidth
         }, 300)
       }
     } else if (props.layoutPosition === 'right') {
@@ -117,9 +117,11 @@ const DragBar = (props: IRemixDragBarUi) => {
         setTimeout(() => {
           props.setHideStatus(false)
           setDragBarPosX(props.refObject.current.offsetLeft)
+          initialWidth.current = props.refObject.current.clientWidth
         }, 300)
       }
     }
+    
   }
 
   function startDrag() {

--- a/libs/remix-ui/git/src/lib/gitactions.ts
+++ b/libs/remix-ui/git/src/lib/gitactions.ts
@@ -852,6 +852,5 @@ export const clearGitLog = async () => {
 }
 
 export const setStorage = async (storage: storage) => {
-  console.log(storage)
   dispatch(setStoragePayload(storage))
 }

--- a/libs/remix-ui/git/src/lib/listeners.ts
+++ b/libs/remix-ui/git/src/lib/listeners.ts
@@ -165,19 +165,8 @@ export const setCallBacks = (viewPlugin: Plugin, gitDispatcher: React.Dispatch<g
   })
 
   plugin.on('sidePanel', 'focusChanged', async (name: string) => {
-    const pinnedPlugin = await plugin.call('pinnedPanel', 'currentFocus')
     if (name == 'dgit') {
-      if (pinnedPlugin === 'dgit') {
-        plugin.call('layout', 'maximisePinnedPanel')
-      } else {
         plugin.call('layout', 'maximiseSidePanel')
-      }
-    } else {
-      if (pinnedPlugin === 'dgit') {
-        plugin.call('layout', 'resetPinnedPanel')
-      } else {
-        plugin.call('layout', 'resetSidePanel')
-      }
     }
   })
 

--- a/libs/remix-ui/git/src/lib/listeners.ts
+++ b/libs/remix-ui/git/src/lib/listeners.ts
@@ -164,12 +164,6 @@ export const setCallBacks = (viewPlugin: Plugin, gitDispatcher: React.Dispatch<g
     setAtivePanel(panelNumber)
   })
 
-  plugin.on('sidePanel', 'focusChanged', async (name: string) => {
-    if (name == 'dgit') {
-      plugin.call('layout', 'maximiseSidePanel')
-    }
-  })
-
   callBackEnabled = true;
 }
 

--- a/libs/remix-ui/git/src/lib/listeners.ts
+++ b/libs/remix-ui/git/src/lib/listeners.ts
@@ -166,7 +166,7 @@ export const setCallBacks = (viewPlugin: Plugin, gitDispatcher: React.Dispatch<g
 
   plugin.on('sidePanel', 'focusChanged', async (name: string) => {
     if (name == 'dgit') {
-        plugin.call('layout', 'maximiseSidePanel')
+      plugin.call('layout', 'maximiseSidePanel')
     }
   })
 

--- a/libs/remix-ui/statusbar/src/lib/remixui-statusbar-panel.tsx
+++ b/libs/remix-ui/statusbar/src/lib/remixui-statusbar-panel.tsx
@@ -31,7 +31,6 @@ export function RemixUIStatusBar({ statusBarPlugin }: RemixUIStatusBarProps) {
       mainAxis: true, padding: 10
     }), size({
       apply({ availableWidth, availableHeight, elements, ...state }) {
-        console.log(state)
         Object.assign(elements.floating.style, {
           maxWidth: `${availableWidth}`,
           maxHeight: `auto`


### PR DESCRIPTION
fixed a bug when switching between two panels that have maximized width ( ie debugger and git ). the initial width would be calculated on the last width, which could be wide also. this would cause the effect of the panel never becoming small again. 
so now it's based on the width after dragging or ofc the original min width of the props.
also removed some logs 