### PR TITLE
fix matomo bug

### DIFF
--- a/apps/remix-ide-e2e/src/tests/matomo.test.ts
+++ b/apps/remix-ide-e2e/src/tests/matomo.test.ts
@@ -1,0 +1,492 @@
+'use strict'
+import { NightwatchBrowser } from 'nightwatch'
+import init from '../helpers/init'
+
+import examples from '../examples/example-contracts'
+
+const sources = [
+    { 'Untitled.sol': { content: examples.ballot.content } }
+]
+
+module.exports = {
+    '@disabled': true,
+    before: function (browser: NightwatchBrowser, done: VoidFunction) {
+        init(browser, done, 'http://127.0.0.1:8080', false)
+    },
+    'confirm Matomo #group1': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser
+                .execute(function () {
+                    localStorage.removeItem('config-v0.8:.remix.config')
+                    localStorage.setItem('showMatomo', 'true')
+                }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .execute(function () {
+                return (window as any)._paq
+            }, [], (res) => {
+                console.log('_paq', res)
+            })
+            .waitForElementVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .pause(1000)
+            .click('[data-id="matomoModal-modal-footer-ok-react"]') // submitted
+            .execute(function () {
+                return (window as any)._paq
+            }, [], (res) => {
+                console.log('_paq', res)
+            })
+            .waitForElementNotVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .waitForElementVisible('*[data-id="beginnerbtn"]', 10000)
+            .pause(1000)
+            .click('[data-id="beginnerbtn"]')
+            .waitForElementNotPresent('*[data-id="beginnerbtn"]')
+            .waitForElementVisible({
+                selector: `//*[contains(text(), 'Welcome to Remix IDE')]`,
+                locateStrategy: 'xpath'
+            })
+            .refreshPage()
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .waitForElementNotPresent('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .clickLaunchIcon('settings')
+            .verify.elementPresent('[id="settingsMatomoAnalytics"]:checked')
+            .execute(function () {
+                return JSON.parse(window.localStorage.getItem('config-v0.8:.remix.config'))['settings/matomo-analytics'] == true
+            }, [], (res) => {
+                console.log('res', res)
+                browser.assert.ok((res as any).value, 'matomo analytics is enabled')
+            })
+    },
+    'decline Matomo #group1': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser.execute(function () {
+                localStorage.removeItem('config-v0.8:.remix.config')
+                localStorage.setItem('showMatomo', 'true')
+                localStorage.removeItem('matomo-analytics-consent')
+            }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .execute(function () {
+                return (window as any)._paq
+            }, [], (res) => {
+                console.log('_paq', res)
+            })
+            .waitForElementVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .click('[data-id="matomoModal-modal-footer-cancel-react"]') // cancel
+            .execute(function () {
+                return (window as any)._paq
+            }, [], (res) => {
+                console.log('_paq', res)
+            })
+            .waitForElementNotVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .pause(2000)
+            .waitForElementNotPresent('*[data-id="beginnerbtn"]', 10000)
+            .clickLaunchIcon('settings')
+            .waitForElementNotPresent('[id="settingsMatomoAnalytics"]:checked')
+            .execute(function () {
+                return JSON.parse(window.localStorage.getItem('config-v0.8:.remix.config'))['settings/matomo-analytics'] == false
+            }, [], (res) => {
+                console.log('res', res)
+                browser.assert.ok((res as any).value, 'matomo analytics is disabled')
+            })
+    },
+    'blur matomo #group2': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser.execute(function () {
+                localStorage.removeItem('config-v0.8:.remix.config')
+                localStorage.setItem('showMatomo', 'true')
+                localStorage.removeItem('matomo-analytics-consent')
+            }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .waitForElementVisible({
+                selector: '*[data-id="matomoModalModalDialogModalBody-react"]',
+                abortOnFailure: true
+            })
+            .waitForElementVisible('*[data-id="matomoModal-modal-close"]')
+            .click('[data-id="matomoModal-modal-close"]')
+            .waitForElementNotVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .pause(2000)
+            .waitForElementNotPresent('*[data-id="beginnerbtn"]', 10000)
+            .clickLaunchIcon('settings')
+            .waitForElementNotPresent('[id="settingsMatomoAnalytics"]:checked')
+            .execute(function () {
+                return JSON.parse(window.localStorage.getItem('config-v0.8:.remix.config'))['settings/matomo-analytics'] == undefined
+            }, [], (res) => {
+                console.log('res', res)
+                browser.assert.ok((res as any).value, 'matomo analytics is undefined')
+            })
+    },
+    'matomo should reappear #group2': function (browser: NightwatchBrowser) {
+        browser
+            .refreshPage()
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .waitForElementVisible({
+                selector: '*[data-id="matomoModalModalDialogModalBody-react"]',
+                abortOnFailure: true
+            })
+            .waitForElementVisible('*[data-id="matomoModal-modal-close"]')
+            .click('[data-id="matomoModal-modal-close"]')
+            .waitForElementNotVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+    },
+    'change settings #group2': function (browser: NightwatchBrowser) {
+        browser
+            .clickLaunchIcon('settings')
+            .waitForElementVisible('*[data-id="label-matomo-settings"]')
+            .pause(1000)
+            .click('*[data-id="label-matomo-settings"]')
+            .refreshPage()
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .waitForElementNotPresent('*[data-id="matomoModalModalDialogModalBody-react"]')
+    },
+    'should get enter dialog again #group2': function (browser: NightwatchBrowser) {
+        browser
+            .waitForElementVisible('*[data-id="beginnerbtn"]', 10000)
+            .pause(1000)
+            .click('[data-id="beginnerbtn"]')
+            .waitForElementNotPresent('*[data-id="beginnerbtn"]')
+            .waitForElementVisible({
+                selector: `//*[contains(text(), 'Welcome to Remix IDE')]`,
+                locateStrategy: 'xpath'
+            })
+            .waitForElementVisible('*[id="remixTourSkipbtn"]')
+            .click('*[id="remixTourSkipbtn"]')
+            .clickLaunchIcon('settings')
+            .waitForElementPresent('[id="settingsMatomoAnalytics"]:checked')
+            .execute(function () {
+                return JSON.parse(window.localStorage.getItem('config-v0.8:.remix.config'))['settings/matomo-analytics'] == true
+            }, [], (res) => {
+                console.log('res', res)
+                browser.assert.ok((res as any).value, 'matomo analytics is enabled')
+            })
+    },
+    'decline Matomo and check timestamp #group3': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser.execute(function () {
+                localStorage.removeItem('config-v0.8:.remix.config')
+                localStorage.setItem('showMatomo', 'true')
+                localStorage.removeItem('matomo-analytics-consent')
+            }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            // output the contents of the storage
+            .execute(function () {
+                return {
+                    consent: window.localStorage.getItem('matomo-analytics-consent'),
+                    config: window.localStorage.getItem('config-v0.8:.remix.config'),
+                    showMatomo: window.localStorage.getItem('showMatomo')
+                }
+            }, [], (res) => {
+                console.log('res', res)
+            })
+            .waitForElementVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .click('[data-id="matomoModal-modal-footer-cancel-react"]') // cancel
+            .waitForElementNotVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .pause(2000)
+            .execute(function () {
+
+                const timestamp = window.localStorage.getItem('matomo-analytics-consent');
+                if (timestamp) {
+
+                    const consentDate = new Date(Number(timestamp));
+                    // validate it is actually a date
+                    if (isNaN(consentDate.getTime())) {
+                        return false;
+                    }
+                    const now = new Date();
+                    console.log('timestamp', timestamp, consentDate, now.getTime())
+                    const diffInMinutes = (now.getTime() - consentDate.getTime()) / (1000 * 60);
+                    console.log('diffInMinutes', diffInMinutes)
+                    return diffInMinutes < 2;
+                }
+                return false;
+
+            }, [], (res) => {
+                console.log('res', res)
+                browser.assert.ok((res as any).value, 'matomo analytics consent timestamp is set')
+            })
+    },
+    'check old timestamp and reappear Matomo #group3': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser.execute(function () {
+                const oldTimestamp = new Date()
+                oldTimestamp.setMonth(oldTimestamp.getMonth() - 7)
+                localStorage.setItem('matomo-analytics-consent', oldTimestamp.getTime().toString())
+            }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .execute(function () {
+
+                const timestamp = window.localStorage.getItem('matomo-analytics-consent');
+                if (timestamp) {
+
+                    const consentDate = new Date(Number(timestamp));
+                    // validate it is actually a date
+                    if (isNaN(consentDate.getTime())) {
+                        return false;
+                    }
+                    // validate it's older than 6 months
+                    const now = new Date();
+                    const diffInMonths = (now.getFullYear() - consentDate.getFullYear()) * 12 + now.getMonth() - consentDate.getMonth();
+                    console.log('timestamp', timestamp, consentDate, now.getTime())
+                    console.log('diffInMonths', diffInMonths)
+                    return diffInMonths > 6;
+                }
+                return false;
+
+            }, [], (res) => {
+                console.log('res', res)
+                browser.assert.ok((res as any).value, 'matomo analytics consent timestamp is set')
+            })
+            .waitForElementVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .click('[data-id="matomoModal-modal-footer-cancel-react"]') // cancel
+            .waitForElementNotVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+    },
+    'check recent timestamp and do not reappear Matomo #group3': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser.execute(function () {
+                const recentTimestamp = new Date()
+                recentTimestamp.setMonth(recentTimestamp.getMonth() - 1)
+                localStorage.setItem('matomo-analytics-consent', recentTimestamp.getTime().toString())
+            }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            // check if timestamp is younger than 6 months
+            .execute(function () {
+
+                const timestamp = window.localStorage.getItem('matomo-analytics-consent');
+                if (timestamp) {
+
+                    const consentDate = new Date(Number(timestamp));
+                    // validate it is actually a date
+                    if (isNaN(consentDate.getTime())) {
+                        return false;
+                    }
+                    // validate it's younger than 2 months
+                    const now = new Date();
+                    const diffInMonths = (now.getFullYear() - consentDate.getFullYear()) * 12 + now.getMonth() - consentDate.getMonth();
+                    console.log('timestamp', timestamp, consentDate, now.getTime())
+                    console.log('diffInMonths', diffInMonths)
+                    return diffInMonths < 2;
+                }
+                return false;
+
+            }, [], (res) => {
+                console.log('res', res)
+                browser.assert.ok((res as any).value, 'matomo analytics consent timestamp is set')
+            })
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .pause(2000)
+            .waitForElementNotPresent('*[data-id="matomoModalModalDialogModalBody-react"]')
+    },
+    'accept Matomo and check timestamp #group3': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser.execute(function () {
+                localStorage.removeItem('config-v0.8:.remix.config')
+                localStorage.setItem('showMatomo', 'true')
+                localStorage.removeItem('matomo-analytics-consent')
+            }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .waitForElementVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .click('[data-id="matomoModal-modal-footer-ok-react"]') // accept
+            .waitForElementNotVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .pause(2000)
+            .execute(function () {
+
+                const timestamp = window.localStorage.getItem('matomo-analytics-consent');
+                if (timestamp) {
+
+                    const consentDate = new Date(Number(timestamp));
+                    // validate it is actually a date
+                    if (isNaN(consentDate.getTime())) {
+                        return false;
+                    }
+                    const now = new Date();
+                    console.log('timestamp', timestamp, consentDate, now.getTime())
+                    const diffInMinutes = (now.getTime() - consentDate.getTime()) / (1000 * 60);
+                    console.log('diffInMinutes', diffInMinutes)
+                    return diffInMinutes < 1;
+                }
+                return false;
+
+            }, [], (res) => {
+                console.log('res', res)
+                browser.assert.ok((res as any).value, 'matomo analytics consent timestamp is to a recent date')
+            })
+    },
+    'check old timestamp and do not reappear Matomo after accept #group3': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser.execute(function () {
+                const oldTimestamp = new Date()
+                oldTimestamp.setMonth(oldTimestamp.getMonth() - 7)
+                localStorage.setItem('matomo-analytics-consent', oldTimestamp.getTime().toString())
+            }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .pause(2000)
+            .waitForElementNotPresent('*[data-id="matomoModalModalDialogModalBody-react"]')
+    },
+    'check recent timestamp and do not reappear Matomo after accept #group3': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser.execute(function () {
+                const recentTimestamp = new Date()
+                recentTimestamp.setMonth(recentTimestamp.getMonth() - 1)
+                localStorage.setItem('matomo-analytics-consent', recentTimestamp.getTime().toString())
+            }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            .waitForElementPresent({
+                selector: `//*[@data-id='compilerloaded']`,
+                locateStrategy: 'xpath',
+                timeout: 120000
+            })
+            .pause(2000)
+            .waitForElementNotPresent('*[data-id="matomoModalModalDialogModalBody-react"]')
+    },
+    'when there is a recent timestamp but no config the dialog should reappear #group3': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser.execute(function () {
+                localStorage.removeItem('config-v0.8:.remix.config')
+                const recentTimestamp = new Date()
+                recentTimestamp.setMonth(recentTimestamp.getMonth() - 1)
+                localStorage.setItem('matomo-analytics-consent', recentTimestamp.getTime().toString())
+            }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            .waitForElementVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .click('[data-id="matomoModal-modal-footer-cancel-react"]') // cancel
+            .waitForElementNotVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+    },
+    'when there is a old timestamp but no config the dialog should reappear #group3': function (browser: NightwatchBrowser) {
+        browser.perform((done) => {
+            browser.execute(function () {
+                localStorage.removeItem('config-v0.8:.remix.config')
+                const oldTimestamp = new Date()
+                oldTimestamp.setMonth(oldTimestamp.getMonth() - 7)
+                localStorage.setItem('matomo-analytics-consent', oldTimestamp.getTime().toString())
+            }, [])
+                .refreshPage()
+                .perform(done())
+        })
+            .waitForElementVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+            .click('[data-id="matomoModal-modal-footer-cancel-react"]') // cancel
+            .waitForElementNotVisible('*[data-id="matomoModalModalDialogModalBody-react"]')
+    },
+    'verify Matomo events are tracked on app start #group4 #lfaky': function (browser: NightwatchBrowser) {
+        browser
+            .execute(function () {
+                return (window as any)._paq
+            }, [], (res) => {
+                const expectedEvents = [
+                    ["trackEvent", "Preload", "start"],
+                    ["trackEvent", "Storage", "activate", "indexedDB"],
+                    ["trackEvent", "App", "load"],
+                ];
+
+                const actualEvents = (res as any).value;
+
+                const areEventsPresent = expectedEvents.every(expectedEvent =>
+                    actualEvents.some(actualEvent =>
+                        JSON.stringify(actualEvent) === JSON.stringify(expectedEvent)
+                    )
+                );
+
+                browser.assert.ok(areEventsPresent, 'Matomo events are tracked correctly');
+            })
+    },
+
+    '@sources': function () {
+        return sources
+    },
+    'Add Ballot #group4': function (browser: NightwatchBrowser) {
+        browser
+            .addFile('Untitled.sol', sources[0]['Untitled.sol'])
+    },
+    'Deploy Ballot #group4': function (browser: NightwatchBrowser) {
+        browser
+            .waitForElementVisible('*[data-id="remixIdeIconPanel"]', 10000)
+            .clickLaunchIcon('solidity')
+            .waitForElementVisible('*[data-id="compilerContainerCompileBtn"]')
+            .click('*[data-id="compilerContainerCompileBtn"]')
+            .testContracts('Untitled.sol', sources[0]['Untitled.sol'], ['Ballot'])
+    },
+    'verify Matomo compiler events are tracked #group4': function (browser: NightwatchBrowser) {
+        browser
+            .execute(function () {
+                return (window as any)._paq
+            }, [], (res) => {
+                const expectedEvent = ["trackEvent", "compiler", "compiled"];
+                const actualEvents = (res as any).value;
+
+                const isEventPresent = actualEvents.some(actualEvent =>
+                    actualEvent[0] === expectedEvent[0] &&
+                    actualEvent[1] === expectedEvent[1] &&
+                    actualEvent[2] === expectedEvent[2] &&
+                    actualEvent[3].startsWith("with_version_")
+                );
+
+                browser.assert.ok(isEventPresent, 'Matomo compiler events are tracked correctly');
+            })
+    },
+}

--- a/apps/remix-ide-e2e/src/tests/terminal.test.ts
+++ b/apps/remix-ide-e2e/src/tests/terminal.test.ts
@@ -361,18 +361,16 @@ module.exports = {
         Resolver resolver = ens.resolver(node);
         console.log(resolver.addr(node));
     }
-    `
+    `    
     if (runMasterTests) {
+      const path = "//*[@class='view-line' and contains(.,'resolveENS') and contains(.,'view')]//span//span[contains(.,'(')]"
+      
       browser
         // .clickLaunchIcon('udapp')
         .switchEnvironment('vm-mainnet-fork')
         .clickLaunchIcon('filePanel')
         .addFile('test_mainnet.sol', { content: script })
-
-      const path = "//*[@class='view-line' and contains(.,'resolveENS') and contains(.,'view')]//span//span[contains(.,'(')]"
-      const pathRunFunction = `//li//*[@aria-label='Run the free function "resolveENS"']`
-      browser.waitForElementVisible('#editorView')
-        //.waitForElementPresent(pathRunFunction)
+        .waitForElementVisible('#editorView')
         .pause(10000) // the parser need to parse the code
         .useXpath()
         .scrollToLine(16)
@@ -396,15 +394,15 @@ module.exports = {
         console.log("test running free function");
     }
     `
+
+    const path = "//*[@class='view-line' and contains(.,'runSomething') and contains(.,'view')]//span//span[contains(.,'(')]"
     browser
       .addFile('test.sol', { content: script })
-      .scrollToLine(3)
-    const path = "//*[@class='view-line' and contains(.,'runSomething') and contains(.,'view')]//span//span[contains(.,'(')]"
-    const pathRunFunction = `//li//*[@aria-label='Run the free function "runSomething"']`
-    browser.waitForElementVisible('#editorView')
+      .waitForElementVisible('#editorView')
+      .pause(10000) // the parser need to parse the code
       .useXpath()
-      .click(path)
-      .pause(3000) // the parser need to parse the code
+      .scrollToLine(3)      
+      .click(path)      
       .perform(function () {
         const actions = this.actions({ async: true });
         return actions

--- a/apps/remix-ide-e2e/src/tests/vyper_api.test.ts
+++ b/apps/remix-ide-e2e/src/tests/vyper_api.test.ts
@@ -67,6 +67,7 @@ module.exports = {
   'Compile blind_auction should success #group1': function (browser: NightwatchBrowser) {
     browser
       // @ts-ignore
+      .clickLaunchIcon('vyper')
       .frame(0)
       .click('[data-id="compile"]')
       .waitForElementVisible({
@@ -209,7 +210,7 @@ const sources = [{
 
   'blindAuction' : { content: `
 # Blind Auction. Adapted to Vyper from [Solidity by Example](https://github.com/ethereum/solidity/blob/develop/docs/solidity-by-example.rst#blind-auction-1)
-#pragma version ^0.3.10
+#pragma version >0.3.10
 
 struct Bid:
   blindedBid: bytes32

--- a/apps/remix-ide-e2e/src/tests/vyper_api.test.ts
+++ b/apps/remix-ide-e2e/src/tests/vyper_api.test.ts
@@ -27,7 +27,7 @@ module.exports = {
       .frameParent()
       .clickLaunchIcon('filePanel')
       .waitForElementVisible({
-        selector: "//*[@data-id='workspacesSelect' and contains(.,'snekmate')]",
+        selector: "//*[@data-id='workspacesSelect' and contains(.,'vyper')]",
         locateStrategy: 'xpath',
         timeout: 120000
       })
@@ -36,33 +36,33 @@ module.exports = {
         locateStrategy: 'xpath',
         timeout: 120000
       })
+      .openFile('examples')
+      .openFile('examples/auctions')
+      .openFile('examples/auctions/blind_auction.vy')
   },
-  // 'Add vyper file to run tests #group1': function (browser: NightwatchBrowser) {
-  //   browser.addFile('TestBallot.sol', sources[0]['TestBallot.sol'])
+
+  // '@sources': () => sources,
+  // 'Context menu click to compile blind_auction should succeed #group1': function (browser: NightwatchBrowser) {
+  //   browser
+  //     // .click('*[data-id="treeViewLitreeViewItemblind_auction.vy"]')
+  //     // .rightClick('*[data-id="treeViewLitreeViewItemblind_auction.vy"]')
+  //     // .waitForElementPresent('[data-id="contextMenuItemvyper"]')
+  //     // .click('[data-id="contextMenuItemvyper"]')
+  //     .clickLaunchIcon('vyper')
+  //     // @ts-ignore
+  //     .frame(0)
+  //     .waitForElementVisible({
+  //       selector:'[data-id="compilation-details"]',
+  //       timeout: 120000
+  //     })
+  //     .click('[data-id="compilation-details"]')
+  //     .frameParent()
+  //     .waitForElementVisible('[data-id="copy-abi"]')
+  //     .waitForElementVisible({
+  //       selector: "//*[@class='variable-value' and contains(.,'highestBidder')]",
+  //       locateStrategy: 'xpath',
+  //     })
   // },
-  '@sources': () => sources,
-  'Context menu click to compile blind_auction should succeed #group1': function (browser: NightwatchBrowser) {
-    browser
-      .addFileSnekmate('blind_auction.vy', sources[0]['blindAuction'])
-      .click('*[data-id="treeViewLitreeViewItemblind_auction.vy"]')
-      .rightClick('*[data-id="treeViewLitreeViewItemblind_auction.vy"]')
-      .waitForElementPresent('[data-id="contextMenuItemvyper"]')
-      .click('[data-id="contextMenuItemvyper"]')
-      .clickLaunchIcon('vyper')
-      // @ts-ignore
-      .frame(0)
-      .waitForElementVisible({
-        selector:'[data-id="compilation-details"]',
-        timeout: 120000
-      })
-      .click('[data-id="compilation-details"]')
-      .frameParent()
-      .waitForElementVisible('[data-id="copy-abi"]')
-      .waitForElementVisible({
-        selector: "//*[@class='variable-value' and contains(.,'highestBidder')]",
-        locateStrategy: 'xpath',
-      })
-  },
 
   'Compile blind_auction should success #group1': function (browser: NightwatchBrowser) {
     browser
@@ -145,32 +145,32 @@ module.exports = {
       })
   },
 
-  'Compile Ownable contract from snekmate #group1': function (browser: NightwatchBrowser) {
-    let contractAddress
-    browser
-      .frameParent()
-      .clickLaunchIcon('filePanel')
-      .switchWorkspace('snekmate')
-      .openFile('src')
-      .openFile('src/snekmate')
-      .openFile('src/snekmate/auth')
-      .openFile('src/snekmate/auth/Ownable.vy')
-      .rightClick('*[data-id="treeViewLitreeViewItemsrc/snekmate/auth/Ownable.vy"]')
-      .waitForElementVisible('*[data-id="contextMenuItemvyper"]')
-      .click('*[data-id="contextMenuItemvyper"]')
-      .clickLaunchIcon('vyper')
-      // @ts-ignore
-      .frame(0)
-      .click('[data-id="compile"]')
-      .waitForElementVisible({
-        selector:'[data-id="compilation-details"]',
-        timeout: 60000
-      })
-      .click('[data-id="compilation-details"]')
-      .frameParent()
-      .waitForElementVisible('[data-id="copy-abi"]')
-      .end()
-  }
+  // 'Compile Ownable contract from snekmate #group1': function (browser: NightwatchBrowser) {
+  //   let contractAddress
+  //   browser
+  //     .frameParent()
+  //     .clickLaunchIcon('filePanel')
+  //     .switchWorkspace('vyper')
+  //     .openFile('src')
+  //     .openFile('src/snekmate')
+  //     .openFile('src/snekmate/auth')
+  //     .openFile('src/snekmate/auth/Ownable.vy')
+  //     .rightClick('*[data-id="treeViewLitreeViewItemsrc/snekmate/auth/Ownable.vy"]')
+  //     .waitForElementVisible('*[data-id="contextMenuItemvyper"]')
+  //     .click('*[data-id="contextMenuItemvyper"]')
+  //     .clickLaunchIcon('vyper')
+  //     // @ts-ignore
+  //     .frame(0)
+  //     .click('[data-id="compile"]')
+  //     .waitForElementVisible({
+  //       selector:'[data-id="compilation-details"]',
+  //       timeout: 60000
+  //     })
+  //     .click('[data-id="compilation-details"]')
+  //     .frameParent()
+  //     .waitForElementVisible('[data-id="copy-abi"]')
+  //     .end()
+  // }
 }
 
 const testContract = `
@@ -384,6 +384,6 @@ def auctionEnd():
 
     # Transfer funds to beneficiary
     send(self.beneficiary, self.highestBid)
-`}
+` }
 }
 ]

--- a/apps/remix-ide/src/app.js
+++ b/apps/remix-ide/src/app.js
@@ -93,6 +93,7 @@ const Editor = require('./app/editor/editor')
 const Terminal = require('./app/panels/terminal')
 const {TabProxy} = require('./app/panels/tab-proxy.js')
 
+const _paq = (window._paq = window._paq || [])
 
 export class platformApi {
   get name () {
@@ -186,8 +187,8 @@ class AppComponent {
 
     if(this.matomoCurrentSetting === false
       && (!lastMatomoCheck || new Date(Number(lastMatomoCheck)) < sixMonthsAgo)) {
-        _paq.push(['trackEvent', 'Matomo', 'refreshMatomoPermissions']);
-      }    
+      _paq.push(['trackEvent', 'Matomo', 'refreshMatomoPermissions']);
+    }    
     
 
     this.walkthroughService = new WalkthroughService(appManager)

--- a/apps/remix-ide/src/app.js
+++ b/apps/remix-ide/src/app.js
@@ -176,17 +176,12 @@ class AppComponent {
     const sixMonthsAgo = new Date();
     sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
 
-    this.showMatomo =
-      (matomoDomains[window.location.hostname]
-        || (window.localStorage.getItem('showMatomo')
-          && window.localStorage.getItem('showMatomo') === 'true'))
-      && (!this.matomoConfAlreadySet
-        || (this.matomoCurrentSetting === false
-          && (!lastMatomoCheck || new Date(Number(lastMatomoCheck)) < sixMonthsAgo)
-        ));
+    const e2eforceMatomoToShow = window.localStorage.getItem('showMatomo') && window.localStorage.getItem('showMatomo') === 'true'
+    const contextShouldShowMatomo = matomoDomains[window.location.hostname] || e2eforceMatomoToShow
+    const shouldRenewConsent = this.matomoCurrentSetting === false && (!lastMatomoCheck || new Date(Number(lastMatomoCheck)) < sixMonthsAgo) // it is set to false for more than 6 months.
+    this.showMatomo = contextShouldShowMatomo && (!this.matomoConfAlreadySet || shouldRenewConsent)        
 
-    if(this.matomoCurrentSetting === false
-      && (!lastMatomoCheck || new Date(Number(lastMatomoCheck)) < sixMonthsAgo)) {
+    if (this.showMatomo && shouldRenewConsent) {
       _paq.push(['trackEvent', 'Matomo', 'refreshMatomoPermissions']);
     }    
     

--- a/apps/remix-ide/src/app.js
+++ b/apps/remix-ide/src/app.js
@@ -168,9 +168,27 @@ class AppComponent {
       '6fd22d6fe5549ad4c4d8fd3ca0b7816b.mod': 35 // remix desktop
     }
 
+    _paq.push(['trackEvent', 'App', 'load']);
     this.matomoConfAlreadySet = Registry.getInstance().get('config').api.exists('settings/matomo-analytics')
     this.matomoCurrentSetting = Registry.getInstance().get('config').api.get('settings/matomo-analytics')
-    this.showMatamo = matomoDomains[window.location.hostname] && !this.matomoConfAlreadySet
+    const lastMatomoCheck = window.localStorage.getItem('matomo-analytics-consent')
+    const sixMonthsAgo = new Date();
+    sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
+
+    this.showMatomo =
+      (matomoDomains[window.location.hostname]
+        || (window.localStorage.getItem('showMatomo')
+          && window.localStorage.getItem('showMatomo') === 'true'))
+      && (!this.matomoConfAlreadySet
+        || (this.matomoCurrentSetting === false
+          && (!lastMatomoCheck || new Date(Number(lastMatomoCheck)) < sixMonthsAgo)
+        ));
+
+    if(this.matomoCurrentSetting === false
+      && (!lastMatomoCheck || new Date(Number(lastMatomoCheck)) < sixMonthsAgo)) {
+        _paq.push(['trackEvent', 'Matomo', 'refreshMatomoPermissions']);
+      }    
+    
 
     this.walkthroughService = new WalkthroughService(appManager)
 

--- a/apps/remix-ide/src/app/components/preload.tsx
+++ b/apps/remix-ide/src/app/components/preload.tsx
@@ -10,6 +10,8 @@ import './styles/preload.css'
 import isElectron from 'is-electron'
 const _paq = (window._paq = window._paq || [])
 
+_paq.push(['trackEvent', 'Preload', 'start'])
+
 export const Preload = (props: any) => {
   const [tip, setTip] = useState<string>('')
   const [supported, setSupported] = useState<boolean>(true)

--- a/apps/remix-ide/src/app/tabs/settings-tab.tsx
+++ b/apps/remix-ide/src/app/tabs/settings-tab.tsx
@@ -109,6 +109,8 @@ module.exports = class SettingsTab extends ViewPlugin {
 
   updateMatomoAnalyticsChoice(isChecked) {
     this.config.set('settings/matomo-analytics', isChecked)
+    // set timestamp to local storage to track when the user has given consent
+    localStorage.setItem('matomo-analytics-consent', Date.now().toString())
     this.useMatomoAnalytics = isChecked
     if (!isChecked) {
       // revoke tracking consent

--- a/apps/remix-ide/src/assets/js/loader.js
+++ b/apps/remix-ide/src/assets/js/loader.js
@@ -5,15 +5,8 @@ const domains = {
   '6fd22d6fe5549ad4c4d8fd3ca0b7816b.mod': 35 // remix desktop
 }
 
-const domainsSecondaryTracker = {
-  'remix-alpha.ethereum.org': 27,
-  'remix-beta.ethereum.org': 25,
-  'remix.ethereum.org': 23,
-  '6fd22d6fe5549ad4c4d8fd3ca0b7816b.mod': 35 // remix desktop
-}
-
 if (domains[window.location.hostname]) {
-  var _paq = window._paq = window._paq || []
+  const _paq = window._paq = window._paq || []
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(["setExcludedQueryParams", ["code","gist"]]);
   _paq.push(["setExcludedReferrers", ["etherscan.io"]]);
@@ -21,14 +14,26 @@ if (domains[window.location.hostname]) {
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   _paq.push(['enableHeartBeatTimer']);
-  if (!window.localStorage.getItem('config-v0.8:.remix.config') ||
-    (window.localStorage.getItem('config-v0.8:.remix.config') && !window.localStorage.getItem('config-v0.8:.remix.config').includes('settings/matomo-analytics'))) {
+  const remixConfig = window.localStorage.getItem('config-v0.8:.remix.config');
+  if (!remixConfig || (remixConfig && !remixConfig.includes('settings/matomo-analytics'))) {
     // require user tracking consent before processing data
     _paq.push(['requireConsent']);
   } else {
-    // user has given consent to process their data
-    _paq.push(['setConsentGiven'])
+    try {
+      const config = JSON.parse(remixConfig);
+      if (config['settings/matomo-analytics'] === true) {
+        // user has given consent to process their data
+        _paq.push(['setConsentGiven']);
+      } else {
+        // user has not given consent to process their data
+        _paq.push(['requireConsent']);
+      }
+    } catch (e) {
+      console.error('Error parsing remix config:', e);
+      _paq.push(['requireConsent']);
+    }
   }
+  _paq.push(['trackEvent', 'loader', 'load']);
   (function () {
     var u = "https://ethereumfoundation.matomo.cloud/";
     _paq.push(['setTrackerUrl', u + 'matomo.php']);

--- a/apps/vyper/src/app/components/CompilerButton.tsx
+++ b/apps/vyper/src/app/components/CompilerButton.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useEffect, useState } from 'react'
-import {isVyper, compile, toStandardOutput, isCompilationError, remixClient, normalizeContractPath, compileContract, RemixClient} from '../utils'
+import { isVyper, compile, toStandardOutput, isCompilationError, remixClient, normalizeContractPath, compileContract, RemixClient } from '../utils'
 import Button from 'react-bootstrap/Button'
 
 interface Props {
@@ -11,7 +11,7 @@ interface Props {
   remixClient: RemixClient
 }
 
-function CompilerButton({contract, setOutput, compilerUrl, resetCompilerState, output, remixClient}: Props) {
+function CompilerButton({ contract, setOutput, compilerUrl, resetCompilerState, output, remixClient }: Props) {
   const [loadingSpinner, setLoadingSpinnerState] = useState(false)
 
   if (!contract || !contract) {

--- a/apps/vyper/src/app/utils/compiler.tsx
+++ b/apps/vyper/src/app/utils/compiler.tsx
@@ -47,7 +47,6 @@ export function normalizeContractPath(contractPath: string): string[] {
 
 function parseErrorString(errorString) {
   // Split the string into lines
-  console.log(errorString)
   let lines = errorString.trim().split('\n')
   // Extract the line number and message
   let message = errorString.trim()
@@ -177,7 +176,6 @@ export async function compile(url: string, contract: Contract): Promise<any> {
   }
 
   const cleanedUpContent = fixContractContent(contract.content)
-  console.log('cleanedUp', cleanedUpContent)
 
   let contractName = contract['name']
   const compilePackage = {
@@ -186,7 +184,6 @@ export async function compile(url: string, contract: Contract): Promise<any> {
       [contractName] : { content : cleanedUpContent }
     }
   }
-  console.log(compilePackage)
   let response = await axios.post(`${url}compile`, compilePackage )
 
   if (response.status === 404) {
@@ -215,7 +212,6 @@ export async function compile(url: string, contract: Contract): Promise<any> {
       method: 'Get'
     })).data
     result = parseErrorString(intermediate)
-    console.log('Errors found', intermediate)
     return result
   }
   await new Promise((resolve) => setTimeout(() => resolve({}), 3000))

--- a/apps/vyper/src/app/utils/compiler.tsx
+++ b/apps/vyper/src/app/utils/compiler.tsx
@@ -45,22 +45,31 @@ export function normalizeContractPath(contractPath: string): string[] {
   return [folders,resultingPath, filename]
 }
 
-function parseErrorString(errorString) {
+function parseErrorString(errorStructure: string[]) {
   // Split the string into lines
-  let lines = errorString.trim().split('\n')
-  // Extract the line number and message
-  let message = errorString.trim()
-  let targetLine = lines[2].split(',')
-  let tline = lines[2].trim().split(' ')[1].split(':')
+  console.log(errorStructure)
+  let errorType = ''
+  let message = ''
+  let tline = ''
+  errorStructure.forEach(errorMsg => {
+    const choppedup = errorMsg.split(': ')
+    errorType = choppedup[0].trim().split('\n')[1]
+    message = choppedup[1]
+    if (errorStructure.length > 2) {
+      console.log(choppedup[2].split(',')[1])
+    }
+    console.log(choppedup)
+  })
+  let lines = errorStructure[0].trim().split('\n')
 
   const errorObject = {
     status: 'failed',
-    message: message,
-    column: tline[1],
-    line: tline[0]
+    message: `${errorType} - ${message}`,
+    column: '',
+    line: ''
   }
   message = null
-  targetLine = null
+  // targetLine = null
   lines = null
   tline = null
   return errorObject
@@ -140,24 +149,30 @@ const compileReturnType = (output, contract) => {
   return result
 }
 
-const fixContractContent = (content: string) => {
-  if (content.length === 0) return
-  const pragmaFound = content.includes('#pragma version ^0.3.10')
-  const wrongpragmaFound = content.includes('# pragma version ^0.3.10')
-  const evmVerFound = content.includes('#pragma evm-version shanghai')
-  const pragma = '#pragma version ^0.3.10'
-  const evmVer = '#pragma evm-version shanghai'
+const updatePragmaDeclaration = (content: string) => {
+  const pragmaRegex = /#\s*pragma\s+[@]*version\s+([~<>!=^]+)\s*(\d+\.\d+\.\d+)/
+  const oldPragmaRegex = /#\s*pragma\s+[@]*version\s+([\^^]+)\s*(\d+\.\d+\.\d+)/
+  const oldPragmaDeclaration = ['# pragma version ^0.2.16', '# pragma version ^0.3.10', '#pragma version ^0.2.16', '#pragma version ^0.3.10']
+  const pragmaFound = content.match(pragmaRegex)
+  const oldPragmaFound = content.match(oldPragmaRegex)
 
-  if (evmVerFound === false) {
-    content = `${evmVer}\n${content}`
+  const pragma = '# pragma version ~=0.4.0'
+
+  if (oldPragmaFound) {
+    // oldPragmaDeclaration.forEach(declaration => {
+    //   content = content.replace(declaration, '# pragma version >0.3.10')
+    // })
+    return content
   }
-  if (wrongpragmaFound === true) {
-    content = content.replace('# pragma version ^0.3.10', '')
-  }
-  if (pragmaFound === false ) {
-    content = `${pragma}\n${content}`
+  if (!pragmaFound) {
+    content = `${pragma}\n\n${content}`
   }
   return content
+}
+
+const fixContractContent = (content: string) => {
+  if (content.length === 0) return
+  return updatePragmaDeclaration(content)
 }
 
 /**
@@ -174,13 +189,17 @@ export async function compile(url: string, contract: Contract): Promise<any> {
     throw new Error('Use extension .vy for Vyper.')
   }
 
+  const cleanedUpContent = fixContractContent(contract.content)
+
   let contractName = contract['name']
   const compilePackage = {
     manifest: 'ethpm/3',
     sources: {
-      [contractName] : { content : fixContractContent(contract.content) }
+      [contractName] : { content : cleanedUpContent }
     }
   }
+  console.log(compilePackage)
+
   let response = await axios.post(`${url}compile`, compilePackage )
 
   if (response.status === 404) {
@@ -194,6 +213,7 @@ export async function compile(url: string, contract: Contract): Promise<any> {
   contractName = null
   response = null
   let result: any
+  let intermediateError
 
   const status = await (await axios.get(url + 'status/' + compileCode , {
     method: 'Get'
@@ -208,7 +228,9 @@ export async function compile(url: string, contract: Contract): Promise<any> {
     const intermediate = await(await axios.get(url + 'exceptions/' + compileCode , {
       method: 'Get'
     })).data
-    result = parseErrorString(intermediate[0])
+    console.log('Errors found', intermediate)
+    result = parseErrorString(intermediate)
+    intermediateError = intermediate
     return result
   }
   await new Promise((resolve) => setTimeout(() => resolve({}), 3000))

--- a/apps/vyper/src/app/utils/compiler.tsx
+++ b/apps/vyper/src/app/utils/compiler.tsx
@@ -47,7 +47,6 @@ export function normalizeContractPath(contractPath: string): string[] {
 
 function parseErrorString(errorStructure: string[]) {
   // Split the string into lines
-  console.log(errorStructure)
   let errorType = ''
   let message = ''
   let tline = ''
@@ -55,10 +54,10 @@ function parseErrorString(errorStructure: string[]) {
     const choppedup = errorMsg.split(': ')
     errorType = choppedup[0].trim().split('\n')[1]
     message = choppedup[1]
-    if (errorStructure.length > 2) {
-      console.log(choppedup[2].split(',')[1])
-    }
-    console.log(choppedup)
+    // if (errorStructure.length > 2) {
+    //   console.log(choppedup[2].split(',')[1])
+    // }
+    // console.log(choppedup)
   })
   let lines = errorStructure[0].trim().split('\n')
 
@@ -198,7 +197,6 @@ export async function compile(url: string, contract: Contract): Promise<any> {
       [contractName] : { content : cleanedUpContent }
     }
   }
-  console.log(compilePackage)
 
   let response = await axios.post(`${url}compile`, compilePackage )
 
@@ -228,7 +226,7 @@ export async function compile(url: string, contract: Contract): Promise<any> {
     const intermediate = await(await axios.get(url + 'exceptions/' + compileCode , {
       method: 'Get'
     })).data
-    console.log('Errors found', intermediate)
+    // console.log('Errors found', intermediate)
     result = parseErrorString(intermediate)
     intermediateError = intermediate
     return result

--- a/apps/vyper/src/app/utils/compiler.tsx
+++ b/apps/vyper/src/app/utils/compiler.tsx
@@ -109,10 +109,10 @@ const compileReturnType = (output, contract) => {
   const normal = normalizeContractPath(contract)[2]
   const abi = temp[normal]['abi']
   const evm = _.merge(temp[normal]['evm'])
-  const dpb = evm.deployedBytecode
+  const depByteCode = evm.deployedBytecode
   const runtimeBytecode = evm.bytecode
   const methodIdentifiers = evm.methodIdentifiers
-  const version = output?.compilers[0]?.version ?? '0.3.10'
+  const version = output?.compilers[0]?.version ?? '0.4.0'
   const optimized = output?.compilers[0]?.settings?.optimize ?? true
   const evmVersion = ''
 
@@ -129,7 +129,7 @@ const compileReturnType = (output, contract) => {
   } = {
     contractName: normal,
     abi,
-    bytecode: dpb,
+    bytecode: depByteCode,
     runtimeBytecode,
     ir: '',
     methodIdentifiers,

--- a/apps/vyper/src/app/utils/remix-client.tsx
+++ b/apps/vyper/src/app/utils/remix-client.tsx
@@ -83,23 +83,23 @@ export class RemixClient extends PluginClient<any, CustomRemixApi> {
 
     try {
       // @ts-ignore
-      this.call('notification', 'toast', 'cloning Snekmate Vyper repository...')     
+      this.call('notification', 'toast', 'cloning Snekmate Vyper repository...')
       await this.call(
         'dgitApi',
         'clone',
-        {url: 'https://github.com/pcaversaccio/snekmate', token: null, branch: 'main', singleBranch: false, workspaceName: 'snekmate'},
+        { url: 'https://github.com/vyperlang/vyper', token: null, branch: 'master', singleBranch: false, workspaceName: 'vyper' },
       )
 
-      await this.call(
-        'dgitApi',
-        'checkout',
-        {
-          ref:'v0.0.5',
-          force: true,
-          refresh: true,
-        }
-      )
-            
+      // await this.call(
+      //   'dgitApi',
+      //   'checkout',
+      //   {
+      //     ref:'v0.0.5',
+      //     force: true,
+      //     refresh: true,
+      //   }
+      // )
+
       this.call(
         // @ts-ignore
         'notification',

--- a/libs/remix-ui/app/src/index.ts
+++ b/libs/remix-ui/app/src/index.ts
@@ -3,5 +3,5 @@ export { dispatchModalContext, dispatchModalInterface, AppContext, appProviderCo
 export { ModalProvider, useDialogDispatchers } from './lib/remix-app/context/provider'
 export { AppModal } from './lib/remix-app/interface/index'
 export { AlertModal } from './lib/remix-app/interface/index'
-export { ModalTypes } from './lib/remix-app/types/index'
+export { ModalTypes, AppModalCancelTypes } from './lib/remix-app/types/index'
 export { AppAction, appActionTypes } from './lib/remix-app/actions/app'

--- a/libs/remix-ui/app/src/lib/remix-app/components/modals/matomo.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/components/modals/matomo.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { AppContext } from '../../context/context'
 import { useDialogDispatchers } from '../../context/provider'
+import { AppModalCancelTypes } from '../../types'
 declare global {
   interface Window {
     _paq: any
@@ -15,7 +16,7 @@ interface MatomoDialogProps {
 }
 
 const MatomoDialog = (props: MatomoDialogProps) => {
-  const { settings, showMatamo, appManager } = useContext(AppContext)
+  const { settings, showMatomo, appManager } = useContext(AppContext)
   const { modal } = useDialogDispatchers()
   const [visible, setVisible] = useState<boolean>(props.hide)
 
@@ -63,7 +64,7 @@ const MatomoDialog = (props: MatomoDialogProps) => {
   }
 
   useEffect(() => {
-    if (visible && showMatamo) {
+    if (visible && showMatomo) {
       modal({
         id: 'matomoModal',
         title: <FormattedMessage id="remixApp.matomoTitle" />,
@@ -72,18 +73,22 @@ const MatomoDialog = (props: MatomoDialogProps) => {
         okFn: handleModalOkClick,
         cancelLabel: <FormattedMessage id="remixApp.decline" />,
         cancelFn: declineModal,
+        preventBlur: true
       })
     }
   }, [visible])
 
-  const declineModal = async () => {
-    settings.updateMatomoAnalyticsChoice(false)
-    // revoke tracking consent
-    _paq.push(['forgetConsentGiven'])
-    setVisible(false)
+  const declineModal = async (reason: AppModalCancelTypes) => {
+    if (reason === AppModalCancelTypes.click || reason === AppModalCancelTypes.enter) {
+      settings.updateMatomoAnalyticsChoice(false)
+      // revoke tracking consent
+      _paq.push(['forgetConsentGiven'])
+      setVisible(false)
+    }
   }
 
   const handleModalOkClick = async () => {
+
     // user has given consent to process their data
     _paq.push(['setConsentGiven'])
     settings.updateMatomoAnalyticsChoice(true)

--- a/libs/remix-ui/app/src/lib/remix-app/components/modals/modal-wrapper.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/components/modals/modal-wrapper.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { ModalDialog, ModalDialogProps, ValidationResult } from '@remix-ui/modal-dialog'
-import { ModalTypes } from '../../types'
+import { AppModalCancelTypes, ModalTypes } from '../../types'
 
 interface ModalWrapperProps extends ModalDialogProps {
   modalType?: ModalTypes
@@ -42,8 +42,8 @@ const ModalWrapper = (props: ModalWrapperProps) => {
     props.okFn ? props.okFn(data.current) : props.resolve(data.current || true)
   }
 
-  const onCancelFn = async () => {
-    props.cancelFn ? props.cancelFn() : props.resolve(false)
+  const onCancelFn = async (reason?: AppModalCancelTypes) => {
+    props.cancelFn ? props.cancelFn(reason) : props.resolve(false)
   }
 
   const onInputChanged = (event) => {
@@ -141,6 +141,8 @@ const ModalWrapper = (props: ModalWrapperProps) => {
     })
     props.handleHide()
   }
+
+  if (!props.id || props.id === '') return null
 
   return <ModalDialog id={props.id} {...state} handleHide={handleHide} />
 }

--- a/libs/remix-ui/app/src/lib/remix-app/context/context.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/context/context.tsx
@@ -5,7 +5,7 @@ import { AppAction } from '../actions/app'
 
 export type appProviderContextType = {
   settings: any,
-  showMatamo: boolean,
+  showMatomo: boolean,
   showEnter: boolean,
   appManager: any
   modal: any

--- a/libs/remix-ui/app/src/lib/remix-app/context/provider.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/context/provider.tsx
@@ -23,7 +23,8 @@ export const ModalProvider = ({ children = [], reducer = modalReducer, initialSt
   }
 
   const modal = (modalData: AppModal) => {
-    const { id, title, message, validationFn, okLabel, okFn, cancelLabel, cancelFn, modalType, modalParentClass, defaultValue, hideFn, data } = modalData
+    const { id, title, message, validationFn, okLabel, okFn, cancelLabel, cancelFn, modalType, modalParentClass, defaultValue, hideFn, data, preventBlur } = modalData
+    console.log('modalData', modalData)
     return new Promise((resolve, reject) => {
       dispatch({
         type: modalActionTypes.setModal,
@@ -42,7 +43,8 @@ export const ModalProvider = ({ children = [], reducer = modalReducer, initialSt
           hideFn,
           resolve,
           next: onNextFn,
-          data
+          data,
+          preventBlur
         }
       })
     })

--- a/libs/remix-ui/app/src/lib/remix-app/context/provider.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/context/provider.tsx
@@ -24,7 +24,6 @@ export const ModalProvider = ({ children = [], reducer = modalReducer, initialSt
 
   const modal = (modalData: AppModal) => {
     const { id, title, message, validationFn, okLabel, okFn, cancelLabel, cancelFn, modalType, modalParentClass, defaultValue, hideFn, data, preventBlur } = modalData
-    console.log('modalData', modalData)
     return new Promise((resolve, reject) => {
       dispatch({
         type: modalActionTypes.setModal,

--- a/libs/remix-ui/app/src/lib/remix-app/interface/index.ts
+++ b/libs/remix-ui/app/src/lib/remix-app/interface/index.ts
@@ -1,5 +1,5 @@
 import { GitHubUser } from '@remix-ui/git'
-import { ModalTypes } from '../types'
+import { AppModalCancelTypes, ModalTypes } from '../types'
 
 export type ValidationResult = {
     valid: boolean,
@@ -17,14 +17,15 @@ export interface AppModal {
     okLabel: string | JSX.Element
     okFn?: (value?:any) => void
     cancelLabel?: string | JSX.Element
-    cancelFn?: () => void,
+    cancelFn?: (reason?: AppModalCancelTypes) => void,
     modalType?: ModalTypes,
     modalParentClass?: string
     defaultValue?: string
     hideFn?: () => void,
     resolve?: (value?:any) => void,
     next?: () => void,
-    data?: any
+    data?: any,
+    preventBlur?: boolean
 }
 
 export interface AlertModal {

--- a/libs/remix-ui/app/src/lib/remix-app/reducer/modals.ts
+++ b/libs/remix-ui/app/src/lib/remix-app/reducer/modals.ts
@@ -23,7 +23,8 @@ export const modalReducer = (state: ModalState = ModalInitialState, action: Moda
       hideFn: action.payload.hideFn,
       resolve: action.payload.resolve,
       next: action.payload.next,
-      data: action.payload.data
+      data: action.payload.data,
+      preventBlur: action.payload.preventBlur
     }
 
     const modalList: AppModal[] = state.modals.slice()

--- a/libs/remix-ui/app/src/lib/remix-app/remix-app.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/remix-app.tsx
@@ -60,7 +60,7 @@ const RemixApp = (props: IRemixAppUi) => {
       activateApp()
     }
     const hadUsageTypeAsked = localStorage.getItem('hadUsageTypeAsked')
-    if (props.app.showMatamo) {
+    if (props.app.showMatomo) {
       // if matomo dialog is displayed, it will take care of calling "setShowEnterDialog",
       // if the user approves matomo tracking.
       // so "showEnterDialog" stays false
@@ -149,7 +149,7 @@ const RemixApp = (props: IRemixAppUi) => {
 
   const value: appProviderContextType = {
     settings: props.app.settings,
-    showMatamo: props.app.showMatamo,
+    showMatomo: props.app.showMatomo,
     appManager: props.app.appManager,
     showEnter: props.app.showEnter,
     modal: props.app.notification,

--- a/libs/remix-ui/app/src/lib/remix-app/types/index.ts
+++ b/libs/remix-ui/app/src/lib/remix-app/types/index.ts
@@ -8,6 +8,15 @@ export const enum ModalTypes {
   forceChoice = 'forceChoice'
 }
 
+export const enum AppModalCancelTypes {
+  close = 'close',
+  cancel = 'cancel',
+  blur = 'blur',
+  escape = 'escape',
+  enter = 'enter',
+  click = 'click'
+}
+
 export const enum UsageTypes {
   Beginner = 1,
   Prototyper,

--- a/libs/remix-ui/home-tab/src/lib/components/homeTabFeatured.tsx
+++ b/libs/remix-ui/home-tab/src/lib/components/homeTabFeatured.tsx
@@ -13,7 +13,12 @@ export type HomeTabFeaturedProps = {
 
 function HomeTabFeatured(props:HomeTabFeaturedProps) {
   const themeFilter = useContext(ThemeContext)
-
+  const handleStartLearneth = async () => {
+    await props.plugin.appManager.activatePlugin(['LearnEth', 'solidityUnitTesting'])
+    props.plugin.verticalIcons.select('LearnEth')
+    _paq.push(['trackEvent', 'hometab', 'featuredSection', 'LearnEth'])
+    await props.plugin.call('LearnEth', 'home')
+  }
   return (
     <div className="pt-1 pl-2" id="hTFeaturedeSection">
       <div className="mb-2 remix_ui-carousel-container">
@@ -66,9 +71,9 @@ function HomeTabFeatured(props:HomeTabFeaturedProps) {
                 </div>
               </div>
               <div className="mr-1 pr-1 d-flex align-items-center justify-content-center h-100">
-                <a href="https://remix-project.org" target="__blank">
+                <button className='btn' onClick={()=>handleStartLearneth()}>
                   <img src={'assets/img/remi-prof.webp'} className="remixui_carouselImage" alt=""></img>
-                </a>
+                </button>
                 <div className="h6 w-50 p-2 pl-4  align-self-center" style={{ flex: '1' }}>
                   <h5>
                     <FormattedMessage id="home.learnEthPromoTitle" />
@@ -79,12 +84,7 @@ function HomeTabFeatured(props:HomeTabFeaturedProps) {
                   <span
                     className="remixui_home_text btn-sm btn-secondary mt-2 text-decoration-none mb-3"
                     style={{ cursor: 'pointer' }}
-                    onClick={async () => {
-                      await props.plugin.appManager.activatePlugin(['LearnEth', 'solidityUnitTesting'])
-                      props.plugin.verticalIcons.select('LearnEth')
-                      await props.plugin.call('LearnEth', 'home')
-                    	}
-                    }
+                    onClick={()=>handleStartLearneth()}
                   >
                     <FormattedMessage id="home.learnEthPromoButton" />
                   </span>

--- a/libs/remix-ui/home-tab/src/lib/components/homeTabFeatured.tsx
+++ b/libs/remix-ui/home-tab/src/lib/components/homeTabFeatured.tsx
@@ -17,7 +17,6 @@ function HomeTabFeatured(props:HomeTabFeaturedProps) {
     await props.plugin.appManager.activatePlugin(['LearnEth', 'solidityUnitTesting'])
     props.plugin.verticalIcons.select('LearnEth')
     _paq.push(['trackEvent', 'hometab', 'featuredSection', 'LearnEth'])
-    await props.plugin.call('LearnEth', 'home')
   }
   return (
     <div className="pt-1 pl-2" id="hTFeaturedeSection">

--- a/libs/remix-ui/home-tab/src/lib/components/homeTabFile.tsx
+++ b/libs/remix-ui/home-tab/src/lib/components/homeTabFile.tsx
@@ -169,7 +169,7 @@ function HomeTabFile({ plugin }: HomeTabFileProps) {
           </label>
           <div className="d-flex flex-row flex-wrap">
             <CustomTooltip placement={'top'} tooltipId="overlay-tooltip" tooltipClasses="text-nowrap" tooltipText={<FormattedMessage id="home.newFileTooltip" />} tooltipTextClasses="border bg-light text-dark p-1 pr-3">
-              <button className="btn btn-primary text-nowrap p-2 mr-2 border my-1 mb-2" data-id="homeTabNewFile" style={{ width: 'fit-content' }} onClick={async () => {
+              <button className="btn text-nowrap p-2 mr-2 border my-1 mb-2" data-id="homeTabNewFile" style={{ width: 'fit-content' }} onClick={async () => {
                 _paq.push(['trackEvent', 'hometab', 'filesSection', 'newFile'])
                 await plugin.call('menuicons', 'select', 'filePanel')
                 await plugin.call('filePanel', 'createNewFile')

--- a/libs/remix-ui/modal-dialog/src/lib/types/index.ts
+++ b/libs/remix-ui/modal-dialog/src/lib/types/index.ts
@@ -1,3 +1,5 @@
+import { AppModalCancelTypes } from "@remix-ui/app"
+
 export type ValidationResult = {
   valid: boolean,
   message?: string
@@ -15,7 +17,7 @@ export interface ModalDialogProps {
   okFn?: (value?:any) => void,
   donotHideOnOkClick?: boolean,
   cancelLabel?: string | JSX.Element,
-  cancelFn?: () => void,
+  cancelFn?: (reason?: AppModalCancelTypes) => void,
   modalClass?: string,
   modalParentClass?: string
   showCancelIcon?: boolean,
@@ -26,5 +28,6 @@ export interface ModalDialogProps {
   next?: () => void,
   data?: any,
   okBtnClass?: string,
-  cancelBtnClass?: string
+  cancelBtnClass?: string,
+  preventBlur?: boolean
 }

--- a/libs/remix-ui/settings/src/lib/remix-ui-settings.tsx
+++ b/libs/remix-ui/settings/src/lib/remix-ui-settings.tsx
@@ -315,7 +315,7 @@ export const RemixUiSettings = (props: RemixUiSettingsProps) => {
           </div>
           <div className="custom-control custom-checkbox mb-1">
             <input onChange={onchangeMatomoAnalytics} id="settingsMatomoAnalytics" type="checkbox" className="custom-control-input" checked={isMatomoChecked} />
-            <label className={`form-check-label custom-control-label align-middle ${getTextClass('settings/matomo-analytics')}`} htmlFor="settingsMatomoAnalytics">
+            <label data-id="label-matomo-settings" className={`form-check-label custom-control-label align-middle ${getTextClass('settings/matomo-analytics')}`} htmlFor="settingsMatomoAnalytics">
               <span>
                 <FormattedMessage id="settings.matomoAnalytics" />
               </span>

--- a/libs/remix-ui/settings/src/lib/settingsAction.ts
+++ b/libs/remix-ui/settings/src/lib/settingsAction.ts
@@ -41,6 +41,7 @@ export const copilotTemperature = (config, checked, dispatch) => {
 
 export const useMatomoAnalytics = (config, checked, dispatch) => {
   config.set('settings/matomo-analytics', checked)
+  localStorage.setItem('matomo-analytics-consent', Date.now().toString())
   dispatch({ type: 'useMatomoAnalytics', payload: { isChecked: checked, textClass: checked ? textDark : textSecondary } })
   if (checked) {
     // user has given consent to process their data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-project",
-  "version": "0.54.0-dev",
+  "version": "0.54.0",
   "license": "MIT",
   "description": "Ethereum Remix Monorepo",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-project",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "license": "MIT",
   "description": "Ethereum Remix Monorepo",
   "main": "index.js",


### PR DESCRIPTION
Bug: matomo dialogs where not showing up in some conditions. esp on firefox it seemed to be an issue.

- the modals where drawing focus to themselves if they were not visible causing the matomo to blur out
- added a preventBlur option to the modal to prevent blur if needed, this is only used on matomo now...
- there is now a timestamp set in localstorage which indicates when the user has reacted to the matomo dialog. if it's older than 6 months and the matomo setting is either false or not set it will ask for matomo permissions again. added this in e2e. 
- added an event in matomo to show this happening
- loader.js would always consider permission granted when any value 'settings/matomo-analytics' was set, even when false.
- the modal cancel method now accepts an enum telling the callback what kind of cancel it was, close, escape, enter, click etc etc allowing. this allows the modal handler not to set the storage when it's a real blur.
- added e2e
- sometimes matomo was spelled matamo :D fixed that




