### PR TITLE
fix broken link to i18n.config.json in the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ const locales = [
 ]
 ```
 You can find the language's `code, name, localeName` in this link
-https://github.com/ethereum/ethereum-org-website/blob/dev/i18n/config.json
+https://github.com/ethereum/ethereum-org-website/blob/dev/i18n.config.json
 
 ### Whether or not to use `defaultMessage`?
 If you search `FormattedMessage` or `intl.formatMessage` in this project, you will notice that most of them only have a `id` prop, but a few of them have a `defaultMessage` prop.


### PR DESCRIPTION
Description:

While going through the document, I found the link to config.json becomes invalid.
The link is updated now which works again
