### PR TITLE
Fix Vyper Error Reporting

### DIFF
--- a/apps/vyper/src/app/components/CompileErrorCard.tsx
+++ b/apps/vyper/src/app/components/CompileErrorCard.tsx
@@ -1,4 +1,4 @@
-import {CopyToClipboard} from '@remix-ui/clipboard'
+import { CopyToClipboard } from '@remix-ui/clipboard'
 import Reaact from 'react'
 import { RemixClient } from '../utils'
 
@@ -20,9 +20,9 @@ export function CompileErrorCard(props: { output: any, plugin: RemixClient }) {
       </span>
       <div className="d-flex flex-column pt-3 align-items-end mb-2">
         <div>
-          <span className="border border-ai text-ai btn-sm" onClick={async () => await props.plugin.askGpt(props.output.message)}>
+          {/* <span className="border border-ai text-ai btn-sm" onClick={async () => await props.plugin.askGpt(props.output.message)}>
             Ask RemixAI
-          </span>
+          </span> */}
           <span className="ml-3 pt-1 py-1">
             <CopyToClipboard content={props.output.message} className={`p-0 m-0 far fa-copy alert alert-danger`} direction={'top'} />
           </span>

--- a/apps/vyper/src/app/utils/compiler.tsx
+++ b/apps/vyper/src/app/utils/compiler.tsx
@@ -54,10 +54,6 @@ function parseErrorString(errorStructure: string[]) {
     const choppedup = errorMsg.split(': ')
     errorType = choppedup[0].trim().split('\n')[1]
     message = choppedup[1]
-    // if (errorStructure.length > 2) {
-    //   console.log(choppedup[2].split(',')[1])
-    // }
-    // console.log(choppedup)
   })
   let lines = errorStructure[0].trim().split('\n')
 


### PR DESCRIPTION
Fix Errors display
- Even though errors are random from the hosted compiler
- Error display is ugly for now
- Removed AskGpt Button from Error cards
- Apeworx are supposed to be working on a structured error object which will be returned when there is an error. See [Make Errors more Structured](https://github.com/ApeWorX/hosted-compiler/issues/50)