### PR TITLE
Fix minor typos and grammar issues in locale files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Remix now supports Internationalization. Everyone is welcome to contribute to th
 ### How to make a string support intl?
 First, put the string in the locale file located under `apps/remix-ide/src/app/tabs/locales/en`.
 Each json file corresponds to a module. If the module does not exist, then create a new json and import it in the `index.js`.
-Then you can replace the string with a intl component. The `id` prop will be the key of this string.
+Then you can replace the string with an intl component. The `id` prop will be the key of this string.
 ```jsx
 <label className="py-2 align-self-center m-0" style={{fontSize: "1.2rem"}}>
 -  Learn

--- a/apps/remix-dapp/src/locales/en/terminal.json
+++ b/apps/remix-dapp/src/locales/en/terminal.json
@@ -12,7 +12,7 @@
   "terminal.welcomeText5": "Execute JavaScript scripts",
   "terminal.welcomeText6": "Input a script directly in the command line interface",
   "terminal.welcomeText7": "Select a Javascript file in the file explorer and then run `remix.execute()` or `remix.exeCurrent()`  in the command line interface",
-  "terminal.welcomeText8": "Right click on a JavaScript file in the file explorer and then click `Run`",
+  "terminal.welcomeText8": "Right-click on a JavaScript file in the file explorer and then click `Run`",
   "terminal.welcomeText9": "The following libraries are accessible",
   "terminal.welcomeText10": "Type the library name to see available commands",
   "terminal.text1": "This type of command has been deprecated and is not functionning anymore. Please run remix.help() to list available commands.",

--- a/apps/remix-dapp/src/locales/en/udapp.json
+++ b/apps/remix-dapp/src/locales/en/udapp.json
@@ -112,7 +112,7 @@
   "udapp.llIError4": "The calldata should be a valid hexadecimal value.",
   "udapp.llIError5": "'Fallback' function is not defined",
   "udapp.llIError6": "Both 'receive' and 'fallback' functions are not defined",
-  "udapp.llIError7": "Please define a 'Fallback' function to send calldata and a either 'Receive' or payable 'Fallback' to send ethers",
+  "udapp.llIError7": "Please define a 'Fallback' function to send calldata and an either 'Receive' or payable 'Fallback' to send ethers",
   "udapp.copy": "Copy",
 
   "udapp._comment_mainnet.tsx": "libs/remix-ui/run-tab/src/lib/components/mainnet.tsx",

--- a/apps/remix-ide/src/app/tabs/locales/en/solUmlGen.json
+++ b/apps/remix-ide/src/app/tabs/locales/en/solUmlGen.json
@@ -4,7 +4,7 @@
   "solUmlGen.pngDownloadTooltip": "Download UML diagram as a PNG file",
   "solUmlGen.pdfDownloadTooltip": "Download UML diagram as a PDF file",
   "solUmlGen.text1": "To view your contract as a UML Diagram",
-  "solUmlGen.text2": "Right click on your contract file",
+  "solUmlGen.text2": "Right-click on your contract file",
   "solUmlGen.clickOn": "Click on",
   "solUmlGen.generateUML": "Generate UML"
 }

--- a/apps/remix-ide/src/app/tabs/locales/en/terminal.json
+++ b/apps/remix-ide/src/app/tabs/locales/en/terminal.json
@@ -12,7 +12,7 @@
   "terminal.welcomeText5": "Execute JavaScript scripts",
   "terminal.welcomeText6": "Input a script directly in the command line interface",
   "terminal.welcomeText7": "Select a Javascript file in the file explorer and then run `remix.execute()` or `remix.exeCurrent()`  in the command line interface",
-  "terminal.welcomeText8": "Right click on a JavaScript file in the file explorer and then click `Run`",
+  "terminal.welcomeText8": "Right-click on a JavaScript file in the file explorer and then click `Run`",
   "terminal.welcomeText9": "The following libraries are accessible",
   "terminal.welcomeText10": "Type the library name to see available commands",
   "terminal.text1": "This type of command has been deprecated and is not functioning anymore. Please run remix.help() to list available commands.",

--- a/apps/remix-ide/src/app/tabs/locales/es/solUmlGen.json
+++ b/apps/remix-ide/src/app/tabs/locales/es/solUmlGen.json
@@ -4,7 +4,7 @@
   "solUmlGen.pngDownloadTooltip": "Download UML diagram as a PNG file",
   "solUmlGen.pdfDownloadTooltip": "Download UML diagram as a PDF file",
   "solUmlGen.text1": "To view your contract as a UML Diagram",
-  "solUmlGen.text2": "Right click on your contract file",
+  "solUmlGen.text2": "Right-click on your contract file",
   "solUmlGen.clickOn": "Click on",
   "solUmlGen.generateUML": "Generate UML"
 }

--- a/apps/remix-ide/src/app/tabs/locales/fr/solUmlGen.json
+++ b/apps/remix-ide/src/app/tabs/locales/fr/solUmlGen.json
@@ -4,7 +4,7 @@
   "solUmlGen.pngDownloadTooltip": "Download UML diagram as a PNG file",
   "solUmlGen.pdfDownloadTooltip": "Download UML diagram as a PDF file",
   "solUmlGen.text1": "To view your contract as a UML Diagram",
-  "solUmlGen.text2": "Right click on your contract file",
+  "solUmlGen.text2": "Right-click on your contract file",
   "solUmlGen.clickOn": "Click on",
   "solUmlGen.generateUML": "Generate UML"
 }

--- a/apps/remix-ide/src/app/tabs/locales/it/solUmlGen.json
+++ b/apps/remix-ide/src/app/tabs/locales/it/solUmlGen.json
@@ -4,7 +4,7 @@
   "solUmlGen.pngDownloadTooltip": "Download UML diagram as a PNG file",
   "solUmlGen.pdfDownloadTooltip": "Download UML diagram as a PDF file",
   "solUmlGen.text1": "To view your contract as a UML Diagram",
-  "solUmlGen.text2": "Right click on your contract file",
+  "solUmlGen.text2": "Right-click on your contract file",
   "solUmlGen.clickOn": "Click on",
   "solUmlGen.generateUML": "Generate UML"
 }


### PR DESCRIPTION
This pull request corrects several grammar and spelling mistakes in the following locale files:

- **CONTRIBUTING.md**: Corrected the usage of "an" instead of "a" before a vowel sound.
- **terminal.json**: Fixed the hyphenation in "right-click."
- **udapp.json**: Fixed the usage of "an" instead of "a" before a vowel sound.
