### PR TITLE
Fix incorrect integrity hash prefix Update index.html

### DIFF
--- a/apps/circuit-compiler/src/index.html
+++ b/apps/circuit-compiler/src/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous"/> -->
     <!-- <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous"> -->
-    <link rel="stylesheet" integrity="ha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+    <link rel="stylesheet" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
 		crossorigin="anonymous" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css">
   </head>
   <body>


### PR DESCRIPTION
**Description:**

<img width="848" alt="Снимок экрана 2024-11-27 в 14 19 13" src="https://github.com/user-attachments/assets/cfd7092c-0a6e-44e0-be29-11bb445c979e">

In the provided HTML code, there was a typo in the `integrity` attribute of the Font Awesome stylesheet link. The integrity value incorrectly started with `ha384`, but it should start with `sha384`. This caused the integrity check to fail and prevented the stylesheet from being loaded correctly in some environments.

**The error:**
```html
<link rel="stylesheet" integrity="ha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css">
```

**The fix:**
```html
<link rel="stylesheet" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css">
```

**Why is this important?**

The integrity attribute is used for Subresource Integrity (SRI) checks, which help ensure that the file loaded by the browser is not tampered with. By correcting the hash prefix to `sha384`, the file's integrity check will work properly, allowing the Font Awesome stylesheet to be loaded securely. This change is crucial to maintaining security and proper functionality.