### PR TITLE
Fix crash on right-click after closing tab

### DIFF
--- a/libs/remix-ui/workspace/src/lib/components/file-explorer-context-menu.tsx
+++ b/libs/remix-ui/workspace/src/lib/components/file-explorer-context-menu.tsx
@@ -72,7 +72,7 @@ export const FileExplorerContextMenu = (props: FileExplorerContextMenuProps) => 
       return !(el.key === '' && el.type === 'folder')
     })
 
-    if (focus[0].key === 'contextMenu') {
+    if (focus[0]?.key === 'contextMenu') {
       return true
     }
 


### PR DESCRIPTION
#5414 The application crashes because when a file is opened, focus is set on it. After closing the file, the browserReducer sets the focusElement in the state to an empty array. When you right-click in the file explorer, a condition tries to read the key of the first element in the focusElement array, which is empty, causing the crash.