### PR TITLE
terminal dragbar zindex reduced

### DIFF
--- a/libs/remix-ui/panel/src/lib/dragbar/dragbar.css
+++ b/libs/remix-ui/panel/src/lib/dragbar/dragbar.css
@@ -7,7 +7,7 @@
   left: 0px;
   top: 0px;
   height: 0.3em;
-  z-index: 1000;
+  z-index: 100;
 }
 
 .overlay {


### PR DESCRIPTION
I noticed the dragbar is showing on top of the AIChat window. So I reduced the zIndex of the dragbar. 

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/bdc2ff8a-4934-417d-8571-4ffc59fc0cec">
