### PR TITLE
Fix grammatical issues in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Everyone is very welcome to contribute on the codebase of Remix. Please join our
 ## Development
 Remix libraries work closely with [Remix IDE](https://remix.ethereum.org). Each library has a readme to explain its application.
 
-When you add a code in any library, please ensure you add related unit tests.
+When you add code in any library, please ensure you add related unit tests.
 
 ## Coding style
 
@@ -27,7 +27,7 @@ Then you can replace the string with a intl component. The `id` prop will be the
 +  <FormattedMessage id="home.learn" />
 </label>
 ```
-In some cases, jsx maybe not be acceptable, you can use `intl.formatMessage` .
+In some cases, jsx may not be acceptable, you can use `intl.formatMessage` .
 ```jsx
 <input
    ref={searchInputRef}

--- a/team-best-practices.md
+++ b/team-best-practices.md
@@ -120,7 +120,7 @@ Before starting coding, we should ensure all devs / contributors are aware of:
 
  - A milestone should **only** contain items we are sure to finish.
  - The end of a milestone triggers a new release.
- - Milestone items and duration should take in account time spent in bugs fixing and support.
+ - Milestone items and duration should take into account time spent in bugs fixing and support.
  - The team should commit to the milestone duration.
  - If a dev finish early he/she can help others to push remaining tasks.
  - If a dev finish early he/she can work on specifying / integrating the next milestone.


### PR DESCRIPTION
 Changes Made
 
1. team-best-practices.md:
Old: take in account
New: take into account
Reason: Correct phrasal verb in standard English.

2. CONTRIBUTING.md:
Old: jsx maybe not be acceptable
New: jsx may not be acceptable
Reason: Correct verbal construction ("may be" instead of "maybe").

Old: add a code in any library
New: add code in any library
Reason: "Code" is uncountable, removing unnecessary article.

Summary
These minor changes improve documentation readability and maintain professional standards.
Please review and let me know if any adjustments are needed.