### PR TITLE
fix at address button enabling

### DIFF
--- a/libs/remix-ui/run-tab/src/lib/components/contractDropdownUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/contractDropdownUI.tsx
@@ -6,7 +6,6 @@ import { ContractData, FuncABI, OverSizeLimit } from '@remix-project/core-plugin
 import * as ethJSUtil from '@ethereumjs/util'
 import { ContractGUI } from './contractGUI'
 import { CustomTooltip, deployWithProxyMsg, upgradeWithProxyMsg } from '@remix-ui/helper'
-import { title } from 'process'
 const _paq = (window._paq = window._paq || [])
 
 export function ContractDropdownUI(props: ContractDropdownProps) {
@@ -80,6 +79,7 @@ export function ContractDropdownUI(props: ContractDropdownProps) {
         content: '',
       })
       if (!currentContract) enableAtAddress(false)
+      if (currentContract && loadedAddress) enableAtAddress(true)
     } else {
       setAbiLabel({
         display: 'none',


### PR DESCRIPTION
fixes #5172 

Without this fix, if you put address in `At address` textbox first and  compile a contract, `At address` button is not enabled.