### PR TITLE
fix ethers6

### DIFF
--- a/apps/remix-ide-e2e/src/tests/terminal.test.ts
+++ b/apps/remix-ide-e2e/src/tests/terminal.test.ts
@@ -501,7 +501,7 @@ const deployWithEthersJs = `
 
         const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
         // 'web3Provider' is a remix global variable object
-        const signer = (new ethers.BrowserProvider(web3Provider)).getSigner()
+        const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner()
 
         let factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 
@@ -531,7 +531,7 @@ describe("Storage with lib", function () {
   it("test initial value", async function () {
     // Make sure contract is compiled and artifacts are generated
     const metadata = JSON.parse(await remix.call('fileManager', 'getFile', 'contracts/artifacts/Storage.json'))
-    const signer = (new ethers.BrowserProvider(web3Provider)).getSigner()
+    const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner()
     let Storage = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
     let storage = await Storage.deploy();
     console.log('storage contract Address: ' + storage.address);
@@ -541,7 +541,7 @@ describe("Storage with lib", function () {
 
   it("test updating and retrieving updated value", async function () {
     const metadata = JSON.parse(await remix.call('fileManager', 'getFile', 'contracts/artifacts/Storage.json'))
-    const signer = (new ethers.BrowserProvider(web3Provider)).getSigner()
+    const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner()
     let Storage = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
     let storage = await Storage.deploy();
     await storage.waitForDeployment()
@@ -552,7 +552,7 @@ describe("Storage with lib", function () {
 
   it("fail test updating and retrieving updated value", async function () {
     const metadata = JSON.parse(await remix.call('fileManager', 'getFile', 'contracts/artifacts/Storage.json'))
-    const signer = (new ethers.BrowserProvider(web3Provider)).getSigner()
+    const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner()
     let Storage = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
     let storage = await Storage.deploy();
     await storage.waitForDeployment()

--- a/apps/remix-ide-e2e/src/tests/terminal.test.ts
+++ b/apps/remix-ide-e2e/src/tests/terminal.test.ts
@@ -501,7 +501,7 @@ const deployWithEthersJs = `
 
         const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
         // 'web3Provider' is a remix global variable object
-        const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner()
+        const signer = (new ethers.BrowserProvider(web3Provider)).getSigner()
 
         let factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 
