### PR TITLE
Gituifixes

### DIFF
--- a/apps/remix-ide-e2e/src/githttpbackend/setup.sh
+++ b/apps/remix-ide-e2e/src/githttpbackend/setup.sh
@@ -1,7 +1,9 @@
 
 cd /tmp/
 rm -rf git/bare.git
+rm -rf git/bare2.git
 rm -rf git
 mkdir -p git
 cd git
 git clone --bare https://github.com/ethereum/awesome-remix bare.git
+git clone --bare https://github.com/ethereum/awesome-remix bare2.git

--- a/apps/remix-ide-e2e/src/tests/dgit_github.test.ts
+++ b/apps/remix-ide-e2e/src/tests/dgit_github.test.ts
@@ -136,22 +136,22 @@ module.exports = {
     },
     'switch to branch links #group1': function (browser: NightwatchBrowser) {
         browser
+            .click('*[data-id="branches-panel"]')
             .waitForElementVisible({
-                selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="branches-branch-links"]',
+                selector: '//*[@data-id="branches-panel-content-remote-branches"]//*[@data-id="branches-branch-links"]',
                 locateStrategy: 'xpath'
             })
             .click({
-                selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="branches-toggle-branch-links"]',
+                selector: '//*[@data-id="branches-panel-content-remote-branches"]//*[@data-id="branches-toggle-branch-links"]',
                 locateStrategy: 'xpath'
             })
             .waitForElementVisible({
-                selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="branches-toggle-current-branch-links"]',
+                selector: '//*[@data-id="branches-panel-content-remote-branches"]//*[@data-id="branches-toggle-current-branch-links"]',
                 locateStrategy: 'xpath'
             })
     },
     'check the local branches #group1': function (browser: NightwatchBrowser) {
         browser
-            .click('*[data-id="branches-panel"]')
             .waitForElementVisible({
                 selector: '//*[@data-id="branches-panel-content"]//*[@data-id="branches-toggle-current-branch-links"]',
                 locateStrategy: 'xpath'

--- a/apps/remix-ide-e2e/src/tests/dgit_github.test.ts
+++ b/apps/remix-ide-e2e/src/tests/dgit_github.test.ts
@@ -153,7 +153,7 @@ module.exports = {
     'check the local branches #group1': function (browser: NightwatchBrowser) {
         browser
             .waitForElementVisible({
-                selector: '//*[@data-id="branches-panel-content"]//*[@data-id="branches-toggle-current-branch-links"]',
+                selector: '//*[@data-id="branches-panel-content-local-branches"]//*[@data-id="branches-toggle-current-branch-links"]',
                 locateStrategy: 'xpath'
             })
     },

--- a/apps/remix-ide-e2e/src/tests/dgit_github.test.ts
+++ b/apps/remix-ide-e2e/src/tests/dgit_github.test.ts
@@ -115,7 +115,8 @@ module.exports = {
             })
             .waitForElementVisible({
                 selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="branches-branch-links"]',
-                locateStrategy: 'xpath'
+                locateStrategy: 'xpath',
+                timeout: 10000
             })
 
     },

--- a/apps/remix-ide-e2e/src/tests/dgit_github.test.ts
+++ b/apps/remix-ide-e2e/src/tests/dgit_github.test.ts
@@ -102,7 +102,7 @@ module.exports = {
             .click('*[data-id="remotes-panel"]')
             .waitForElementVisible('*[data-id="remotes-panel-content"]')
             .waitForElementVisible({
-                selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-origin"]',
+                selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-origin-default"]',
                 locateStrategy: 'xpath'
             })
             .waitForElementVisible({
@@ -232,7 +232,7 @@ module.exports = {
                 locateStrategy: 'xpath'
             })
             .waitForElementVisible({
-                selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-newremote"]',
+                selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-newremote-default"]',
                 locateStrategy: 'xpath'
             })
     },
@@ -263,7 +263,7 @@ module.exports = {
                 }
             })
     },
-    'remove the remove #group2': function (browser: NightwatchBrowser) {
+    'remove the remote #group2': function (browser: NightwatchBrowser) {
         browser
             .pause(1000)
             .click('*[data-id="remotes-panel"]')
@@ -278,7 +278,7 @@ module.exports = {
             })
             .pause(1000)
             .waitForElementNotPresent({
-                selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-newremote"]',
+                selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-newremote-default"]',
                 locateStrategy: 'xpath'
             })
     },

