### PR TITLE
wrong execution Environment Bug Fixed

### DIFF
--- a/libs/remix-ui/run-tab/src/lib/components/contractDropdownUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/contractDropdownUI.tsx
@@ -371,7 +371,7 @@ export function ContractDropdownUI(props: ContractDropdownProps) {
   let evmVersion = null
   try {
     if (loadedContractData && loadedContractData.metadata) {
-      evmVersion = JSON.parse(loadedContractData.metadata).settings.evmVersion
+      evmVersion = props.exEnvironment
     }
   } catch (err) {}
   return (


### PR DESCRIPTION
### The selected execution environment always shows vm-cannun. Now its fixed and it correctly shows selected execution environment. Here is before and after for better explanation.  

![Screenshot 2024-08-18 152143](https://github.com/user-attachments/assets/9cc5e888-944f-4cd6-83b3-97ee372f4b94)

![image](https://github.com/user-attachments/assets/884d4db6-b3fd-4066-a8c4-c54c09ff5acf)

Let me know if need any further changes or details about this pr.

also this issue was also described in this issue #4028