@@ -510,7 +510,7 @@ const deployWithEthersJs = `
         console.log('Contract Address: ', contract.address);
 
         // The contract is NOT deployed yet; we must wait until it is mined
-        await contract.deployed()
+        await contract.waitForDeployment()
         console.log('Deployment successful.')
 
         contract.on('OwnerSet', (previousOwner, newOwner) => {
@@ -531,20 +531,20 @@ describe("Storage with lib", function () {
   it("test initial value", async function () {
     // Make sure contract is compiled and artifacts are generated
     const metadata = JSON.parse(await remix.call('fileManager', 'getFile', 'contracts/artifacts/Storage.json'))
-    const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner()
+    const signer = (new ethers.BrowserProvider(web3Provider)).getSigner()
     let Storage = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
     let storage = await Storage.deploy();
     console.log('storage contract Address: ' + storage.address);
-    await storage.deployed()
+    await storage.waitForDeployment()
     expect((await storage.retrieve()).toNumber()).to.equal(0);
   });
 
   it("test updating and retrieving updated value", async function () {
     const metadata = JSON.parse(await remix.call('fileManager', 'getFile', 'contracts/artifacts/Storage.json'))
-    const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner()
+    const signer = (new ethers.BrowserProvider(web3Provider)).getSigner()
     let Storage = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
     let storage = await Storage.deploy();
-    await storage.deployed()
+    await storage.waitForDeployment()
     const setValue = await storage.store(56);
     await setValue.wait();
     expect((await storage.retrieve()).toNumber()).to.equal(56);
@@ -552,10 +552,10 @@ describe("Storage with lib", function () {
 
   it("fail test updating and retrieving updated value", async function () {
     const metadata = JSON.parse(await remix.call('fileManager', 'getFile', 'contracts/artifacts/Storage.json'))
-    const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner()
+    const signer = (new ethers.BrowserProvider(web3Provider)).getSigner()
     let Storage = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
     let storage = await Storage.deploy();
-    await storage.deployed()
+    await storage.waitForDeployment()
     const setValue = await storage.store(56);
     await setValue.wait();
     expect((await storage.retrieve()).toNumber(), 'incorrect number').to.equal(55);
@@ -623,7 +623,7 @@ describe("Storage", function () {
         const optionsLib = {}
         const factoryLib = await ethers.getContractFactoryFromArtifact(artifactLib, optionsLib)
         const lib = await factoryLib.deploy();
-        await lib.deployed()
+        await lib.waitForDeployment()
 
         const metadata = JSON.parse(await remix.call('fileManager', 'readFile', 'contracts/artifacts/StorageWithLib.json'))
         const artifact  = {
@@ -643,7 +643,7 @@ describe("Storage", function () {
 
         const factory = await ethers.getContractFactoryFromArtifact(artifact, options)
         const storage = await factory.deploy();
-        await storage.deployed()
+        await storage.waitForDeployment()
         const storeValue = await storage.store(333);
         await storeValue.wait();
         expect((await storage.getFromLib()).toString()).to.equal('34');
@@ -779,7 +779,7 @@ const scriptAutoExec = {
 
           const lib = await factoryLib.deploy();
 
-          await lib.deployed()
+          await lib.waitForDeployment()
 
           console.log('lib deployed', lib.address)
 
@@ -803,7 +803,7 @@ const scriptAutoExec = {
 
           const storage = await factory.deploy();
 
-          await storage.deployed()
+          await storage.waitForDeployment()
 
           const storeValue = await storage.store(333);
 
@@ -826,7 +826,7 @@ const scriptBlockAndTransaction = `
     try {
       web3.eth.getTransaction('0x0d2baaed96425861677e87dcf6961d34e2b73ad9a0929c32a05607ca94f98d17').then(console.log).catch(console.error)
       web3.eth.getBlock(4757766).then(console.log).catch(console.error)
-      let ethersProvider = new ethers.providers.Web3Provider(web3Provider)
+      let ethersProvider = new ethers.BrowserProvider(web3Provider)
       ethersProvider.getBlock(4757767).then(console.log).catch(console.error)
     } catch (e) {
         console.log(e.message)

--- a/apps/remix-ide/src/app/tabs/script-runner-ui.tsx
+++ b/apps/remix-ide/src/app/tabs/script-runner-ui.tsx
@@ -39,16 +39,16 @@ export class ScriptRunnerUIPlugin extends ViewPlugin {
     const testPluginUrl = localStorage.getItem('test-plugin-url')
     let baseUrl = 'http://localhost:3000'
     let url = `${baseUrl}?template=${name}`
-    if(testPluginName === 'scriptRunner'){
+    if(testPluginName === 'scriptRunner') {
       // if testpluginurl has template specified only use that
-      if(testPluginUrl.indexOf('template')>-1){
-          url = testPluginUrl
-      }else{
+      if (testPluginUrl.indexOf('template')>-1) {
+        url = testPluginUrl
+      } else {
         baseUrl = `//${new URL(testPluginUrl).host}`
         url = `${baseUrl}?template=${name}&timestamp=${Date.now()}`
       }
     }
-    
+
     const newProfile: IframeProfile = {
       ...profile,
       name: profile.name + name,
@@ -97,7 +97,6 @@ export class ScriptRunnerUIPlugin extends ViewPlugin {
     console.log('info', data)
     this.emit('info', data)
   }
-
 
   render() {
     return (

--- a/libs/ghaction-helper/src/methods.ts
+++ b/libs/ghaction-helper/src/methods.ts
@@ -14,7 +14,7 @@ const providerConfig = {
 const config = { defaultTransactionType: '0x0' }
 global.remixProvider = new Provider(providerConfig)
 global.remixProvider.init()
-global.web3Provider = new ethers.providers.Web3Provider(global.remixProvider)
+global.web3Provider = new ethers.BrowserProvider(global.remixProvider)
 global.provider = global.web3Provider
 global.ethereum = global.web3Provider
 global.web3 = new Web3(global.web3Provider)

--- a/libs/remix-simulator/src/methods/accounts.ts
+++ b/libs/remix-simulator/src/methods/accounts.ts
@@ -76,6 +76,7 @@ export class Web3Accounts {
 
   methods (): Record<string, unknown> {
     return {
+      eth_requestAccounts: this.eth_requestAccounts.bind(this),
       eth_accounts: this.eth_accounts.bind(this),
       eth_getBalance: this.eth_getBalance.bind(this),
       eth_sign: this.eth_sign.bind(this),
@@ -83,6 +84,10 @@ export class Web3Accounts {
       eth_signTypedData: this.eth_signTypedData_v4.bind(this), // default call is using V4
       eth_signTypedData_v4: this.eth_signTypedData_v4.bind(this)
     }
+  }
+
+  eth_requestAccounts (_payload, cb) {
+    return cb(null, Object.keys(this.accounts))
   }
 
   eth_accounts (_payload, cb) {

--- a/libs/remix-simulator/src/methods/transactions.ts
+++ b/libs/remix-simulator/src/methods/transactions.ts
@@ -308,7 +308,6 @@ export class Transactions {
 
       const txBlock = this.vmContext.blockByTxHash[receipt.transactionHash]
       const tx = this.vmContext.txByHash[receipt.transactionHash]
-
       // TODO: params to add later
       const r: Record<string, unknown> = {
         blockHash: bytesToHex(txBlock.hash()),
@@ -322,11 +321,10 @@ export class Transactions {
         input: receipt.input,
         nonce: bigIntToHex(tx.nonce),
         transactionIndex: this.TX_INDEX,
-        value: bigIntToHex(tx.value)
-        // "value":"0xf3dbb76162000" // 4290000000000000
-        // "v": "0x25", // 37
-        // "r": "0x1b5e176d927f8e9ab405058b2d2457392da3e20f328b16ddabcebc33eaac5fea",
-        // "s": "0x4ba69724e8f69de52f0125ad8b3c5c2cef33019bac3249e2c0a2192766d1721c"
+        value: bigIntToHex(tx.value),
+        v: bigIntToHex(tx.v),
+        r: bigIntToHex(tx.r),
+        s: bigIntToHex(tx.s)
       }
 
       if (receipt.to) {

--- a/libs/remix-ws-templates/src/script-templates/contract-deployer/basic-contract-deploy.ts
+++ b/libs/remix-ws-templates/src/script-templates/contract-deployer/basic-contract-deploy.ts
@@ -17,13 +17,13 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner(accountIndex)
+  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 
   const contract = await factory.deploy(...args)
 
   // The contract is NOT deployed yet; we must wait until it is mined
-  await contract.deployed()
+  await contract.waitForDeployment()
   return contract
 }

--- a/libs/remix-ws-templates/src/script-templates/contract-deployer/basic-contract-deploy.ts
+++ b/libs/remix-ws-templates/src/script-templates/contract-deployer/basic-contract-deploy.ts
@@ -17,7 +17,7 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
+  const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 

--- a/libs/remix-ws-templates/src/script-templates/contract-deployer/create2-factory-deploy.ts
+++ b/libs/remix-ws-templates/src/script-templates/contract-deployer/create2-factory-deploy.ts
@@ -15,7 +15,7 @@ export const CREATE2_DEPLOYER_ADDRESS = '0x13b0D85CcB8bf860b6b79AF3029fCA081AE9b
 export const deploy = async (contractName: string, args: Array<any>, salt: string, accountIndex?: number): Promise<string> => {
   console.log(`deploying ${contractName}`)
 
-  const signer = new ethers.providers.Web3Provider(web3Provider).getSigner(accountIndex)
+  const signer = new ethers.BrowserProvider(web3Provider).getSigner(accountIndex)
 
   const factory = new ethers.Contract(CREATE2_DEPLOYER_ADDRESS, contractDeployerAbi, signer)
   //@ts-ignore

--- a/libs/remix-ws-templates/src/script-templates/contract-deployer/create2-factory-deploy.ts
+++ b/libs/remix-ws-templates/src/script-templates/contract-deployer/create2-factory-deploy.ts
@@ -15,7 +15,7 @@ export const CREATE2_DEPLOYER_ADDRESS = '0x13b0D85CcB8bf860b6b79AF3029fCA081AE9b
 export const deploy = async (contractName: string, args: Array<any>, salt: string, accountIndex?: number): Promise<string> => {
   console.log(`deploying ${contractName}`)
 
-  const signer = new ethers.BrowserProvider(web3Provider).getSigner(accountIndex)
+  const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.Contract(CREATE2_DEPLOYER_ADDRESS, contractDeployerAbi, signer)
   //@ts-ignore

--- a/libs/remix-ws-templates/src/templates/gnosisSafeMultisig/scripts/deploy_with_ethers.ts
+++ b/libs/remix-ws-templates/src/templates/gnosisSafeMultisig/scripts/deploy_with_ethers.ts
@@ -3,7 +3,7 @@ import { deploy } from './ethers-lib'
 (async () => {
   try {
     const result = await deploy('MultisigWallet', [])
-    console.log(`address: ${result.address}`)
+    console.log(`address: ${await result.getAddress()}`)
   } catch (e) {
     console.log(e.message)
   }

--- a/libs/remix-ws-templates/src/templates/gnosisSafeMultisig/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/gnosisSafeMultisig/scripts/ethers-lib.ts
@@ -17,13 +17,13 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner(accountIndex)
+  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 
   const contract = await factory.deploy(...args)
 
   // The contract is NOT deployed yet; we must wait until it is mined
-  await contract.deployed()
+  await contract.waitForDeployment()
   return contract
 }

--- a/libs/remix-ws-templates/src/templates/gnosisSafeMultisig/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/gnosisSafeMultisig/scripts/ethers-lib.ts
@@ -17,7 +17,7 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
+  const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 

--- a/libs/remix-ws-templates/src/templates/ozerc1155/scripts/deploy_with_ethers.ts
+++ b/libs/remix-ws-templates/src/templates/ozerc1155/scripts/deploy_with_ethers.ts
@@ -3,7 +3,7 @@ import { deploy } from './ethers-lib'
 (async () => {
   try {
     const result = await deploy('MyToken', [])
-    console.log(`address: ${result.address}`)
+    console.log(`address: ${await result.getAddress()}`)
   } catch (e) {
     console.log(e.message)
   }

--- a/libs/remix-ws-templates/src/templates/ozerc1155/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/ozerc1155/scripts/ethers-lib.ts
@@ -17,13 +17,13 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner(accountIndex)
+  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 
   const contract = await factory.deploy(...args)
 
   // The contract is NOT deployed yet; we must wait until it is mined
-  await contract.deployed()
+  await contract.waitForDeployment()
   return contract
 }

--- a/libs/remix-ws-templates/src/templates/ozerc1155/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/ozerc1155/scripts/ethers-lib.ts
@@ -17,7 +17,7 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
+  const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 

--- a/libs/remix-ws-templates/src/templates/ozerc20/scripts/deploy_with_ethers.ts
+++ b/libs/remix-ws-templates/src/templates/ozerc20/scripts/deploy_with_ethers.ts
@@ -3,7 +3,7 @@ import { deploy } from './ethers-lib'
 (async () => {
   try {
     const result = await deploy('MyToken', [])
-    console.log(`address: ${result.address}`)
+    console.log(`address: ${await result.getAddress()}`)
   } catch (e) {
     console.log(e.message)
   }

--- a/libs/remix-ws-templates/src/templates/ozerc20/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/ozerc20/scripts/ethers-lib.ts
@@ -17,13 +17,13 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner(accountIndex)
+  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 
   const contract = await factory.deploy(...args)
 
   // The contract is NOT deployed yet; we must wait until it is mined
-  await contract.deployed()
+  await contract.waitForDeployment()
   return contract
 }

--- a/libs/remix-ws-templates/src/templates/ozerc20/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/ozerc20/scripts/ethers-lib.ts
@@ -17,7 +17,7 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
+  const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 

--- a/libs/remix-ws-templates/src/templates/ozerc721/scripts/deploy_with_ethers.ts
+++ b/libs/remix-ws-templates/src/templates/ozerc721/scripts/deploy_with_ethers.ts
@@ -3,7 +3,7 @@ import { deploy } from './ethers-lib'
 (async () => {
   try {
     const result = await deploy('MyToken', [])
-    console.log(`address: ${result.address}`)
+    console.log(`address: ${await result.getAddress()}`)
   } catch (e) {
     console.log(e.message)
   }

--- a/libs/remix-ws-templates/src/templates/ozerc721/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/ozerc721/scripts/ethers-lib.ts
@@ -17,13 +17,13 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner(accountIndex)
+  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 
   const contract = await factory.deploy(...args)
 
   // The contract is NOT deployed yet; we must wait until it is mined
-  await contract.deployed()
+  await contract.waitForDeployment()
   return contract
 }

--- a/libs/remix-ws-templates/src/templates/ozerc721/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/ozerc721/scripts/ethers-lib.ts
@@ -17,7 +17,7 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
+  const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 

--- a/libs/remix-ws-templates/src/templates/playground/scripts/deploy_with_ethers.ts
+++ b/libs/remix-ws-templates/src/templates/playground/scripts/deploy_with_ethers.ts
@@ -7,7 +7,7 @@ import { deploy } from './ethers-lib'
 (async () => {
   try {
     const result = await deploy('HelloWorld', [])
-    console.log(`address: ${result.address}`)
+    console.log(`address: ${await result.getAddress()}`)
   } catch (e) {
     console.log(e.message)
   }

--- a/libs/remix-ws-templates/src/templates/playground/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/playground/scripts/ethers-lib.ts
@@ -17,13 +17,13 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner(accountIndex)
+  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 
   const contract = await factory.deploy(...args)
 
   // The contract is NOT deployed yet; we must wait until it is mined
-  await contract.deployed()
+  await contract.waitForDeployment()
   return contract
 }

--- a/libs/remix-ws-templates/src/templates/playground/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/playground/scripts/ethers-lib.ts
@@ -17,7 +17,7 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
+  const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 

--- a/libs/remix-ws-templates/src/templates/remixDefault/scripts/deploy_with_ethers.ts
+++ b/libs/remix-ws-templates/src/templates/remixDefault/scripts/deploy_with_ethers.ts
@@ -7,7 +7,7 @@ import { deploy } from './ethers-lib'
 (async () => {
   try {
     const result = await deploy('Storage', [])
-    console.log(`address: ${result.address}`)
+    console.log(`address: ${await result.getAddress()}`)
   } catch (e) {
     console.log(e.message)
   }

--- a/libs/remix-ws-templates/src/templates/remixDefault/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/remixDefault/scripts/ethers-lib.ts
@@ -17,13 +17,13 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner(accountIndex)
+  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 
   const contract = await factory.deploy(...args)
 
   // The contract is NOT deployed yet; we must wait until it is mined
-  await contract.deployed()
+  await contract.waitForDeployment()
   return contract
 }

--- a/libs/remix-ws-templates/src/templates/remixDefault/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/remixDefault/scripts/ethers-lib.ts
@@ -17,7 +17,7 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
+  const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 

--- a/libs/remix-ws-templates/src/templates/remixDefault/tests/storage.test.js
+++ b/libs/remix-ws-templates/src/templates/remixDefault/tests/storage.test.js
@@ -7,14 +7,14 @@ describe("Storage", function () {
   it("test initial value", async function () {
     const Storage = await ethers.getContractFactory("Storage");
     const storage = await Storage.deploy();
-    await storage.deployed();
+    await storage.waitForDeployment();
     console.log("storage deployed at:" + storage.address);
     expect((await storage.retrieve()).toNumber()).to.equal(0);
   });
   it("test updating and retrieving updated value", async function () {
     const Storage = await ethers.getContractFactory("Storage");
     const storage = await Storage.deploy();
-    await storage.deployed();
+    await storage.waitForDeployment();
     const storage2 = await ethers.getContractAt("Storage", storage.address);
     const setValue = await storage2.store(56);
     await setValue.wait();

--- a/libs/remix-ws-templates/src/templates/zeroxErc20/scripts/deploy_with_ethers.ts
+++ b/libs/remix-ws-templates/src/templates/zeroxErc20/scripts/deploy_with_ethers.ts
@@ -3,7 +3,7 @@ import { deploy } from './ethers-lib'
 (async () => {
   try {
     const result = await deploy('SampleERC20', ["TestToken", "TST", 18, 1000])
-    console.log(`address: ${result.address}`)
+    console.log(`address: ${await result.getAddress()}`)
   } catch (e) {
     console.log(e.message)
   }

--- a/libs/remix-ws-templates/src/templates/zeroxErc20/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/zeroxErc20/scripts/ethers-lib.ts
@@ -17,13 +17,13 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.providers.Web3Provider(web3Provider)).getSigner(accountIndex)
+  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 
   const contract = await factory.deploy(...args)
 
   // The contract is NOT deployed yet; we must wait until it is mined
-  await contract.deployed()
+  await contract.waitForDeployment()
   return contract
 }

--- a/libs/remix-ws-templates/src/templates/zeroxErc20/scripts/ethers-lib.ts
+++ b/libs/remix-ws-templates/src/templates/zeroxErc20/scripts/ethers-lib.ts
@@ -17,7 +17,7 @@ export const deploy = async (contractName: string, args: Array<any>, accountInde
   const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
   // 'web3Provider' is a remix global variable object
 
-  const signer = (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
+  const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)
 
   const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
 


### PR DESCRIPTION
And the script need to ne updated...
from `deploy_with_ethers.ts`: 
```
console.log(`address: ${await result.getAddress()}`)
```
use `getAddress`.

and from the script `ethers-lib.ts`:
```
import { ethers } from 'ethers'

/**
 * Deploy the given contract
 * @param {string} contractName name of the contract to deploy
 * @param {Array<any>} args list of constructor' parameters
 * @param {Number} accountIndex account index from the exposed account
 * @return {Contract} deployed contract
 */
export const deploy = async (contractName: string, args: Array<any>, accountIndex?: number): Promise<ethers.Contract> => {    

  console.log(`deploying ${contractName}`)
  // Note that the script needs the ABI which is generated from the compilation artifact.
  // Make sure contract is compiled and artifacts are generated
  const artifactsPath = `browser/contracts/artifacts/${contractName}.json` // Change this for different path

  const metadata = JSON.parse(await remix.call('fileManager', 'getFile', artifactsPath))
  // 'web3Provider' is a remix global variable object
    
  const signer = await (new ethers.BrowserProvider(web3Provider)).getSigner(accountIndex)

  const factory = new ethers.ContractFactory(metadata.abi, metadata.data.bytecode.object, signer)
  const contract = await factory.deploy(...args)   
  // The contract is NOT deployed yet; we must wait until it is mined
  await contract.waitForDeployment()
  return contract
}
```

