### PR TITLE
use the default evmVersion.

### DIFF
--- a/apps/remix-ide/src/app/plugins/parser/services/code-parser-compiler.ts
+++ b/apps/remix-ide/src/app/plugins/parser/services/code-parser-compiler.ts
@@ -161,7 +161,7 @@ export default class CodeParserCompiler {
                 "*": ["evm.gasEstimates"]
               }
             },
-            "evmVersion": state.evmVersion && state.evmVersion.toString() || "cancun",
+            "evmVersion": state.evmVersion && state.evmVersion.toString() || undefined,
           }
         }
 


### PR DESCRIPTION
Select 0.8.20 (which doesn't support cancun), the parser always shows an error at the top of the editor.
Reaon is that the default set in the parser is `cancun`, it should default to the default one supported by the current version.