### PR TITLE
placement of folder name on desktop

### DIFF
--- a/libs/remix-ui/workspace/src/lib/components/electron-menu.tsx
+++ b/libs/remix-ui/workspace/src/lib/components/electron-menu.tsx
@@ -44,7 +44,7 @@ export const ElectronMenu = () => {
                     >
                       <div className="recentfolder pb-1">
                         <span onClick={async () => { await openFolderElectron(folder) }} className="pl-2 recentfolder_name pr-2">{lastFolderName(folder)}</span>
-                        <span onClick={async () => { await openFolderElectron(folder) }} data-id={{ folder }} className="recentfolder_path pr-2">{folder}</span>
+                        <span onClick={async () => { await openFolderElectron(folder) }} data-id={`recent_folder_${folder}`} className="recentfolder_path pr-2">{folder}</span>
                         <i
                           onClick={() => {
                             global.dispatchRemoveRecentFolder(folder)

--- a/libs/remix-ui/workspace/src/lib/components/electron-workspace-name.tsx
+++ b/libs/remix-ui/workspace/src/lib/components/electron-workspace-name.tsx
@@ -23,14 +23,21 @@ export const ElectronWorkspaceName = (props: ElectronWorkspaceNameProps) => {
 
   return (
     (dir === undefined || dir === '') ? <></> :
-      <div className="d-flex align-items-baseline">
+      <div className="d-flex align-items-baseline mt-2">
         <CustomTooltip
           placement="bottom"
           tooltipId="workspace-name"
           tooltipClasses="text-nowrap"
           tooltipText={dir}
         >
-          <div>{parsePath()}</div>
+          <div
+            style={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              flexGrow: 1,
+            }}
+          
+          >{parsePath()}</div>
         </CustomTooltip>
         <CustomTooltip
           placement="top"

--- a/libs/remix-ui/workspace/src/lib/components/electron-workspace-name.tsx
+++ b/libs/remix-ui/workspace/src/lib/components/electron-workspace-name.tsx
@@ -36,7 +36,7 @@ export const ElectronWorkspaceName = (props: ElectronWorkspaceNameProps) => {
               textOverflow: 'ellipsis',
               flexGrow: 1,
             }}
-          
+
           >{parsePath()}</div>
         </CustomTooltip>
         <CustomTooltip

--- a/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
+++ b/libs/remix-ui/workspace/src/lib/remix-ui-workspace.tsx
@@ -1060,7 +1060,7 @@ export function Workspace() {
                     <span className="d-flex">
                       <label className="pl-2 form-check-label" style={{ wordBreak: 'keep-all' }}>
                         {(platform == appPlatformTypes.desktop) ? (
-                          <ElectronWorkspaceName plugin={global.plugin} path={global.fs.browser.currentLocalFilePath} />
+                          null
                         ) : <FormattedMessage id='filePanel.workspace' />}
                       </label>
                       {selectedWorkspace && selectedWorkspace.name === 'code-sample' && <CustomTooltip
@@ -1143,7 +1143,7 @@ export function Workspace() {
                         )}
                       </Dropdown.Menu>
                     </Dropdown>
-                  ):null}
+                  ):<ElectronWorkspaceName plugin={global.plugin} path={global.fs.browser.currentLocalFilePath} />}
                 </div>
               </div>
             </header>


### PR DESCRIPTION
On desktop the folder name was between the hamburger and the github sign in button that created a confusing interface. Put the folder name underneath the hamburger now.