--- a/apps/remix-ide-e2e/src/tests/dgit_github.test.ts
+++ b/apps/remix-ide-e2e/src/tests/dgit_github.test.ts
@@ -101,7 +101,7 @@ module.exports = {
 
             .click('*[data-id="remotes-panel"]')
             .waitForElementVisible('*[data-id="remotes-panel-content"]')
-            .click({
+            .waitForElementVisible({
                 selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-origin"]',
                 locateStrategy: 'xpath'
             })

--- a/apps/remix-ide-e2e/src/tests/dgit_local.test.ts
+++ b/apps/remix-ide-e2e/src/tests/dgit_local.test.ts
@@ -24,14 +24,14 @@ module.exports = {
         })
     },
 
-    'run server #group1 #group2 #group3': function (browser: NightwatchBrowser) {
+    'run server #group1 #group2 #group3 #group4': function (browser: NightwatchBrowser) {
         browser.perform(async (done) => {
             gitserver = await spawnGitServer('/tmp/')
             console.log('working directory', process.cwd())
             done()
         })
     },
-    'Update settings for git #group1 #group2 #group3': function (browser: NightwatchBrowser) {
+    'Update settings for git #group1 #group2 #group3 #group4': function (browser: NightwatchBrowser) {
         browser.
             clickLaunchIcon('dgit')
             .waitForElementVisible('*[data-id="initgit-btn"]')
@@ -325,8 +325,61 @@ module.exports = {
     },
     'check if test file is gone #group2': function (browser: NightwatchBrowser) {
         browser
+            .pause()
             .clickLaunchIcon('filePanel')
             .waitForElementNotPresent('*[data-id="treeViewLitreeViewItemtest.txt"]')
+    },
+    'clone locally #group4': async function (browser: NightwatchBrowser) {
+        await cloneOnServer('http://localhost:6868/bare.git', '/tmp/', 'bare')
+        await cloneOnServer('http://localhost:6868/bare2.git', '/tmp/', 'bare2')
+    },
+    'add remote #group4': function (browser: NightwatchBrowser) {
+        browser
+            .pause(1000)
+            .click('*[data-id="remotes-panel"]')
+            .waitForElementVisible('*[data-id="add-manual-remoteurl"]')
+            .setValue('*[data-id="add-manual-remoteurl"]', 'http://localhost:6868/bare.git')
+            .waitForElementVisible('*[data-id="add-manual-remotename"]')
+            .setValue('*[data-id="add-manual-remotename"]', 'origin')
+            .waitForElementVisible('*[data-id="add-manual-remotebtn"]')
+            .click('*[data-id="add-manual-remotebtn"]')
+    },
+    'add second remote #group4': function (browser: NightwatchBrowser) {
+        browser
+            .pause(1000)
+            .waitForElementVisible('*[data-id="add-manual-remoteurl"]')
+            .setValue('*[data-id="add-manual-remoteurl"]', 'http://localhost:6868/bare2.git')
+            .waitForElementVisible('*[data-id="add-manual-remotename"]')
+            .setValue('*[data-id="add-manual-remotename"]', 'origin2')
+            .waitForElementVisible('*[data-id="add-manual-remotebtn"]')
+            .click('*[data-id="add-manual-remotebtn"]')
+    },
+    'check the buttons #group4': function (browser: NightwatchBrowser) {
+        browser
+            .waitForElementVisible('*[data-id="default-remote-check-origin"]')
+            .waitForElementVisible('*[data-id="set-as-default-origin2"]')
+    },
+    'check the commands #group4': function (browser: NightwatchBrowser) {
+        browser
+            .click('*[data-id="commands-panel"]')
+            .waitForElementVisible({
+                selector: "//div[@id='commands-remote-origin-select']//div[contains(@class, 'singleValue') and contains(text(), 'origin')]",
+                locateStrategy: 'xpath'
+            })
+    },
+    'switch to origin2 #group4': function (browser: NightwatchBrowser) {
+        browser
+            .click('*[data-id="remotes-panel"]')
+            .waitForElementVisible('*[data-id="set-as-default-origin2"]')
+            .click('*[data-id="set-as-default-origin2"]')
+    },
+    'check the commands for origin2 #group4': function (browser: NightwatchBrowser) {
+        browser
+            .click('*[data-id="commands-panel"]')
+            .waitForElementVisible({
+                selector: "//div[@id='commands-remote-origin-select']//div[contains(@class, 'singleValue') and contains(text(), 'origin2')]",
+                locateStrategy: 'xpath'
+            })
     }
 }
 
@@ -364,10 +417,10 @@ async function getGitLog(path: string): Promise<string> {
     })
 }
 
-async function cloneOnServer(repo: string, path: string) {
+async function cloneOnServer(repo: string, path: string, name: string = 'bare') {
     console.log('cloning', repo, path)
     return new Promise((resolve, reject) => {
-        const git = spawn('rm -rf bare && git', ['clone', repo], { cwd: path, shell: true, detached: true });
+        const git = spawn(`rm -rf ${name} && git`, ['clone', repo], { cwd: path, shell: true, detached: true });
 
         git.stdout.on('data', function (data) {
             console.log('stdout data cloning', data.toString());

--- a/apps/remix-ide-e2e/src/tests/dgit_local.test.ts
+++ b/apps/remix-ide-e2e/src/tests/dgit_local.test.ts
@@ -42,7 +42,7 @@ module.exports = {
             .modalFooterOKClick('github-credentials-error')
             .pause(2000)
     },
-    'clone a repo #group1 #group2 #group3': function (browser: NightwatchBrowser) {
+    'clone a repo #group1 #group2 #group3 #group4': function (browser: NightwatchBrowser) {
         browser
             .waitForElementVisible('*[data-id="clone-panel"]')
             .click('*[data-id="clone-panel"]')
@@ -56,7 +56,7 @@ module.exports = {
 
     // GROUP 1
 
-    'check file added #group1 #group3': function (browser: NightwatchBrowser) {
+    'check file added #group1 #group3 #group4': function (browser: NightwatchBrowser) {
         browser.
             addFile('test.txt', { content: 'hello world' }, 'README.md')
             .clickLaunchIcon('dgit')
@@ -76,7 +76,7 @@ module.exports = {
             .setValue('*[data-id="commitMessage"]', 'testcommit')
             .click('*[data-id="commitButton"]')
     },
-    'look at the commit #group1': function (browser: NightwatchBrowser) {
+    'look at the commit #group1 #group4': function (browser: NightwatchBrowser) {
         browser
             .click('*[data-id="commits-panel"]')
             .waitForElementPresent({
@@ -329,24 +329,10 @@ module.exports = {
             .clickLaunchIcon('filePanel')
             .waitForElementNotPresent('*[data-id="treeViewLitreeViewItemtest.txt"]')
     },
-    'clone locally #group4': async function (browser: NightwatchBrowser) {
-        await cloneOnServer('http://localhost:6868/bare.git', '/tmp/', 'bare')
-        await cloneOnServer('http://localhost:6868/bare2.git', '/tmp/', 'bare2')
-    },
-    'add remote #group4': function (browser: NightwatchBrowser) {
-        browser
-            .pause(1000)
-            .click('*[data-id="remotes-panel"]')
-            .waitForElementVisible('*[data-id="add-manual-remoteurl"]')
-            .setValue('*[data-id="add-manual-remoteurl"]', 'http://localhost:6868/bare.git')
-            .waitForElementVisible('*[data-id="add-manual-remotename"]')
-            .setValue('*[data-id="add-manual-remotename"]', 'origin')
-            .waitForElementVisible('*[data-id="add-manual-remotebtn"]')
-            .click('*[data-id="add-manual-remotebtn"]')
-    },
     'add second remote #group4': function (browser: NightwatchBrowser) {
         browser
             .pause(1000)
+            .click('*[data-id="remotes-panel"]')
             .waitForElementVisible('*[data-id="add-manual-remoteurl"]')
             .setValue('*[data-id="add-manual-remoteurl"]', 'http://localhost:6868/bare2.git')
             .waitForElementVisible('*[data-id="add-manual-remotename"]')
@@ -380,7 +366,56 @@ module.exports = {
                 selector: "//div[@id='commands-remote-origin-select']//div[contains(@class, 'singleValue') and contains(text(), 'origin2')]",
                 locateStrategy: 'xpath'
             })
-    }
+    },
+    'sync the commit #group4': function (browser: NightwatchBrowser) {
+        browser
+            .pause(1000)
+            .waitForElementVisible('*[data-id="sourcecontrol-panel"]')
+            .click('*[data-id="sourcecontrol-panel"]')
+            .waitForElementVisible('*[data-id="syncButton"]')
+            .click('*[data-id="syncButton"]')
+            .waitForElementVisible('*[data-id="commitButton"]')
+            .click('*[data-id="commits-panel"]')
+            .waitForElementPresent({
+                selector: '//*[@data-id="commit-summary-testcommit-"]',
+                locateStrategy: 'xpath'
+            })
+    },
+    'check the log #group4': async function (browser: NightwatchBrowser) {
+        const logs = await getGitLog('/tmp/git/bare2.git')
+        console.log(logs)
+        browser.assert.ok(logs.includes('testcommit'))
+        const logs2 = await getGitLog('/tmp/git/bare.git')
+        console.log(logs2)
+        browser.assert.fail(logs2.includes('testcommit'))
+    },
+    'switch to origin #group4': function (browser: NightwatchBrowser) {
+        browser
+            .click('*[data-id="remotes-panel"]')
+            .waitForElementVisible('*[data-id="set-as-default-origin"]')
+            .click('*[data-id="set-as-default-origin"]')
+    },
+    'check the commands for origin #group4': function (browser: NightwatchBrowser) {
+        browser
+            .click('*[data-id="commands-panel"]')
+            .waitForElementVisible({
+                selector: "//div[@id='commands-remote-origin-select']//div[contains(@class, 'singleValue') and contains(text(), 'origin')]",
+                locateStrategy: 'xpath'
+            })
+    },
+    'check the commit ahead #group4': function (browser: NightwatchBrowser) {
+        browser
+            .pause(1000)
+            .waitForElementVisible('*[data-id="sourcecontrol-panel"]')
+            .click('*[data-id="sourcecontrol-panel"]')
+            .waitForElementVisible('*[data-id="syncButton"]')
+            // do not sync
+            .click('*[data-id="commits-panel"]')
+            .waitForElementPresent({
+                selector: '//*[@data-id="commit-summary-testcommit-ahead"]',
+                locateStrategy: 'xpath'
+            })
+    },
 }
 
 async function getBranches(path: string): Promise<string> {

--- a/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
+++ b/apps/remix-ide-e2e/src/tests/workspace_git.test.ts
@@ -491,11 +491,11 @@ module.exports = {
       .click('*[data-id="remotes-panel"]')
       .waitForElementVisible('*[data-id="remotes-panel-content"]')
       .click({
-        selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-origin"]',
+        selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-origin-default"]',
         locateStrategy: 'xpath'
       })
       .waitForElementVisible({
-        selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-origin" and contains(.,"v4-template")]',
+        selector: '//*[@data-id="remotes-panel-content"]//*[@data-id="remote-detail-origin-default" and contains(.,"v4-template")]',
         locateStrategy: 'xpath'
       })
   },

--- a/libs/remix-ui/git/src/components/branchHeader.tsx
+++ b/libs/remix-ui/git/src/components/branchHeader.tsx
@@ -33,7 +33,7 @@ export const BranchHeader = () => {
         }
       }
     }
-  }, [context.currentBranch, context.commits, context.branches, context.remotes, context.currentHead])
+  }, [context.currentBranch, context.commits, context.branches, context.remotes, context.currentHead, context.defaultRemote])
 
   useEffect(() => {
     if (context.fileStatusResult) {

--- a/libs/remix-ui/git/src/components/branchHeader.tsx
+++ b/libs/remix-ui/git/src/components/branchHeader.tsx
@@ -66,6 +66,7 @@ export const BranchHeader = () => {
             {getName() ? (
               <span className={`text-truncate overflow-hidden whitespace-nowrap w-100`}>
                 {getName() ?? ''}
+                {context.currentBranch && context.currentBranch.remote && context.currentBranch.remote.name ? ` on ${context.currentBranch.remote.name}` : ''}
               </span>
             ) : null
             }

--- a/libs/remix-ui/git/src/components/buttons/gituibutton.tsx
+++ b/libs/remix-ui/git/src/components/buttons/gituibutton.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react'
 import { gitPluginContext } from '../gitui'
+import { CustomTooltip } from '@remix-ui/helper';
 
 interface ButtonWithContextProps {
   onClick: React.MouseEventHandler<HTMLButtonElement>;
@@ -7,18 +8,31 @@ interface ButtonWithContextProps {
   disabledCondition?: boolean; // Optional additional disabling condition
   // You can add other props if needed, like 'type', 'className', etc.
   [key: string]: any; // Allow additional props to be passed
+  tooltip?: string;
 }
 
 // This component extends a button, disabling it when loading is true
-const GitUIButton = ({ children, disabledCondition = false, ...rest }:ButtonWithContextProps) => {
+const GitUIButton = ({ children, disabledCondition = false, ...rest }: ButtonWithContextProps) => {
   const { loading } = React.useContext(gitPluginContext)
 
   const isDisabled = loading || disabledCondition
-  return (
-    <button disabled={isDisabled} {...rest}>
-      {children}
-    </button>
-  );
+
+  if (rest.tooltip) {
+
+    return (
+      <CustomTooltip tooltipText={rest.tooltip} placement="top">
+        <button disabled={isDisabled} {...rest}>
+          {children}
+        </button>
+      </CustomTooltip>
+    );
+  } else {
+    return (
+      <button disabled={isDisabled} {...rest}>
+        {children}
+      </button>
+    );
+  }
 };
 
 export default GitUIButton;

--- a/libs/remix-ui/git/src/components/buttons/sourceControlBase.tsx
+++ b/libs/remix-ui/git/src/components/buttons/sourceControlBase.tsx
@@ -44,7 +44,10 @@ export const SourceControlBase = (props: SourceControlButtonsProps) => {
   }, [context.branchDifferences, context.currentBranch, branch, remote])
 
   const setDefaultRemote = () => {
-
+    if(context.defaultRemote) {
+      setRemote(context.defaultRemote)
+      return
+    }
     if (context.remotes.length > 0) {
       // find remote called origin
       const origin = context.remotes.find(remote => remote.name === 'origin')

--- a/libs/remix-ui/git/src/components/buttons/sourceControlBase.tsx
+++ b/libs/remix-ui/git/src/components/buttons/sourceControlBase.tsx
@@ -44,7 +44,7 @@ export const SourceControlBase = (props: SourceControlButtonsProps) => {
   }, [context.branchDifferences, context.currentBranch, branch, remote])
 
   const setDefaultRemote = () => {
-    if(context.defaultRemote) {
+    if (context.defaultRemote) {
       setRemote(context.defaultRemote)
       return
     }

--- a/libs/remix-ui/git/src/components/github/branchselect.tsx
+++ b/libs/remix-ui/git/src/components/github/branchselect.tsx
@@ -38,7 +38,7 @@ export const BranchSelect = (props: BranchySelectProps) => {
   return (<>{branchOptions && branchOptions.length ?
     <Select
       options={branchOptions}
-      className="mt-1"
+      className="mt-2"
       id="branch-select"
       onChange={(e: any) => selectRemoteBranch(e)}
       theme={selectTheme}

--- a/libs/remix-ui/git/src/components/github/devicecode.tsx
+++ b/libs/remix-ui/git/src/components/github/devicecode.tsx
@@ -108,14 +108,16 @@ export const GetDeviceCode = () => {
         (context.gitHubUser && context.gitHubUser.login) ?
           <div className="pt-2">
             <Card>
-              <Card.Body>
-                <Card.Title data-id={`connected-as-${context.gitHubUser.login}`}>Connected as {context.gitHubUser.login}</Card.Title>
+              <Card.Body className="p-2">
+              <div className="mb-1" data-id={`connected-as-${context.gitHubUser.login}`}>Connected as {context.gitHubUser.login}</div>
                 <Card.Text>
-                  <img data-id={`connected-img-${context.gitHubUser.login}`} src={context.gitHubUser.avatar_url} className="w-100" />
-                  <a data-id={`connected-link-${context.gitHubUser.login}`} href={context.gitHubUser.html_url}>{context.gitHubUser.html_url}</a>
-                  {context.userEmails && context.userEmails.filter((email: any) => email.primary).map((email: any) => {
-                    return <span key={email.email}><br></br>{email.email}</span>
-                  })}
+                  <img data-id={`connected-img-${context.gitHubUser.login}`} src={context.gitHubUser.avatar_url} className="w-25" />
+                  <br></br>
+                  
+                    <a data-id={`connected-link-${context.gitHubUser.login}`} href={context.gitHubUser.html_url}>{context.gitHubUser.html_url}</a>
+                    {context.userEmails && context.userEmails.filter((email: any) => email.primary).map((email: any) => {
+                      return <span key={email.email}><br></br>{email.email}</span>
+                    })}
                 </Card.Text>
               </Card.Body>
             </Card>

--- a/libs/remix-ui/git/src/components/github/devicecode.tsx
+++ b/libs/remix-ui/git/src/components/github/devicecode.tsx
@@ -129,7 +129,6 @@ export const GetDeviceCode = () => {
               </div>
             </div>
 
-
           </div> : null
       }
 

--- a/libs/remix-ui/git/src/components/github/devicecode.tsx
+++ b/libs/remix-ui/git/src/components/github/devicecode.tsx
@@ -71,10 +71,11 @@ export const GetDeviceCode = () => {
 
   return (
     <>
-      {(context.gitHubUser && context.gitHubUser.login) ? null :
+      {(context.gitHubUser && context.gitHubUser.login) ? null : <>
+        <label className="text-uppercase">Connect to GitHub</label>
         <button className='btn btn-secondary mt-1 w-100' onClick={async () => {
           await getDeviceCodeFromGitHub()
-        }}><i className="fab fa-github mr-1"></i>Login in with github</button>
+        }}><i className="fab fa-github mr-1"></i>Login in with github</button></>
       }
       {gitHubResponse && !authorized &&
         <div className="pt-2">
@@ -109,15 +110,15 @@ export const GetDeviceCode = () => {
           <div className="pt-2">
             <Card>
               <Card.Body className="p-2">
-              <div className="mb-1" data-id={`connected-as-${context.gitHubUser.login}`}>Connected as {context.gitHubUser.login}</div>
+                <div className="mb-1" data-id={`connected-as-${context.gitHubUser.login}`}>Connected as {context.gitHubUser.login}</div>
                 <Card.Text>
                   <img data-id={`connected-img-${context.gitHubUser.login}`} src={context.gitHubUser.avatar_url} className="w-25" />
                   <br></br>
-                  
-                    <a data-id={`connected-link-${context.gitHubUser.login}`} href={context.gitHubUser.html_url}>{context.gitHubUser.html_url}</a>
-                    {context.userEmails && context.userEmails.filter((email: any) => email.primary).map((email: any) => {
-                      return <span key={email.email}><br></br>{email.email}</span>
-                    })}
+
+                  <a data-id={`connected-link-${context.gitHubUser.login}`} href={context.gitHubUser.html_url}>{context.gitHubUser.html_url}</a>
+                  {context.userEmails && context.userEmails.filter((email: any) => email.primary).map((email: any) => {
+                    return <span key={email.email}><br></br>{email.email}</span>
+                  })}
                 </Card.Text>
               </Card.Body>
             </Card>

--- a/libs/remix-ui/git/src/components/github/devicecode.tsx
+++ b/libs/remix-ui/git/src/components/github/devicecode.tsx
@@ -108,20 +108,27 @@ export const GetDeviceCode = () => {
       {
         (context.gitHubUser && context.gitHubUser.login) ?
           <div className="pt-2">
-            <Card>
-              <Card.Body className="p-2">
-                <div className="mb-1" data-id={`connected-as-${context.gitHubUser.login}`}>Connected as {context.gitHubUser.login}</div>
-                <Card.Text>
-                  <img data-id={`connected-img-${context.gitHubUser.login}`} src={context.gitHubUser.avatar_url} className="w-25" />
-                  <br></br>
 
-                  <a data-id={`connected-link-${context.gitHubUser.login}`} href={context.gitHubUser.html_url}>{context.gitHubUser.html_url}</a>
+            <div className="mb-1" data-id={`connected-as-${context.gitHubUser.login}`}>Connected as {context.gitHubUser.login}</div>
+            <div className="row">
+              {context.gitHubUser.avatar_url ?
+                <div className="col-6">
+                  <img data-id={`connected-img-${context.gitHubUser.login}`} src={context.gitHubUser.avatar_url} className="w-100" />
+                </div> : null}
+            </div>
+            <div className="row mt-2">
+              <div className="col-6">
+                {context.gitHubUser.html_url ? <>
+                  <label className="text-uppercase">user on github:</label>
+                  <a data-id={`connected-link-${context.gitHubUser.login}`} href={context.gitHubUser.html_url}>{context.gitHubUser.html_url}</a> </> : null}
+                {context.userEmails && context.userEmails.length > 0 ? <>
+                  <label className="text-uppercase mt-2">email:</label>
                   {context.userEmails && context.userEmails.filter((email: any) => email.primary).map((email: any) => {
                     return <span key={email.email}><br></br>{email.email}</span>
-                  })}
-                </Card.Text>
-              </Card.Body>
-            </Card>
+                  })}</> : null}
+              </div>
+            </div>
+
 
           </div> : null
       }

--- a/libs/remix-ui/git/src/components/github/repositoryselect.tsx
+++ b/libs/remix-ui/git/src/components/github/repositoryselect.tsx
@@ -18,6 +18,7 @@ const RepositorySelect = (props: RepositorySelectProps) => {
   const actions = React.useContext(gitActionsContext)
   const [loading, setLoading] = useState(false)
   const [show, setShow] = useState(false)
+  const [selected, setSelected] = useState<any>(null)
 
   useEffect(() => {
     if (context.repositories && context.repositories.length > 0) {
@@ -39,6 +40,7 @@ const RepositorySelect = (props: RepositorySelectProps) => {
   const selectRepo = async (e: any) => {
     if (!e || !e.value) {
       props.select(null)
+      setSelected(null)
       return
     }
     const value = e && e.value
@@ -49,6 +51,7 @@ const RepositorySelect = (props: RepositorySelectProps) => {
 
     if (repo) {
       props.select(repo)
+      setSelected(repo)
       await actions.remoteBranches(repo.owner.login, repo.name)
     }
   }
@@ -70,17 +73,20 @@ const RepositorySelect = (props: RepositorySelectProps) => {
     </button>
     {
       show ?
-        <Select
-          options={repoOtions}
-          className="mt-1"
-          id="repository-select"
-          onChange={(e: any) => selectRepo(e)}
-          theme={selectTheme}
-          styles={selectStyles}
-          isClearable={true}
-          placeholder="Type to search for a repository..."
-          isLoading={loading}
-        /> : null
+        <>
+          <Select
+            options={repoOtions}
+            className="mt-1"
+            id="repository-select"
+            onChange={(e: any) => selectRepo(e)}
+            theme={selectTheme}
+            styles={selectStyles}
+            isClearable={true}
+            placeholder="Type to search for a repository..."
+            isLoading={loading}
+          />
+          { selected ? null : <label className="text-warning mt-2">Please select a repository</label> }
+        </>: null
     }</>
   );
 };

--- a/libs/remix-ui/git/src/components/github/selectandclonerepositories.tsx
+++ b/libs/remix-ui/git/src/components/github/selectandclonerepositories.tsx
@@ -43,7 +43,7 @@ export const SelectAndCloneRepositories = (props: RepositoriesProps) => {
 
   return (
     <>
-      <RepositorySelect title="Clone from GitHub" select={selectRepo} />
+      <RepositorySelect title="Load from GitHub" select={selectRepo} />
       <TokenWarning />
 
       { repo && <BranchSelect select={selectRemoteBranch} /> }

--- a/libs/remix-ui/git/src/components/github/selectandclonerepositories.tsx
+++ b/libs/remix-ui/git/src/components/github/selectandclonerepositories.tsx
@@ -18,7 +18,7 @@ export const SelectAndCloneRepositories = (props: RepositoriesProps) => {
   const [branch, setBranch] = useState({ name: "" });
   const [repo, setRepo] = useState<repository>(null);
 
-  const selectRemoteBranch = async (branch:{ name: string }) => {
+  const selectRemoteBranch = async (branch: { name: string }) => {
     setBranch(branch)
   }
 
@@ -46,12 +46,15 @@ export const SelectAndCloneRepositories = (props: RepositoriesProps) => {
       <RepositorySelect title="Load from GitHub" select={selectRepo} />
       <TokenWarning />
 
-      { repo && <BranchSelect select={selectRemoteBranch} /> }
+      {repo && <BranchSelect select={selectRemoteBranch} />}
 
-      { repo && branch && branch.name && branch.name !== '0' ?
+      {repo && branch && branch.name && branch.name !== '0' ?
         <button data-id={`clonebtn-${repo.full_name}-${branch.name}`} className='btn btn-primary mt-1 w-100' onClick={async () => {
           await clone()
-        }}>clone {repo.full_name}:{branch.name}</button> : null }
+        }}>clone {repo.full_name}:{branch.name}</button> : null}
+
+      {repo && (!branch || branch.name === '0') ?
+        <label className="text-warning">Please select a branch to clone</label> : null}
 
     </>
   )

--- a/libs/remix-ui/git/src/components/navigation/branchedetails.tsx
+++ b/libs/remix-ui/git/src/components/navigation/branchedetails.tsx
@@ -57,6 +57,10 @@ export const BrancheDetailsNavigation = (props: BrancheDetailsNavigationProps) =
 
   }
 
+  if(branch.name === 'HEAD'){
+    return null;
+  }
+
   return (
     <>
       <div className="d-flex flex-row w-100 mb-2 mt-2">

--- a/libs/remix-ui/git/src/components/navigation/branchedetails.tsx
+++ b/libs/remix-ui/git/src/components/navigation/branchedetails.tsx
@@ -5,6 +5,7 @@ import { gitActionsContext } from "../../state/context";
 import { branch } from "../../types";
 import GitUIButton from "../buttons/gituibutton";
 import { gitPluginContext } from "../gitui";
+import { removeGitFromUrl } from "../../utils";
 
 interface BrancheDetailsNavigationProps {
   eventKey: string;
@@ -33,7 +34,7 @@ export const BrancheDetailsNavigation = (props: BrancheDetailsNavigationProps) =
 
   const openRemote = () => {
     const remote = branch.remote || getRemote()
-    window.open(`${remote.url}/tree/${branch.name}`, '_blank');
+    window.open(`${removeGitFromUrl(remote.url)}/tree/${branch.name}`, '_blank');
   }
 
   const reloadBranch = () => {

--- a/libs/remix-ui/git/src/components/navigation/branchedetails.tsx
+++ b/libs/remix-ui/git/src/components/navigation/branchedetails.tsx
@@ -13,10 +13,11 @@ interface BrancheDetailsNavigationProps {
   callback: (eventKey: string) => void;
   branch: branch;
   checkout: (branch: branch) => void;
+  allowCheckout: boolean;
 }
 
 export const BrancheDetailsNavigation = (props: BrancheDetailsNavigationProps) => {
-  const { eventKey, activePanel, callback, branch, checkout } = props;
+  const { eventKey, activePanel, callback, branch, checkout, allowCheckout } = props;
   const context = React.useContext(gitPluginContext)
   const actions = React.useContext(gitActionsContext)
   const handleClick = () => {
@@ -64,18 +65,19 @@ export const BrancheDetailsNavigation = (props: BrancheDetailsNavigationProps) =
             activePanel === eventKey ? <FontAwesomeIcon className='' icon={faCaretDown}></FontAwesomeIcon> : <FontAwesomeIcon className='' icon={faCaretRight}></FontAwesomeIcon>
           }
           <i className="fa fa-code-branch ml-1"></i>
-          <div className={`ml-1 ${context.currentBranch.name === branch.name ? 'text-success' : ''}`}>{branch.name} {branch.remote ? `on ${branch.remote.name}` : ''}</div>
+          <div className={`ml-1 ${context.currentBranch.name === branch.name && allowCheckout ? 'text-success' : ''}`}>{branch.name} {branch.remote ? `on ${branch.remote.name}` : ''}</div>
 
         </div>
-        {context.currentBranch && context.currentBranch.name === branch.name ?
-          <GitUIButton data-id={`branches-toggle-current-branch-${branch.name}`} className="btn btn-sm p-0 mr-1" onClick={() => { }}>
-            <FontAwesomeIcon className='pointer text-success' icon={faToggleOff} ></FontAwesomeIcon>
-          </GitUIButton>
-          :
-          <GitUIButton tooltip="checkout branch" data-id={`branches-toggle-branch-${branch.name}`} className="btn btn-sm p-0 mr-1" onClick={() => checkout(branch)}>
-            <FontAwesomeIcon icon={faToggleOn}></FontAwesomeIcon>
-          </GitUIButton>
-        }
+        {allowCheckout ?
+          context.currentBranch && context.currentBranch.name === branch.name ?
+            <GitUIButton data-id={`branches-toggle-current-branch-${branch.name}`} className="btn btn-sm p-0 mr-1" onClick={() => { }}>
+              <FontAwesomeIcon className='pointer text-success' icon={faToggleOff} ></FontAwesomeIcon>
+            </GitUIButton>
+            :
+            <GitUIButton tooltip="checkout branch" data-id={`branches-toggle-branch-${branch.name}`} className="btn btn-sm p-0 mr-1" onClick={() => checkout(branch)}>
+              <FontAwesomeIcon icon={faToggleOn}></FontAwesomeIcon>
+            </GitUIButton>
+          : null}
         {!branch.remote && canFetch() && <>
           <GitUIButton tooltip="fetch branch" className="btn btn-sm p-0 mr-1 text-muted" onClick={() => fetchBranch()}><FontAwesomeIcon icon={faSync} ></FontAwesomeIcon></GitUIButton>
           <GitUIButton tooltip="open on remote" className="btn btn-sm p-0 mr-1 text-muted" onClick={() => openRemote()}><FontAwesomeIcon icon={faGlobe} ></FontAwesomeIcon></GitUIButton>

--- a/libs/remix-ui/git/src/components/navigation/branchedetails.tsx
+++ b/libs/remix-ui/git/src/components/navigation/branchedetails.tsx
@@ -57,7 +57,7 @@ export const BrancheDetailsNavigation = (props: BrancheDetailsNavigationProps) =
 
   }
 
-  if(branch.name === 'HEAD'){
+  if (branch.name === 'HEAD'){
     return null;
   }
 

--- a/libs/remix-ui/git/src/components/navigation/branchedetails.tsx
+++ b/libs/remix-ui/git/src/components/navigation/branchedetails.tsx
@@ -72,22 +72,22 @@ export const BrancheDetailsNavigation = (props: BrancheDetailsNavigationProps) =
             <FontAwesomeIcon className='pointer text-success' icon={faToggleOff} ></FontAwesomeIcon>
           </GitUIButton>
           :
-          <GitUIButton data-id={`branches-toggle-branch-${branch.name}`} className="btn btn-sm p-0 mr-1" onClick={() => checkout(branch)}>
+          <GitUIButton tooltip="checkout branch" data-id={`branches-toggle-branch-${branch.name}`} className="btn btn-sm p-0 mr-1" onClick={() => checkout(branch)}>
             <FontAwesomeIcon icon={faToggleOn}></FontAwesomeIcon>
           </GitUIButton>
         }
         {!branch.remote && canFetch() && <>
-          <GitUIButton className="btn btn-sm p-0 mr-1 text-muted" onClick={() => fetchBranch()}><FontAwesomeIcon icon={faSync} ></FontAwesomeIcon></GitUIButton>
-          <GitUIButton className="btn btn-sm p-0 mr-1 text-muted" onClick={() => openRemote()}><FontAwesomeIcon icon={faGlobe} ></FontAwesomeIcon></GitUIButton>
+          <GitUIButton tooltip="fetch branch" className="btn btn-sm p-0 mr-1 text-muted" onClick={() => fetchBranch()}><FontAwesomeIcon icon={faSync} ></FontAwesomeIcon></GitUIButton>
+          <GitUIButton tooltip="open on remote" className="btn btn-sm p-0 mr-1 text-muted" onClick={() => openRemote()}><FontAwesomeIcon icon={faGlobe} ></FontAwesomeIcon></GitUIButton>
         </>}
         {branch.remote?.url && <>
-          <GitUIButton className="btn btn-sm p-0 mr-1 text-muted" onClick={() => reloadBranch()}>
+          <GitUIButton tooltip="fetch branch" className="btn btn-sm p-0 mr-1 text-muted" onClick={() => reloadBranch()}>
             <FontAwesomeIcon icon={faSync} ></FontAwesomeIcon>
           </GitUIButton>
         </>}
 
         {branch.remote?.url && <>
-          <GitUIButton className="btn btn-sm p-0 mr-1 text-muted" onClick={() => openRemote()}>
+          <GitUIButton tooltip="open remote" className="btn btn-sm p-0 mr-1 text-muted" onClick={() => openRemote()}>
             <FontAwesomeIcon icon={faGlobe} ></FontAwesomeIcon>
           </GitUIButton>
         </>}

--- a/libs/remix-ui/git/src/components/navigation/commitdetails.tsx
+++ b/libs/remix-ui/git/src/components/navigation/commitdetails.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useContext, useEffect } from "react";
 import { CommitSummary } from "../panels/commits/commitsummary";
 import { ReadCommitResult } from "isomorphic-git"
+import { branch } from "../../types";
 
 interface CommitDetailsNavigationProps {
   commit: ReadCommitResult,
@@ -11,10 +12,11 @@ interface CommitDetailsNavigationProps {
   activePanel: string
   callback: (eventKey: string) => void
   isAheadOfRepo: boolean
+  branch: branch
 }
 
 export const CommitDetailsNavigation = (props: CommitDetailsNavigationProps) => {
-  const { commit, checkout, eventKey, activePanel, callback, isAheadOfRepo } = props;
+  const { commit, checkout, eventKey, activePanel, callback, isAheadOfRepo, branch } = props;
   const handleClick = () => {
     if (!callback) return
     if (activePanel === eventKey) {
@@ -30,7 +32,7 @@ export const CommitDetailsNavigation = (props: CommitDetailsNavigationProps) => 
           activePanel === eventKey ? <FontAwesomeIcon className='' icon={faCaretDown}></FontAwesomeIcon> : <FontAwesomeIcon className='' icon={faCaretRight}></FontAwesomeIcon>
         }
 
-        <CommitSummary isAheadOfRepo={isAheadOfRepo} commit={commit} checkout={checkout}></CommitSummary>
+        <CommitSummary branch={branch} isAheadOfRepo={isAheadOfRepo} commit={commit} checkout={checkout}></CommitSummary>
       </div>
     </>
   );

--- a/libs/remix-ui/git/src/components/navigation/remotesdetails.tsx
+++ b/libs/remix-ui/git/src/components/navigation/remotesdetails.tsx
@@ -54,15 +54,15 @@ export const RemotesDetailsNavigation = (props: RemotesDetailsNavigationProps) =
         {context.defaultRemote && context.defaultRemote?.url === remote.url ?
           <GitUIButton className="btn btn-sm" onClick={() => { }} disabledCondition={true}><FontAwesomeIcon className='text-success' icon={faCheck} ></FontAwesomeIcon></GitUIButton>
           :
-          <GitUIButton className="btn btn-sm" onClick={setAsDefault}><FontAwesomeIcon icon={faToggleOn}></FontAwesomeIcon></GitUIButton>
+          <GitUIButton tooltip="set as default" className="btn btn-sm" onClick={setAsDefault}><FontAwesomeIcon icon={faToggleOn}></FontAwesomeIcon></GitUIButton>
         }
-        <GitUIButton data-id={`remote-sync-${remote.name}`} className="btn btn-sm" onClick={async () => {
+        <GitUIButton tooltip="Fetch remote" data-id={`remote-sync-${remote.name}`} className="btn btn-sm" onClick={async () => {
           await actions.fetch({
             remote
           })
         }}><FontAwesomeIcon icon={faSync} ></FontAwesomeIcon></GitUIButton>
         <GitUIButton data-id={`remote-rm-${remote.name}`} className="btn btn-sm" onClick={() => actions.removeRemote(remote)}><FontAwesomeIcon className='text-danger' icon={faTrash} ></FontAwesomeIcon></GitUIButton>
-        {remote?.url && <GitUIButton className="btn btn-sm pr-0" onClick={() => openRemote()}><FontAwesomeIcon icon={faGlobe} ></FontAwesomeIcon></GitUIButton>}
+        {remote?.url && <GitUIButton tooltip="open on remote" className="btn btn-sm pr-0" onClick={() => openRemote()}><FontAwesomeIcon icon={faGlobe} ></FontAwesomeIcon></GitUIButton>}
       </div>
     </>
   );

--- a/libs/remix-ui/git/src/components/navigation/remotesdetails.tsx
+++ b/libs/remix-ui/git/src/components/navigation/remotesdetails.tsx
@@ -6,6 +6,7 @@ import { gitActionsContext } from "../../state/context";
 import { branch, remote } from "../../types";
 import GitUIButton from "../buttons/gituibutton";
 import { gitPluginContext } from "../gitui";
+import { removeGitFromUrl } from "../../utils";
 
 interface RemotesDetailsNavigationProps {
   eventKey: string;
@@ -29,7 +30,7 @@ export const RemotesDetailsNavigation = (props: RemotesDetailsNavigationProps) =
   }
 
   const openRemote = () => {
-    window.open(`${remote.url}`, '_blank');
+    window.open(`${removeGitFromUrl(remote.url)}`, '_blank');
   }
 
   const setAsDefault = () => {

--- a/libs/remix-ui/git/src/components/navigation/remotesdetails.tsx
+++ b/libs/remix-ui/git/src/components/navigation/remotesdetails.tsx
@@ -56,9 +56,9 @@ export const RemotesDetailsNavigation = (props: RemotesDetailsNavigationProps) =
 
         </div>
         {isDefault() ?
-          <GitUIButton className="btn btn-sm" onClick={() => { }} disabledCondition={true}><FontAwesomeIcon className='text-success' icon={faCheck} ></FontAwesomeIcon></GitUIButton>
+          <GitUIButton data-id={`default-remote-check-${remote.name}`}className="btn btn-sm" onClick={() => { }} disabledCondition={true}><FontAwesomeIcon className='text-success' icon={faCheck} ></FontAwesomeIcon></GitUIButton>
           :
-          <GitUIButton tooltip="set as default" className="btn btn-sm" onClick={setAsDefault}><FontAwesomeIcon icon={faToggleOn}></FontAwesomeIcon></GitUIButton>
+          <GitUIButton data-id={`set-as-default-${remote.name}`} tooltip="set as default" className="btn btn-sm" onClick={setAsDefault}><FontAwesomeIcon icon={faToggleOn}></FontAwesomeIcon></GitUIButton>
         }
         <GitUIButton tooltip="Fetch remote" data-id={`remote-sync-${remote.name}`} className="btn btn-sm" onClick={async () => {
           await actions.fetch({

--- a/libs/remix-ui/git/src/components/navigation/remotesdetails.tsx
+++ b/libs/remix-ui/git/src/components/navigation/remotesdetails.tsx
@@ -37,21 +37,25 @@ export const RemotesDetailsNavigation = (props: RemotesDetailsNavigationProps) =
     actions.setDefaultRemote(remote)
   }
 
+  const isDefault = () => {
+    return (context.defaultRemote && context.defaultRemote?.url === remote.url) || (context.upstream && context.upstream?.url === remote.url)
+  }
+
   return (
     <>
       <div className="d-flex flex-row w-100 mb-2 mt-2">
-        <div data-id={`remote-detail-${remote.name}${context.defaultRemote && context.defaultRemote?.url === remote.url ? '-default' : ''}`} onClick={() => handleClick()} role={'button'} className='pointer long-and-truncated d-flex flex-row commit-navigation'>
+        <div data-id={`remote-detail-${remote.name}${isDefault() ? '-default' : ''}`} onClick={() => handleClick()} role={'button'} className='pointer long-and-truncated d-flex flex-row commit-navigation'>
           {
             activePanel === eventKey ? <FontAwesomeIcon className='' icon={faCaretDown}></FontAwesomeIcon> : <FontAwesomeIcon className='' icon={faCaretRight}></FontAwesomeIcon>
           }
           <CustomTooltip tooltipText={remote.url} placement="top">
-            <div className={`long-and-truncated ml-1 ${context.defaultRemote && context.defaultRemote?.url === remote.url ? 'text-success' : ''}`}>
+            <div className={`long-and-truncated ml-1 ${isDefault() ? 'text-success' : ''}`}>
               {remote.name}  <FontAwesomeIcon className='' icon={faArrowRightArrowLeft}></FontAwesomeIcon> {remote.url}
             </div>
           </CustomTooltip>
 
         </div>
-        {context.defaultRemote && context.defaultRemote?.url === remote.url ?
+        {isDefault() ?
           <GitUIButton className="btn btn-sm" onClick={() => { }} disabledCondition={true}><FontAwesomeIcon className='text-success' icon={faCheck} ></FontAwesomeIcon></GitUIButton>
           :
           <GitUIButton tooltip="set as default" className="btn btn-sm" onClick={setAsDefault}><FontAwesomeIcon icon={faToggleOn}></FontAwesomeIcon></GitUIButton>

--- a/libs/remix-ui/git/src/components/panels/branches.tsx
+++ b/libs/remix-ui/git/src/components/panels/branches.tsx
@@ -35,7 +35,7 @@ export const Branches = () => {
                 <label className="text-uppercase">remote branches on {context.upstream ? context.upstream.name : null}</label>
                 {context.branches && context.branches.filter((branch, index) => branch.remote && branch.remote.name === context.upstream.name).map((branch, index) => {
                   return (
-                    <RemoteBranchDetails key={index} branch={branch}></RemoteBranchDetails>
+                    <RemoteBranchDetails allowCheckout={true} key={index} branch={branch}></RemoteBranchDetails>
                   );
                 })}
                 <GitUIButton data-id={`remote-sync-${context.upstream.name}`} className="btn btn-sm" onClick={async () => {

--- a/libs/remix-ui/git/src/components/panels/branches.tsx
+++ b/libs/remix-ui/git/src/components/panels/branches.tsx
@@ -32,18 +32,19 @@ export const Branches = () => {
             <hr />
             {context.upstream ?
               <>
-                <label className="text-uppercase">remote branches on {context.upstream ? context.upstream.name : null}</label>
-                {context.branches && context.branches.filter((branch, index) => branch.remote && branch.remote.name === context.upstream.name).map((branch, index) => {
-                  return (
-                    <RemoteBranchDetails allowCheckout={true} key={index} branch={branch}></RemoteBranchDetails>
-                  );
-                })}
-                <GitUIButton data-id={`remote-sync-${context.upstream.name}`} className="btn btn-sm" onClick={async () => {
-                  await actions.fetch({
-                    remote: context.upstream
-                  })
-                }}><FontAwesomeIcon icon={faSync} ></FontAwesomeIcon><label className="pl-1">Fetch more from remote</label></GitUIButton>
-                <hr /></> : null}
+                <div data-id='branches-panel-content-remote-branches'>
+                  <label className="text-uppercase">remote branches on {context.upstream ? context.upstream.name : null}</label>
+                  {context.branches && context.branches.filter((branch, index) => branch.remote && branch.remote.name === context.upstream.name).map((branch, index) => {
+                    return (
+                      <RemoteBranchDetails allowCheckout={true} key={index} branch={branch}></RemoteBranchDetails>
+                    );
+                  })}
+                  <GitUIButton data-id={`remote-sync-${context.upstream.name}`} className="btn btn-sm" onClick={async () => {
+                    await actions.fetch({
+                      remote: context.upstream
+                    })
+                  }}><FontAwesomeIcon icon={faSync} ></FontAwesomeIcon><label className="pl-1">Fetch more from remote</label></GitUIButton>
+                  <hr /></div></> : null}
 
           </div> : null}
         {context.currentBranch

--- a/libs/remix-ui/git/src/components/panels/branches.tsx
+++ b/libs/remix-ui/git/src/components/panels/branches.tsx
@@ -23,12 +23,14 @@ export const Branches = () => {
       <div data-id='branches-panel-content' className="pt-2">
         {context.branches && context.branches.length ?
           <div>
-            <label className="text-uppercase">local branches</label>
-            {context.branches && context.branches.filter((branch, index) => !branch.remote).map((branch, index) => {
-              return (
-                <LocalBranchDetails key={index} branch={branch}></LocalBranchDetails>
-              );
-            })}
+            <div data-id='branches-panel-content-local-branches'>
+              <label className="text-uppercase">local branches</label>
+              {context.branches && context.branches.filter((branch, index) => !branch.remote).map((branch, index) => {
+                return (
+                  <LocalBranchDetails key={index} branch={branch}></LocalBranchDetails>
+                );
+              })}
+            </div>
             <hr />
             {context.upstream ?
               <>

--- a/libs/remix-ui/git/src/components/panels/branches.tsx
+++ b/libs/remix-ui/git/src/components/panels/branches.tsx
@@ -6,6 +6,8 @@ import GitUIButton from "../buttons/gituibutton";
 import { gitPluginContext } from "../gitui";
 import { LocalBranchDetails } from "./branches/localbranchdetails";
 import { RemoteBranchDetails } from "./branches/remotebranchedetails";
+import { faSync } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 export const Branches = () => {
   const context = React.useContext(gitPluginContext)
@@ -31,11 +33,16 @@ export const Branches = () => {
             {context.upstream ?
               <>
                 <label className="text-uppercase">remote branches on {context.upstream ? context.upstream.name : null}</label>
-                {context.branches && context.branches.filter((branch, index) => branch.remote && branch.remote.name === context.upstream.name ).map((branch, index) => {
+                {context.branches && context.branches.filter((branch, index) => branch.remote && branch.remote.name === context.upstream.name).map((branch, index) => {
                   return (
                     <RemoteBranchDetails key={index} branch={branch}></RemoteBranchDetails>
                   );
                 })}
+                <GitUIButton data-id={`remote-sync-${context.upstream.name}`} className="btn btn-sm" onClick={async () => {
+                  await actions.fetch({
+                    remote: context.upstream
+                  })
+                }}><FontAwesomeIcon icon={faSync} ></FontAwesomeIcon><label className="pl-1">Fetch more from remote</label></GitUIButton>
                 <hr /></> : null}
 
           </div> : null}

--- a/libs/remix-ui/git/src/components/panels/branches.tsx
+++ b/libs/remix-ui/git/src/components/panels/branches.tsx
@@ -21,12 +21,22 @@ export const Branches = () => {
       <div data-id='branches-panel-content' className="pt-2">
         {context.branches && context.branches.length ?
           <div>
+            <label className="text-uppercase">local branches</label>
             {context.branches && context.branches.filter((branch, index) => !branch.remote).map((branch, index) => {
               return (
                 <LocalBranchDetails key={index} branch={branch}></LocalBranchDetails>
               );
             })}
             <hr />
+            {context.upstream ?
+              <>
+                <label className="text-uppercase">remote branches on {context.upstream ? context.upstream.name : null}</label>
+                {context.branches && context.branches.filter((branch, index) => branch.remote && branch.remote.name === context.upstream.name ).map((branch, index) => {
+                  return (
+                    <RemoteBranchDetails key={index} branch={branch}></RemoteBranchDetails>
+                  );
+                })}
+                <hr /></> : null}
 
           </div> : null}
         {context.currentBranch

--- a/libs/remix-ui/git/src/components/panels/branches/branchdifferencedetails.tsx
+++ b/libs/remix-ui/git/src/components/panels/branches/branchdifferencedetails.tsx
@@ -33,7 +33,7 @@ export const BranchDifferenceDetails = (props: BrancheDifferenceProps) => {
   }
 
   return (
-    <Accordion activeKey={activePanel} defaultActiveKey="">
+    <Accordion activeKey={activePanel} className="mt-2" defaultActiveKey="">
       <CommitsNavigation ahead={ahead} behind={behind} branch={branch} remote={remote} title={title} eventKey="0" activePanel={activePanel} callback={setActivePanel} />
       <Accordion.Collapse className="pl-2 border-left ml-1" eventKey="0">
         <div data-id={`branchdifference-commits-${branch.name}${ahead?'-ahead':''}${behind?'-behind':''}`} className="ml-1">

--- a/libs/remix-ui/git/src/components/panels/branches/localbranchdetails.tsx
+++ b/libs/remix-ui/git/src/components/panels/branches/localbranchdetails.tsx
@@ -63,7 +63,7 @@ export const LocalBranchDetails = (props: BrancheDetailsProps) => {
   }
 
   return (<Accordion activeKey={activePanel} defaultActiveKey="">
-    <BrancheDetailsNavigation checkout={checkout} branch={branch} eventKey="0" activePanel={activePanel} callback={setActivePanel} />
+    <BrancheDetailsNavigation allowCheckout={true} checkout={checkout} branch={branch} eventKey="0" activePanel={activePanel} callback={setActivePanel} />
     <Accordion.Collapse className="pl-2 border-left ml-1" eventKey="0">
       <>
         <div className="ml-1">

--- a/libs/remix-ui/git/src/components/panels/branches/remotebranchedetails.tsx
+++ b/libs/remix-ui/git/src/components/panels/branches/remotebranchedetails.tsx
@@ -12,10 +12,11 @@ import GitUIButton from "../../buttons/gituibutton";
 
 export interface BrancheDetailsProps {
   branch: branch;
+  allowCheckout: boolean
 }
 
 export const RemoteBranchDetails = (props: BrancheDetailsProps) => {
-  const { branch } = props;
+  const { branch, allowCheckout } = props;
   const actions = React.useContext(gitActionsContext)
   const context = React.useContext(gitPluginContext)
   const [activePanel, setActivePanel] = useState<string>("");
@@ -89,7 +90,7 @@ export const RemoteBranchDetails = (props: BrancheDetailsProps) => {
   }
 
   return (<Accordion activeKey={activePanel} defaultActiveKey="">
-    <BrancheDetailsNavigation checkout={checkout} branch={branch} eventKey="0" activePanel={activePanel} callback={setActivePanel} />
+    <BrancheDetailsNavigation allowCheckout={allowCheckout} checkout={checkout} branch={branch} eventKey="0" activePanel={activePanel} callback={setActivePanel} />
     <Accordion.Collapse className="pl-2 border-left ml-1" eventKey="0">
       <>
         <div data-id={`remote-branch-commits-${branch && branch.name}`} className="ml-1">

--- a/libs/remix-ui/git/src/components/panels/clone.tsx
+++ b/libs/remix-ui/git/src/components/panels/clone.tsx
@@ -64,9 +64,11 @@ export const Clone = () => {
   return (
     <>
       <div data-id="clone-panel-content">
+        <label className="text-uppercase">Clone from GitHub</label>
         <SelectAndCloneRepositories cloneAllBranches={cloneAllBranches} cloneDepth={cloneDepth} />
         <hr />
-        <InputGroup className="mb-2 pb-1">
+        <label className="text-uppercase">Clone from URL</label>
+        <InputGroup className="mb-2">
           <FormControl data-id="clone-url" id="cloneulr" placeholder="url" name='cloneurl' value={cloneUrl} onChange={e => onGitHubCloneUrlChange(e.target.value)} aria-describedby="urlprepend" />
         </InputGroup>
 

--- a/libs/remix-ui/git/src/components/panels/clone.tsx
+++ b/libs/remix-ui/git/src/components/panels/clone.tsx
@@ -8,7 +8,12 @@ import { SelectAndCloneRepositories } from "../github/selectandclonerepositories
 import { RemixUiCheckbox } from "@remix-ui/checkbox"
 import GitUIButton from "../buttons/gituibutton"
 
-export const Clone = () => {
+interface CloneProps {
+  hideLoadFromGitHub?: boolean
+}
+
+export const Clone = (props: CloneProps) => {
+  const { hideLoadFromGitHub } = props
   const context = React.useContext(gitPluginContext)
   const actions = React.useContext(gitActionsContext)
   const [cloneUrl, setCloneUrl] = useLocalStorage(
@@ -64,9 +69,10 @@ export const Clone = () => {
   return (
     <>
       <div data-id="clone-panel-content">
-        <label className="text-uppercase">Clone from GitHub</label>
-        <SelectAndCloneRepositories cloneAllBranches={cloneAllBranches} cloneDepth={cloneDepth} />
-        <hr />
+        {!hideLoadFromGitHub ? <>
+          <label className="text-uppercase">Clone from GitHub</label>
+          <SelectAndCloneRepositories cloneAllBranches={cloneAllBranches} cloneDepth={cloneDepth} />
+          <hr /></> : null}
         <label className="text-uppercase">Clone from URL</label>
         <InputGroup className="mb-2">
           <FormControl data-id="clone-url" id="cloneulr" placeholder="url" name='cloneurl' value={cloneUrl} onChange={e => onGitHubCloneUrlChange(e.target.value)} aria-describedby="urlprepend" />

--- a/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
+++ b/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
@@ -19,10 +19,11 @@ export const PushPull = () => {
   const [force, setForce] = useState(false)
 
   useEffect(() => {
+    console.log('context.currentBranch', context.currentBranch, context.remotes, context.branches)
     setRemoteBranch(context.currentBranch.name)
     setLocalBranch(context.currentBranch.name)
 
-    const currentUpstreamIsInRemotes = context.upstream && context.remotes.find(r => r.name === context.upstream.name)
+    const currentUpstreamIsInRemotes = context.upstream && context.remotes.find(r => r.name === context.upstream.name && r.url === context.upstream.url)
     if (!context.upstream || !currentUpstreamIsInRemotes) {
       if (context.currentBranch && context.currentBranch.remote && context.currentBranch.remote.name) {
         actions.setUpstreamRemote(context.currentBranch.remote)

--- a/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
+++ b/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
@@ -39,6 +39,13 @@ export const PushPull = () => {
     }
   }, [context.currentBranch, context.remotes, context.branches])
 
+  useEffect(() => {
+    console.log('defaultRemote', context.defaultRemote)
+    if (context.defaultRemote && context.remotes.find(r => r.name === context.defaultRemote.name && r.url === context.defaultRemote.url)) {
+      actions.setUpstreamRemote(context.defaultRemote)
+    }
+  },[context.defaultRemote])
+
   const onRemoteBranchChange = (value: string) => {
     setRemoteBranch(value)
   }

--- a/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
+++ b/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
@@ -19,7 +19,6 @@ export const PushPull = () => {
   const [force, setForce] = useState(false)
 
   useEffect(() => {
-    console.log('context.currentBranch', context.currentBranch, context.remotes, context.branches)
     setRemoteBranch(context.currentBranch.name)
     setLocalBranch(context.currentBranch.name)
 

--- a/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
+++ b/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
@@ -40,7 +40,6 @@ export const PushPull = () => {
   }, [context.currentBranch, context.remotes, context.branches])
 
   useEffect(() => {
-    console.log('defaultRemote', context.defaultRemote)
     if (context.defaultRemote && context.remotes.find(r => r.name === context.defaultRemote.name && r.url === context.defaultRemote.url)) {
       actions.setUpstreamRemote(context.defaultRemote)
     }

--- a/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
+++ b/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
@@ -126,6 +126,7 @@ export const PushPull = () => {
     }
     const remoteBranches = context.branches && context.branches.length > 0 && context.branches
       .filter(branch => branch.remote && branch.remote.name === context.upstream.name)
+      .filter(branch => branch.name !== 'HEAD')
       .map(repo => {
         return { value: repo.name, label: repo.name }
       }

--- a/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
+++ b/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
@@ -58,6 +58,7 @@ export const PushPull = () => {
     const remote: remote = context.remotes.find(r => r.name === value)
     if (remote) {
       actions.setUpstreamRemote(remote)
+      actions.setDefaultRemote(remote)
     }
   }
 
@@ -119,15 +120,19 @@ export const PushPull = () => {
       })
     setLocalBranchOptions(localBranches)
 
+    if(!context.upstream){
+      setRemoteBranchOptions([])
+      return
+    }
     const remoteBranches = context.branches && context.branches.length > 0 && context.branches
-      .filter(branch => branch.remote)
+      .filter(branch => branch.remote && branch.remote.name === context.upstream.name)
       .map(repo => {
         return { value: repo.name, label: repo.name }
       }
       )
     setRemoteBranchOptions(remoteBranches)
 
-  }, [context.branches])
+  }, [context.branches, context.upstream])
 
   useEffect(() => {
 

--- a/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
+++ b/libs/remix-ui/git/src/components/panels/commands/pushpull.tsx
@@ -120,7 +120,7 @@ export const PushPull = () => {
       })
     setLocalBranchOptions(localBranches)
 
-    if(!context.upstream){
+    if (!context.upstream){
       setRemoteBranchOptions([])
       return
     }

--- a/libs/remix-ui/git/src/components/panels/commits/commitdetails.tsx
+++ b/libs/remix-ui/git/src/components/panels/commits/commitdetails.tsx
@@ -6,6 +6,7 @@ import { gitActionsContext } from "../../../state/context";
 import { gitPluginContext } from "../../gitui";
 import { CommitDetailsItems } from "./commitdetailsitem";
 import { branch, remote } from "@remix-ui/git";
+import { removeGitFromUrl } from "../../../utils";
 
 export interface CommitDetailsProps {
   commit: ReadCommitResult;
@@ -41,7 +42,7 @@ export const CommitDetails = (props: CommitDetailsProps) => {
 
   const openFileOnRemote = (file: string, hash: string) => {
     if (!getRemote()) return
-    window.open(`${getRemote() ? `${getRemote().url}/blob/${hash}/${file}` : ""}`, "_blank")
+    window.open(`${getRemote() ? `${removeGitFromUrl(getRemote().url)}/blob/${hash}/${file}` : ""}`, "_blank")
   }
 
   return (<Accordion activeKey={activePanel} defaultActiveKey="">

--- a/libs/remix-ui/git/src/components/panels/commits/commitdetails.tsx
+++ b/libs/remix-ui/git/src/components/panels/commits/commitdetails.tsx
@@ -41,7 +41,6 @@ export const CommitDetails = (props: CommitDetailsProps) => {
   }
 
   const openFileOnRemote = (file: string, hash: string, branch: branch) => {
-    console.log(branch)
     if (!getRemote()) return
     window.open(`${getRemote() ? `${removeGitFromUrl(getRemote().url)}/blob/${hash}/${file}` : ""}`, "_blank")
   }

--- a/libs/remix-ui/git/src/components/panels/commits/commitdetails.tsx
+++ b/libs/remix-ui/git/src/components/panels/commits/commitdetails.tsx
@@ -28,7 +28,7 @@ export const CommitDetails = (props: CommitDetailsProps) => {
   }, [activePanel])
 
   const getRemote = (): remote | null => {
-    return context.upstream ? context.upstream : context.defaultRemote ? context.defaultRemote : null
+    return branch.remote? branch.remote: context.upstream ? context.upstream : context.defaultRemote ? context.defaultRemote : null
   }
 
   const commitsAhead = (remote: remote) => {
@@ -40,19 +40,20 @@ export const CommitDetails = (props: CommitDetailsProps) => {
     return commitsAhead(getRemote()).findIndex((c) => c.oid === commit.oid) > -1
   }
 
-  const openFileOnRemote = (file: string, hash: string) => {
+  const openFileOnRemote = (file: string, hash: string, branch: branch) => {
+    console.log(branch)
     if (!getRemote()) return
     window.open(`${getRemote() ? `${removeGitFromUrl(getRemote().url)}/blob/${hash}/${file}` : ""}`, "_blank")
   }
 
   return (<Accordion activeKey={activePanel} defaultActiveKey="">
-    <CommitDetailsNavigation isAheadOfRepo={isAheadOfRepo()} commit={commit} checkout={checkout} eventKey="0" activePanel={activePanel} callback={setActivePanel} />
+    <CommitDetailsNavigation isAheadOfRepo={isAheadOfRepo()} branch={branch} commit={commit} checkout={checkout} eventKey="0" activePanel={activePanel} callback={setActivePanel} />
     <Accordion.Collapse className="pl-2 border-left ml-1" eventKey="0">
       <>
         {context.commitChanges && context.commitChanges.filter(
           (change) => change.hashModified === commit.oid && change.hashOriginal === commit.commit.parent[0]
         ).map((change, index) => {
-          return (<CommitDetailsItems openFileOnRemote={openFileOnRemote} isAheadOfRepo={isAheadOfRepo()} key={index} commitChange={change}></CommitDetailsItems>)
+          return (<CommitDetailsItems branch={branch} openFileOnRemote={openFileOnRemote} isAheadOfRepo={isAheadOfRepo()} key={index} commitChange={change}></CommitDetailsItems>)
         })}
 
       </>

--- a/libs/remix-ui/git/src/components/panels/commits/commitdetails.tsx
+++ b/libs/remix-ui/git/src/components/panels/commits/commitdetails.tsx
@@ -28,7 +28,7 @@ export const CommitDetails = (props: CommitDetailsProps) => {
   }, [activePanel])
 
   const getRemote = (): remote | null => {
-    return branch.remote? branch.remote: context.upstream ? context.upstream : context.defaultRemote ? context.defaultRemote : null
+    return context.upstream ? context.upstream : context.defaultRemote ? context.defaultRemote : branch.remote ? branch.remote : null
   }
 
   const commitsAhead = (remote: remote) => {

--- a/libs/remix-ui/git/src/components/panels/commits/commitdetailsitem.tsx
+++ b/libs/remix-ui/git/src/components/panels/commits/commitdetailsitem.tsx
@@ -9,11 +9,12 @@ import GitUIButton from "../../buttons/gituibutton";
 export interface CCommitDetailsItemsProps {
   commitChange: commitChange;
   isAheadOfRepo: boolean;
-  openFileOnRemote: (file: string, hash: string) => void;
+  openFileOnRemote: (file: string, hash: string, branch: branch) => void;
+  branch: branch
 }
 
 export const CommitDetailsItems = (props: CCommitDetailsItemsProps) => {
-  const { commitChange, isAheadOfRepo, openFileOnRemote } = props;
+  const { commitChange, isAheadOfRepo, openFileOnRemote, branch } = props;
   const actions = React.useContext(gitActionsContext)
   const pluginActions = React.useContext(pluginActionsContext)
 
@@ -23,7 +24,7 @@ export const CommitDetailsItems = (props: CCommitDetailsItemsProps) => {
   }
 
   const openRemote = () => {
-    openFileOnRemote(commitChange.path, commitChange.hashModified)
+    openFileOnRemote(commitChange.path, commitChange.hashModified, branch)
   }
 
   function FunctionStatusIcons() {

--- a/libs/remix-ui/git/src/components/panels/commits/commitdetailsitem.tsx
+++ b/libs/remix-ui/git/src/components/panels/commits/commitdetailsitem.tsx
@@ -4,6 +4,7 @@ import path from "path";
 import { gitActionsContext, pluginActionsContext } from "../../../state/context";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGlobe } from "@fortawesome/free-solid-svg-icons";
+import GitUIButton from "../../buttons/gituibutton";
 
 export interface CCommitDetailsItemsProps {
   commitChange: commitChange;
@@ -43,7 +44,8 @@ export const CommitDetailsItems = (props: CCommitDetailsItemsProps) => {
       </div>
       <div className="d-flex align-items-end">
         {!isAheadOfRepo ?
-          <FontAwesomeIcon role={'button'} icon={faGlobe} onClick={() => openRemote()} className="pointer mr-1 align-self-center" /> : <></>}
+          <GitUIButton tooltip="open on remote" className="btn btn-sm p-0 text-muted mr-1" onClick={() => openRemote()}><FontAwesomeIcon icon={faGlobe} ></FontAwesomeIcon></GitUIButton>
+          : <></>}
         <FunctionStatusIcons></FunctionStatusIcons>
       </div>
     </div>

--- a/libs/remix-ui/git/src/components/panels/commits/commitsummary.tsx
+++ b/libs/remix-ui/git/src/components/panels/commits/commitsummary.tsx
@@ -3,7 +3,7 @@ import { default as dateFormat } from "dateformat";
 import React from "react";
 import { faGlobe } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { remote } from "@remix-ui/git";
+import { branch, remote } from "@remix-ui/git";
 import GitUIButton from "../../buttons/gituibutton";
 import { gitPluginContext } from "../../gitui";
 import { removeGitFromUrl } from "../../../utils";
@@ -12,10 +12,11 @@ export interface CommitSummaryProps {
   commit: ReadCommitResult;
   checkout: (oid: string) => void;
   isAheadOfRepo: boolean
+  branch: branch
 }
 
 export const CommitSummary = (props: CommitSummaryProps) => {
-  const { commit, checkout, isAheadOfRepo } = props;
+  const { commit, checkout, isAheadOfRepo, branch } = props;
   const context = React.useContext(gitPluginContext)
 
   const getDate = (commit: ReadCommitResult) => {
@@ -47,7 +48,7 @@ export const CommitSummary = (props: CommitSummaryProps) => {
   };
 
   const getRemote = (): remote | null => {
-    return context.upstream ? context.upstream : context.defaultRemote ? context.defaultRemote : null
+    return branch.remote? branch.remote: context.upstream ? context.upstream : context.defaultRemote ? context.defaultRemote : null
   }
 
   const openRemote = () => {

--- a/libs/remix-ui/git/src/components/panels/commits/commitsummary.tsx
+++ b/libs/remix-ui/git/src/components/panels/commits/commitsummary.tsx
@@ -65,7 +65,7 @@ export const CommitSummary = (props: CommitSummaryProps) => {
       </div>
       {commit.commit.author.name || ""}
       <span className="ml-1">{getDate(commit)}</span>
-      {getRemote() && getRemote()?.url && !isAheadOfRepo && <GitUIButton className="btn btn-sm p-0 text-muted ml-1" onClick={() => openRemote()}><FontAwesomeIcon icon={faGlobe} ></FontAwesomeIcon></GitUIButton>}
+      {getRemote() && getRemote()?.url && !isAheadOfRepo && <GitUIButton tooltip="open on remote" className="btn btn-sm p-0 text-muted ml-1" onClick={() => openRemote()}><FontAwesomeIcon icon={faGlobe} ></FontAwesomeIcon></GitUIButton>}
     </>
   )
 }

--- a/libs/remix-ui/git/src/components/panels/commits/commitsummary.tsx
+++ b/libs/remix-ui/git/src/components/panels/commits/commitsummary.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { remote } from "@remix-ui/git";
 import GitUIButton from "../../buttons/gituibutton";
 import { gitPluginContext } from "../../gitui";
+import { removeGitFromUrl } from "../../../utils";
 
 export interface CommitSummaryProps {
   commit: ReadCommitResult;
@@ -51,7 +52,7 @@ export const CommitSummary = (props: CommitSummaryProps) => {
 
   const openRemote = () => {
     if (getRemote())
-      window.open(`${getRemote().url}/commit/${commit.oid}`, '_blank');
+      window.open(`${removeGitFromUrl(getRemote().url)}/commit/${commit.oid}`, '_blank');
   }
   function removeLineBreaks(str: string): string {
     return str.replace(/(\r\n|\n|\r)/gm, '');

--- a/libs/remix-ui/git/src/components/panels/githubcredentials.tsx
+++ b/libs/remix-ui/git/src/components/panels/githubcredentials.tsx
@@ -19,7 +19,7 @@ export const GitHubCredentials = () => {
 
   useEffect(() => {
     refresh()
-    if (context.gitHubUser){
+    if (context.gitHubUser) {
       setScopeWarning(!(context.gitHubScopes && context.gitHubScopes.length > 0))
     } else {
       setScopeWarning(false)
@@ -67,14 +67,15 @@ export const GitHubCredentials = () => {
 
   return (
     <>
+      <label className="text-uppercase">Enter GitHub credentials manually</label>
       <div className="input-group text-secondary mb-3 h6">
-        <input data-id='githubToken' type="password" value={githubToken} placeholder="GitHub token" className="form-control" name='githubToken' onChange={e => handleChangeTokenState(e.target.value)} />
+        <input data-id='githubToken' type="password" autoComplete="off" value={githubToken} placeholder="GitHub token" className="form-control" name='githubToken' onChange={e => handleChangeTokenState(e.target.value)} />
         <div className="input-group-append">
           <CopyToClipboard content={githubToken} data-id='copyToClipboardCopyIcon' className='far fa-copy ml-1 p-2 mt-1' direction={"top"} />
         </div>
       </div>
-      <input data-id='gitubUsername' name='githubUsername' onChange={e => handleChangeUserNameState(e.target.value)} value={githubUsername} className="form-control mb-3" placeholder="Git username" type="text" id="githubUsername" />
-      <input data-id='githubEmail' name='githubEmail' onChange={e => handleChangeEmailState(e.target.value)} value={githubEmail} className="form-control mb-3" placeholder="Git email" type="text" id="githubEmail" />
+      <input data-id='gitubUsername' name='githubUsername' onChange={e => handleChangeUserNameState(e.target.value)} value={githubUsername} className="form-control mb-3" placeholder="* Git username" type="text" id="githubUsername" />
+      <input data-id='githubEmail' name='githubEmail' onChange={e => handleChangeEmailState(e.target.value)} value={githubEmail} className="form-control mb-3" placeholder="* Git email" type="text" id="githubEmail" />
       <div className="d-flex justify-content-between">
         <button data-id='saveGitHubCredentials' className="btn btn-primary w-100" onClick={saveGithubToken}>
           <FormattedMessage id="save" defaultMessage="Save" />
@@ -82,8 +83,8 @@ export const GitHubCredentials = () => {
         <button className="btn btn-danger far fa-trash-alt" onClick={removeToken}>
         </button>
       </div>
-      {scopeWarning?
-        <div className="text-warning">Your GitHub token may not have the correct permissions. Please use the login with GitHub feature.</div>:null}
+      {scopeWarning ?
+        <div className="text-warning">Your GitHub token may not have the correct permissions. Please use the login with GitHub feature.</div> : null}
       <hr />
     </>
   );

--- a/libs/remix-ui/git/src/components/panels/githubcredentials.tsx
+++ b/libs/remix-ui/git/src/components/panels/githubcredentials.tsx
@@ -68,14 +68,19 @@ export const GitHubCredentials = () => {
   return (
     <>
       <label className="text-uppercase">Enter GitHub credentials manually</label>
+      <br></br>
+
+      <label>Git username&nbsp;<small>(required)</small></label>
+      <input data-id='gitubUsername' name='githubUsername' onChange={e => handleChangeUserNameState(e.target.value)} value={githubUsername} className="form-control mb-3" placeholder="* Git username" type="text" id="githubUsername" />
+      <label>Git email&nbsp;<small>(required)</small></label>
+      <input data-id='githubEmail' name='githubEmail' onChange={e => handleChangeEmailState(e.target.value)} value={githubEmail} className="form-control mb-3" placeholder="* Git email" type="text" id="githubEmail" />
+      <label>GitHub token&nbsp;<small>(optional)</small></label>
       <div className="input-group text-secondary mb-3 h6">
         <input data-id='githubToken' type="password" autoComplete="off" value={githubToken} placeholder="GitHub token" className="form-control" name='githubToken' onChange={e => handleChangeTokenState(e.target.value)} />
         <div className="input-group-append">
           <CopyToClipboard content={githubToken} data-id='copyToClipboardCopyIcon' className='far fa-copy ml-1 p-2 mt-1' direction={"top"} />
         </div>
       </div>
-      <input data-id='gitubUsername' name='githubUsername' onChange={e => handleChangeUserNameState(e.target.value)} value={githubUsername} className="form-control mb-3" placeholder="* Git username" type="text" id="githubUsername" />
-      <input data-id='githubEmail' name='githubEmail' onChange={e => handleChangeEmailState(e.target.value)} value={githubEmail} className="form-control mb-3" placeholder="* Git email" type="text" id="githubEmail" />
       <div className="d-flex justify-content-between">
         <button data-id='saveGitHubCredentials' className="btn btn-primary w-100" onClick={saveGithubToken}>
           <FormattedMessage id="save" defaultMessage="Save" />

--- a/libs/remix-ui/git/src/components/panels/githubcredentials.tsx
+++ b/libs/remix-ui/git/src/components/panels/githubcredentials.tsx
@@ -76,7 +76,7 @@ export const GitHubCredentials = () => {
       <input data-id='githubEmail' name='githubEmail' onChange={e => handleChangeEmailState(e.target.value)} value={githubEmail} className="form-control mb-3" placeholder="* Git email" type="text" id="githubEmail" />
       <label>GitHub token&nbsp;<small>(optional)</small></label>
       <div className="input-group text-secondary mb-3 h6">
-        <input data-id='githubToken' type="password" autoComplete="new-password" value={githubToken} placeholder="GitHub token" className="form-control" name='githubToken' onChange={e => handleChangeTokenState(e.target.value)} />
+        <input data-id='githubToken' type="password" autoComplete="off" value={githubToken} placeholder="GitHub token" className="form-control" name='githubToken' onChange={e => handleChangeTokenState(e.target.value)} />
         <div className="input-group-append">
           <CopyToClipboard content={githubToken} data-id='copyToClipboardCopyIcon' className='far fa-copy ml-1 p-2 mt-1' direction={"top"} />
         </div>

--- a/libs/remix-ui/git/src/components/panels/githubcredentials.tsx
+++ b/libs/remix-ui/git/src/components/panels/githubcredentials.tsx
@@ -76,7 +76,7 @@ export const GitHubCredentials = () => {
       <input data-id='githubEmail' name='githubEmail' onChange={e => handleChangeEmailState(e.target.value)} value={githubEmail} className="form-control mb-3" placeholder="* Git email" type="text" id="githubEmail" />
       <label>GitHub token&nbsp;<small>(optional)</small></label>
       <div className="input-group text-secondary mb-3 h6">
-        <input data-id='githubToken' type="password" autoComplete="off" value={githubToken} placeholder="GitHub token" className="form-control" name='githubToken' onChange={e => handleChangeTokenState(e.target.value)} />
+        <input data-id='githubToken' type="password" autoComplete="new-password" value={githubToken} placeholder="GitHub token" className="form-control" name='githubToken' onChange={e => handleChangeTokenState(e.target.value)} />
         <div className="input-group-append">
           <CopyToClipboard content={githubToken} data-id='copyToClipboardCopyIcon' className='far fa-copy ml-1 p-2 mt-1' direction={"top"} />
         </div>

--- a/libs/remix-ui/git/src/components/panels/init.tsx
+++ b/libs/remix-ui/git/src/components/panels/init.tsx
@@ -4,6 +4,7 @@ import React, { useContext } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { gitActionsContext } from '../../state/context';
 import GitUIButton from '../buttons/gituibutton';
+import { Clone } from './clone';
 
 export const Init = () => {
 
@@ -15,15 +16,20 @@ export const Init = () => {
 
   return (
     <>
+
       <div>
         <div className='mt-1 mb-2'>
+          <h5>INITIALIZE</h5>
           <GitUIButton
             onClick={init}
             className="btn w-md-25 w-100 btn-primary"
             data-id="initgit-btn"
-          ><FormattedMessage id='git.init'/></GitUIButton>
+          ><FormattedMessage id='git.init' /></GitUIButton>
         </div>
       </div>
+      <hr></hr>
+      <h5>CLONE</h5>
+      <Clone></Clone>
     </>
   )
 }

--- a/libs/remix-ui/git/src/components/panels/remotes.tsx
+++ b/libs/remix-ui/git/src/components/panels/remotes.tsx
@@ -27,23 +27,25 @@ export const Remotes = () => {
   return (
     <>
       <div data-id="remotes-panel-content" className="d-flex flex-column">
-        <RemotesImport />
-        <hr className="mt-0 border border-2" />
         {context.remotes && context.remotes.length ?
           <div>
 
             {context.remotes && context.remotes.map((remote, index) => {
 
               return (
-                <Remoteselect key={index} remote={remote}></Remoteselect>
+                <Remoteselect key={index} openDefault={index===0} remote={remote}></Remoteselect>
               );
             })}
           </div> : <div>
             <label className="text-uppercase">No remotes</label>
           </div>}
-
-        <input placeholder="remote name" name='remotename' onChange={e => onRemoteNameChange(e.target.value)} value={remoteName} className="form-control mb-3" type="text" id="remotename" />
-        <input placeholder="remote url" name='remoteurl' onChange={e => onUrlChange(e.target.value)} value={url} className="form-control mb-3" type="text" id="remoteurl" />
+        <hr></hr>
+        <label className="text-uppercase">Add remote from GitHub</label>
+        <RemotesImport />
+        <hr></hr>
+        <label className="text-uppercase">Add remote manually</label>
+        <input placeholder="remote name" name='remotename' onChange={e => onRemoteNameChange(e.target.value)} value={remoteName} className="form-control mb-2" type="text" id="remotename" />
+        <input placeholder="remote url" name='remoteurl' onChange={e => onUrlChange(e.target.value)} value={url} className="form-control mb-2" type="text" id="remoteurl" />
 
         <button disabled={(remoteName && url) ? false : true} className='btn btn-primary mt-1 w-100' onClick={async () => {
           addRemote();

--- a/libs/remix-ui/git/src/components/panels/remotes.tsx
+++ b/libs/remix-ui/git/src/components/panels/remotes.tsx
@@ -44,10 +44,10 @@ export const Remotes = () => {
         <RemotesImport />
         <hr></hr>
         <label className="text-uppercase">Add remote manually</label>
-        <input placeholder="remote name" name='remotename' onChange={e => onRemoteNameChange(e.target.value)} value={remoteName} className="form-control mb-2" type="text" id="remotename" />
-        <input placeholder="remote url" name='remoteurl' onChange={e => onUrlChange(e.target.value)} value={url} className="form-control mb-2" type="text" id="remoteurl" />
+        <input data-id="add-manual-remotename" placeholder="remote name" name='remotename' onChange={e => onRemoteNameChange(e.target.value)} value={remoteName} className="form-control mb-2" type="text" id="remotename" />
+        <input data-id="add-manual-remoteurl" placeholder="remote url" name='remoteurl' onChange={e => onUrlChange(e.target.value)} value={url} className="form-control mb-2" type="text" id="remoteurl" />
 
-        <button disabled={(remoteName && url) ? false : true} className='btn btn-primary mt-1 w-100' onClick={async () => {
+        <button data-id="add-manual-remotebtn" disabled={(remoteName && url) ? false : true} className='btn btn-primary mt-1 w-100' onClick={async () => {
           addRemote();
         }}>add remote</button>
         <hr className="mt-0 border border-2" />

--- a/libs/remix-ui/git/src/components/panels/remotes.tsx
+++ b/libs/remix-ui/git/src/components/panels/remotes.tsx
@@ -33,7 +33,7 @@ export const Remotes = () => {
             {context.remotes && context.remotes.map((remote, index) => {
 
               return (
-                <Remoteselect key={index} openDefault={index===0} remote={remote}></Remoteselect>
+                <Remoteselect key={index} openDefault={(context.upstream && context.upstream.name === remote.url) || index===0} remote={remote}></Remoteselect>
               );
             })}
           </div> : <div>

--- a/libs/remix-ui/git/src/components/panels/remoteselect.tsx
+++ b/libs/remix-ui/git/src/components/panels/remoteselect.tsx
@@ -34,7 +34,7 @@ export const Remoteselect = (props: RemoteSelectProps) => {
           <>
             {context.branches && context.branches.filter((branch, index) => branch.remote && branch.remote.name === remote.name).map((branch, index) => {
               return (
-                <RemoteBranchDetails key={index} branch={branch}></RemoteBranchDetails>
+                <RemoteBranchDetails allowCheckout={false} key={index} branch={branch}></RemoteBranchDetails>
               );
             })}
             <GitUIButton data-id={`remote-sync-${remote.name}`} className="btn btn-sm" onClick={async () => {

--- a/libs/remix-ui/git/src/components/panels/remoteselect.tsx
+++ b/libs/remix-ui/git/src/components/panels/remoteselect.tsx
@@ -17,14 +17,18 @@ export interface RemoteSelectProps {
 }
 
 export const Remoteselect = (props: RemoteSelectProps) => {
-  const { remote } = props;
+  const { remote, openDefault } = props;
   const context = React.useContext(gitPluginContext)
   const actions = React.useContext(gitActionsContext)
   const [activePanel, setActivePanel] = useState<string>("");
 
+  useEffect(() => {
+    setActivePanel(openDefault ? "0" : "")
+  }, [openDefault])
+
   return (
     <>
-      <Accordion activeKey={activePanel ? activePanel : props.openDefault ? '0' : ''} defaultActiveKey=''>
+      <Accordion activeKey={activePanel} defaultActiveKey=''>
         <RemotesDetailsNavigation callback={setActivePanel} eventKey="0" activePanel={activePanel} remote={remote} />
         <Accordion.Collapse className="pl-2 border-left ml-1" eventKey="0">
           <>

--- a/libs/remix-ui/git/src/components/panels/remoteselect.tsx
+++ b/libs/remix-ui/git/src/components/panels/remoteselect.tsx
@@ -7,9 +7,13 @@ import { RemotesDetailsNavigation } from "../navigation/remotesdetails";
 import { Accordion } from "react-bootstrap";
 import { remote } from "../../types";
 import { RemoteBranchDetails } from "./branches/remotebranchedetails";
+import GitUIButton from "../buttons/gituibutton";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSync } from "@fortawesome/free-solid-svg-icons";
 
 export interface RemoteSelectProps {
   remote: remote
+  openDefault: boolean
 }
 
 export const Remoteselect = (props: RemoteSelectProps) => {
@@ -20,15 +24,21 @@ export const Remoteselect = (props: RemoteSelectProps) => {
 
   return (
     <>
-      <Accordion activeKey={activePanel} defaultActiveKey="">
+      <Accordion activeKey={activePanel ? activePanel : props.openDefault ? '0' : ''} defaultActiveKey=''>
         <RemotesDetailsNavigation callback={setActivePanel} eventKey="0" activePanel={activePanel} remote={remote} />
         <Accordion.Collapse className="pl-2 border-left ml-1" eventKey="0">
           <>
-            {context.branches && context.branches.filter((branch, index) => branch.remote && branch.remote.name === remote.name ).map((branch, index) => {
+            {context.branches && context.branches.filter((branch, index) => branch.remote && branch.remote.name === remote.name).map((branch, index) => {
               return (
                 <RemoteBranchDetails key={index} branch={branch}></RemoteBranchDetails>
               );
-            })}</>
+            })}
+            <GitUIButton data-id={`remote-sync-${remote.name}`} className="btn btn-sm" onClick={async () => {
+              await actions.fetch({
+                remote
+              })
+            }}><FontAwesomeIcon icon={faSync} ></FontAwesomeIcon><label className="pl-1">Fetch more from remote</label></GitUIButton>
+          </>
 
         </Accordion.Collapse>
       </Accordion>

--- a/libs/remix-ui/git/src/components/panels/remotesimport.tsx
+++ b/libs/remix-ui/git/src/components/panels/remotesimport.tsx
@@ -75,6 +75,9 @@ export const RemotesImport = () => {
           await addRemote()
         }}>add {remoteName}:{repo.full_name}</button> : null}
 
+      {repo && !remoteName ?
+        <label className="text-warning">Please enter a remote name</label> : null}
+
     </>
   )
 }

--- a/libs/remix-ui/git/src/components/panels/remotesimport.tsx
+++ b/libs/remix-ui/git/src/components/panels/remotesimport.tsx
@@ -64,10 +64,10 @@ export const RemotesImport = () => {
 
   return (
     <>
-      <RepositorySelect title="Add from GitHub" select={selectRepo} />
+      <RepositorySelect title="Load from GitHub" select={selectRepo} />
       <TokenWarning />
       {repo ?
-        <input data-id='remote-panel-remotename' placeholder="remote name" name='remotename' onChange={e => onRemoteNameChange(e.target.value)} value={remoteName} className="form-control mb-2" type="text" id="remotename" />
+        <input data-id='remote-panel-remotename' placeholder="remote name" name='remotename' onChange={e => onRemoteNameChange(e.target.value)} value={remoteName} className="form-control mb-2 mt-2" type="text" id="remotename" />
         : null}
 
       {repo && remoteName ?

--- a/libs/remix-ui/git/src/components/panels/setup.tsx
+++ b/libs/remix-ui/git/src/components/panels/setup.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { GetDeviceCode } from '../github/devicecode'
 import { GitHubCredentials } from './githubcredentials'
+import { Clone } from './clone'
 
 export const Setup = () => {
 
@@ -19,6 +20,8 @@ export const Setup = () => {
           <hr></hr>
           <GitHubCredentials></GitHubCredentials>
         </div>
+        <h5>CLONE</h5>
+        <Clone hideLoadFromGitHub={true}></Clone>
       </>
     )
   } else if (screen === 1) {

--- a/libs/remix-ui/git/src/components/panels/tokenWarning.tsx
+++ b/libs/remix-ui/git/src/components/panels/tokenWarning.tsx
@@ -6,7 +6,7 @@ export const TokenWarning = () => {
   return (<>
     {(context.gitHubUser && context.gitHubUser.login) ? null :
       <span className="text-warning text-left">
-        <span>Generate and add a Git token to use this plugin. Tokens are added in </span><span className=" text-decoration-line-through messageTip" onClick={async () => {
+        <span>Generate and add a Git token or login with GitHub. Tokens are added in </span><span className=" text-decoration-line-through messageTip" onClick={async () => {
         }}>settings.</span>
       </span>
     }

--- a/libs/remix-ui/git/src/lib/gitactions.ts
+++ b/libs/remix-ui/git/src/lib/gitactions.ts
@@ -644,7 +644,7 @@ export const loadGitHubUserFromToken = async () => {
 }
 
 export const statusMatrix = async (filepaths: string[]) => {
-  const matrix = await plugin.call('dgitApi', 'status', { ref: "HEAD", filepaths: filepaths || ['.'] });
+  const matrix = await plugin.call('dgitApi', 'status', { ref: "HEAD", filepaths: filepaths || ['.']});
   const result = (matrix || []).map((x) => {
     return {
       filename: `/${x.shift()}`,

--- a/libs/remix-ui/git/src/lib/gitactions.ts
+++ b/libs/remix-ui/git/src/lib/gitactions.ts
@@ -805,7 +805,8 @@ export const getBranchDifferences = async (branch: branch, remote: remote, state
       }))
   } catch (e) {
     // do nothing
-    dispatch(resetBranchDifferences())
+    if(dispatch)
+      dispatch(resetBranchDifferences())
   }
 }
 

--- a/libs/remix-ui/git/src/lib/gitactions.ts
+++ b/libs/remix-ui/git/src/lib/gitactions.ts
@@ -805,7 +805,7 @@ export const getBranchDifferences = async (branch: branch, remote: remote, state
       }))
   } catch (e) {
     // do nothing
-    if(dispatch)
+    if (dispatch)
       dispatch(resetBranchDifferences())
   }
 }

--- a/libs/remix-ui/git/src/lib/gitactions.ts
+++ b/libs/remix-ui/git/src/lib/gitactions.ts
@@ -322,6 +322,8 @@ export const clone = async (input: cloneInputType) => {
       message: `Cloned ${input.url} to ${repoNameWithTimestamp}`
     })
 
+    plugin.call('notification', 'toast', `Cloned ${input.url} to ${repoNameWithTimestamp}`)
+
   } catch (e: any) {
     await parseError(e)
   }

--- a/libs/remix-ui/git/src/lib/gitactions.ts
+++ b/libs/remix-ui/git/src/lib/gitactions.ts
@@ -1,6 +1,6 @@
 import { ReadBlobResult, ReadCommitResult } from "isomorphic-git";
 import React from "react";
-import { fileStatus, fileStatusMerge, setRemoteBranchCommits, resetRemoteBranchCommits, setBranches, setCanCommit, setCommitChanges, setCommits, setCurrentBranch, setGitHubUser, setLoading, setRemoteBranches, setRemotes, setRepos, setUpstream, setLocalBranchCommits, setBranchDifferences, setRemoteAsDefault, setScopes, setLog, clearLog, setUserEmails, setCurrenHead, setStoragePayload } from "../state/gitpayload";
+import { fileStatus, fileStatusMerge, setRemoteBranchCommits, resetRemoteBranchCommits, setBranches, setCanCommit, setCommitChanges, setCommits, setCurrentBranch, setGitHubUser, setLoading, setRemoteBranches, setRemotes, setRepos, setUpstream, setLocalBranchCommits, setBranchDifferences, setRemoteAsDefault, setScopes, setLog, clearLog, setUserEmails, setCurrenHead, setStoragePayload, resetBranchDifferences } from "../state/gitpayload";
 import { GitHubUser, branch, commitChange, gitActionDispatch, statusMatrixType, gitState, branchDifference, remote, gitLog, fileStatusResult, customGitApi, IGitApi, cloneInputType, fetchInputType, pullInputType, pushInputType, checkoutInput, rmInput, addInput, repository, userEmails, storage } from '../types';
 import { removeSlash } from "../utils";
 import { disableCallBacks, enableCallBacks } from "./listeners";
@@ -784,7 +784,10 @@ export const getBranchDifferences = async (branch: branch, remote: remote, state
       remote = state.remotes[0]
     }
   }
-  if (!remote) return
+  if (!remote) {
+    dispatch(resetBranchDifferences())
+    return
+  }
   try {
 
     const branchDifference: branchDifference = await plugin.call('dgitApi', 'compareBranches', {

--- a/libs/remix-ui/git/src/lib/gitactions.ts
+++ b/libs/remix-ui/git/src/lib/gitactions.ts
@@ -787,13 +787,6 @@ export const getBranchDifferences = async (branch: branch, remote: remote, state
 
   try {
 
-    await fetch({
-      remote: remote,
-      singleBranch: true,
-      ref: branch,
-      quiet: true,
-    })
-
     if (!remote) {
       dispatch(resetBranchDifferences())
       return
@@ -844,6 +837,11 @@ export const addRemote = async (remote: remote) => {
   try {
     await plugin.call('dgitApi', 'addremote', remote)
     await getRemotes()
+    await fetch({
+      remote: remote,
+      singleBranch: true,
+      quiet: true,
+    })
   } catch (e) {
     console.log(e)
   }

--- a/libs/remix-ui/git/src/lib/gitactions.ts
+++ b/libs/remix-ui/git/src/lib/gitactions.ts
@@ -341,7 +341,7 @@ export const fetch = async (input: fetchInputType) => {
     }
   } catch (e: any) {
     console.log(e)
-    await parseError(e)
+    if (!input.quiet) { await parseError(e) }
   }
   dispatch(setLoading(false))
   await enableCallBacks()
@@ -644,7 +644,7 @@ export const loadGitHubUserFromToken = async () => {
 }
 
 export const statusMatrix = async (filepaths: string[]) => {
-  const matrix = await plugin.call('dgitApi', 'status', { ref: "HEAD", filepaths: filepaths || ['.']});
+  const matrix = await plugin.call('dgitApi', 'status', { ref: "HEAD", filepaths: filepaths || ['.'] });
   const result = (matrix || []).map((x) => {
     return {
       filename: `/${x.shift()}`,
@@ -784,11 +784,20 @@ export const getBranchDifferences = async (branch: branch, remote: remote, state
       remote = state.remotes[0]
     }
   }
-  if (!remote) {
-    dispatch(resetBranchDifferences())
-    return
-  }
+
   try {
+
+    await fetch({
+      remote: remote,
+      singleBranch: true,
+      ref: branch,
+      quiet: true,
+    })
+
+    if (!remote) {
+      dispatch(resetBranchDifferences())
+      return
+    }
 
     const branchDifference: branchDifference = await plugin.call('dgitApi', 'compareBranches', {
       branch,
@@ -803,6 +812,7 @@ export const getBranchDifferences = async (branch: branch, remote: remote, state
       }))
   } catch (e) {
     // do nothing
+    dispatch(resetBranchDifferences())
   }
 }
 

--- a/libs/remix-ui/git/src/lib/listeners.ts
+++ b/libs/remix-ui/git/src/lib/listeners.ts
@@ -141,6 +141,12 @@ export const setCallBacks = (viewPlugin: Plugin, gitDispatcher: React.Dispatch<g
     loadFileQueue.enqueue(async () => {
       loadFiles()
     })
+    loadFileQueue.enqueue(async () => {
+      getBranches()
+    })
+    loadFileQueue.enqueue(async () => {
+      gitlog()
+    })
   })
   plugin.on('manager', 'pluginActivated', async (p: Profile<any>) => {
     if (p.name === 'dgitApi') {

--- a/libs/remix-ui/git/src/state/actions.ts
+++ b/libs/remix-ui/git/src/state/actions.ts
@@ -34,6 +34,7 @@ export interface ActionPayloadTypes {
     remote: remote
     branchDifference: branchDifference
   }
+  RESET_BRANCH_DIFFERENCES: null
   SET_GITHUB_USER: GitHubUser
   SET_RATE_LIMIT: any
   SET_GITHUB_ACCESS_TOKEN: string

--- a/libs/remix-ui/git/src/state/gitpayload.ts
+++ b/libs/remix-ui/git/src/state/gitpayload.ts
@@ -192,6 +192,12 @@ export const setBranchDifferences = ({
   }
 }
 
+export const resetBranchDifferences = () => {
+  return {
+    type: 'RESET_BRANCH_DIFFERENCES'
+  }
+}
+
 export const setGItHubToken = (token: string) => {
   return {
     type: 'SET_GITHUB_ACCESS_TOKEN',

--- a/libs/remix-ui/git/src/state/gitreducer.tsx
+++ b/libs/remix-ui/git/src/state/gitreducer.tsx
@@ -156,6 +156,12 @@ export const gitReducer = (state: gitState = defaultGitState, action: Actions): 
       branchDifferences: { ...state.branchDifferences }
     }
 
+  case 'RESET_BRANCH_DIFFERENCES':
+    return {
+      ...state,
+      branchDifferences: {}
+    }
+
   case 'SET_GITHUB_USER':
     return {
       ...state,

--- a/libs/remix-ui/git/src/utils/index.ts
+++ b/libs/remix-ui/git/src/utils/index.ts
@@ -1,3 +1,7 @@
 export const removeSlash = (s: string) => {
   return s.replace(/^\/+/, "");
 };
+
+export const removeGitFromUrl = (url: string) => {
+  return url.replace(/\.git$/, "");
+}


### PR DESCRIPTION
- by default a remote is always opened in remotes
- added a clear indication how to fetch the remote
- selecting a default remote now affects the default upstream in push/pull and in the branches view
- Bracnhes: remote branches of the current remote are also shown in the branch panel so you can select them without going into the remotes section
- Added clone options to the setup page, to be able to clone without setting the credentials
- Added clone option to the initialize repo page so people can clone from there
- Github image is resized now
- fixed the password popup from chrome
- indicate required fields when providing credentials
- added more labels to things
- added tooltips to small icons
- fixed open on remote with urls that contain .git
- disable checkout of branches on any remote in remote list
- sync the default remote with the upstream
- filter remote branch list correctly
- fix tests
- reset branch diff on workspace set
- when adding remote it should fetch it to allow it to be compared to local branches