### PR TITLE
Verification plugin: add lookupAndSave method to plugin client

### DIFF
--- a/apps/contract-verification/src/app/ContractVerificationPluginClient.ts
+++ b/apps/contract-verification/src/app/ContractVerificationPluginClient.ts
@@ -1,12 +1,16 @@
 import { PluginClient } from '@remixproject/plugin'
 import { createClient } from '@remixproject/plugin-webview'
 import EventManager from 'events'
+import { VERIFIERS, type ChainSettings, type ContractVerificationSettings, type LookupResponse, type VerifierIdentifier } from './types'
+import { mergeChainSettingsWithDefaults, validConfiguration } from './utils'
+import { getVerifier } from './Verifiers'
 
 export class ContractVerificationPluginClient extends PluginClient {
   public internalEvents: EventManager
 
   constructor() {
     super()
+    this.methods = ['lookupAndSave']
     this.internalEvents = new EventManager()
     createClient(this)
     this.onload()
@@ -14,5 +18,58 @@ export class ContractVerificationPluginClient extends PluginClient {
 
   onActivation(): void {
     this.internalEvents.emit('verification_activated')
+  }
+
+  async lookupAndSave(verifierId: string, chainId: string, contractAddress: string): Promise<LookupResponse> {
+    const canonicalVerifierId = VERIFIERS.find((id) => id.toLowerCase() === verifierId.toLowerCase())
+    if (!canonicalVerifierId) {
+      console.error(`lookupAndSave failed: Unknown verifier: ${verifierId}`)
+      return
+    }
+
+    const userSettings = this.getUserSettingsFromLocalStorage()
+    const chainSettings = mergeChainSettingsWithDefaults(chainId, userSettings)
+
+    try {
+      const lookupResult = await this.lookup(canonicalVerifierId, chainSettings, chainId, contractAddress)
+      await this.saveToRemix(lookupResult)
+      return lookupResult
+    } catch (err) {
+      console.error(`lookupAndSave failed: ${err}`)
+    }
+  }
+
+  async lookup(verifierId: VerifierIdentifier, chainSettings: ChainSettings, chainId: string, contractAddress: string): Promise<LookupResponse> {
+    if (!validConfiguration(chainSettings, verifierId)) {
+      throw new Error(`Error during lookup: Invalid configuration given for verifier ${verifierId}`)
+    }
+    const verifier = getVerifier(verifierId, chainSettings.verifiers[verifierId])
+    return await verifier.lookup(contractAddress, chainId)
+  }
+
+  async saveToRemix(lookupResponse: LookupResponse): Promise<void> {
+    for (const source of lookupResponse.sourceFiles ?? []) {
+      try {
+        await this.call('fileManager', 'setFile', source.path, source.content)
+      } catch (err) {
+        throw new Error(`Error while creating file ${source.path}: ${err.message}`)
+      }
+    }
+    try {
+      await this.call('fileManager', 'open', lookupResponse.targetFilePath)
+    } catch (err) {
+      throw new Error(`Error focusing file ${lookupResponse.targetFilePath}: ${err.message}`)
+    }
+  }
+
+  private getUserSettingsFromLocalStorage(): ContractVerificationSettings {
+    const fallbackSettings = { chains: {} };
+    try {
+      const settings = window.localStorage.getItem("contract-verification:settings")
+      return settings ? JSON.parse(settings) : fallbackSettings
+    } catch (error) {
+      console.error(error)
+      return fallbackSettings
+    }
   }
 }

--- a/apps/contract-verification/src/app/views/LookupView.tsx
+++ b/apps/contract-verification/src/app/views/LookupView.tsx
@@ -5,7 +5,6 @@ import type { LookupResponse, VerifierIdentifier } from '../types'
 import { VERIFIERS } from '../types'
 import { AppContext } from '../AppContext'
 import { CustomTooltip } from '@remix-ui/helper'
-import { getVerifier } from '../Verifiers'
 import { useNavigate } from 'react-router-dom'
 import { VerifyFormContext } from '../VerifyFormContext'
 import { useSourcifySupported } from '../hooks/useSourcifySupported'
@@ -24,7 +23,7 @@ export const LookupView = () => {
   const sourcifySupported = useSourcifySupported(selectedChain, chainSettings)
 
   const noVerifierEnabled = VERIFIERS.every((verifierId) => !validConfiguration(chainSettings, verifierId) || (verifierId === 'Sourcify' && !sourcifySupported))
-  const submitDisabled = !!contractAddressError || !contractAddress || !selectedChain || noVerifierEnabled
+  const submitDisabled = !!contractAddressError || !contractAddress || !selectedChain || noVerifierEnabled || Object.values(loadingVerifiers).some((loading) => loading)
 
   // Reset results when chain or contract changes
   useEffect(() => {
@@ -46,9 +45,7 @@ export const LookupView = () => {
       }
 
       setLoadingVerifiers((prev) => ({ ...prev, [verifierId]: true }))
-      const verifier = getVerifier(verifierId, chainSettings.verifiers[verifierId])
-      verifier
-        .lookup(contractAddress, selectedChain.chainId.toString())
+      clientInstance.lookup(verifierId, chainSettings, selectedChain.chainId.toString(), contractAddress)
         .then((result) => setLookupResult((prev) => ({ ...prev, [verifierId]: result })))
         .catch((err) =>
           setLookupResult((prev) => {
@@ -65,18 +62,11 @@ export const LookupView = () => {
   }
 
   const handleOpenInRemix = async (lookupResponse: LookupResponse) => {
-    for (const source of lookupResponse.sourceFiles ?? []) {
-      try {
-        await clientInstance.call('fileManager', 'setFile', source.path, source.content)
-      } catch (err) {
-        console.error(`Error while creating file ${source.path}: ${err.message}`)
-      }
-    }
     try {
-      await clientInstance.call('fileManager', 'open', lookupResponse.targetFilePath)
+      await clientInstance.saveToRemix(lookupResponse)
       await sendToMatomo('lookup', 'openInRemix On: ' + selectedChain)
     } catch (err) {
-      console.error(`Error focusing file ${lookupResponse.targetFilePath}: ${err.message}`)
+      console.error(`Error while trying to open in Remix: ${err.message}`)
     }
   }
 


### PR DESCRIPTION
Removing the Sourcify plugin broke the "Open in Remix" functionality in the Sourcify UI. See https://github.com/ethereum/sourcify/issues/1730.

The verification plugin client was implemented without any externally callable methods.  In order to support a "Open in Remix" button in the Sourcify UI, this PR adds a `lookupAndSave` method.