### PR TITLE
expose method for plugin

### DIFF
--- a/apps/remix-ide/src/app/components/side-panel.tsx
+++ b/apps/remix-ide/src/app/components/side-panel.tsx
@@ -12,7 +12,7 @@ const sidePanel = {
   displayName: 'Side Panel',
   description: 'Remix IDE side panel',
   version: packageJson.version,
-  methods: ['addView', 'removeView', 'currentFocus', 'pinView', 'unPinView', 'focus']
+  methods: ['addView', 'removeView', 'currentFocus', 'pinView', 'unPinView', 'focus', 'showContent']
 }
 
 export class SidePanel extends AbstractPanel {


### PR DESCRIPTION
Switching to a workspace from recent workspaces shows this error in browser console on live:
```
Uncaught (in promise) Error: Cannot call method "showContent" of "sidePanel" from "home", because "showContent" is not exposed. Here is the list of exposed methods: "addView","removeView","currentFocus","pinView","unPinView","focus","canDeactivate"
    at RemixEngine.<anonymous> (engine.ts:132:13)
    at Generator.next (<anonymous>)
    at fulfilled (tslib.es6.js:73:58)
```

This PR fixes it.