### PR TITLE
Fix documentation links in RemixAI-related plugins

### DIFF
--- a/apps/remix-ide/src/app/plugins/electron/remixAIDesktopPlugin.tsx
+++ b/apps/remix-ide/src/app/plugins/electron/remixAIDesktopPlugin.tsx
@@ -8,7 +8,7 @@ const desktop_profile = {
   displayName: 'RemixAI Desktop',
   maintainedBy: 'Remix',
   description: 'RemixAI provides AI services to Remix IDE Desktop.',
-  documentation: 'https://remix-ide.readthedocs.io/en/latest/remixai.html',
+  documentation: 'https://remix-ide.readthedocs.io/en/latest/ai.html',
   icon: 'assets/img/remix-logo-blue.png',
   methods: ['initializeModelBackend', 'code_completion', 'code_insertion', 'code_generation', 'code_explaining', 'error_explaining', 'solidity_answer'],
 }

--- a/apps/remix-ide/src/app/plugins/remixAIPlugin.tsx
+++ b/apps/remix-ide/src/app/plugins/remixAIPlugin.tsx
@@ -24,7 +24,7 @@ const profile = {
   description: 'RemixAI provides AI services to Remix IDE.',
   kind: '',
   location: 'popupPanel',
-  documentation: 'https://remix-ide.readthedocs.io/en/latest/remixai.html',
+  documentation: 'https://remix-ide.readthedocs.io/en/latest/ai.html',
   version: packageJson.version,
   maintainedBy: 'Remix'
 }

--- a/apps/remixdesktop/src/plugins/remixAIDektop.ts
+++ b/apps/remixdesktop/src/plugins/remixAIDektop.ts
@@ -14,7 +14,7 @@ const profile = {
   maintainedBy: 'Remix',
   description: 'RemixAI provides AI services to Remix IDE Desktop.',
   kind: '',
-  documentation: 'https://remix-ide.readthedocs.io/en/latest/remixai.html',
+  documentation: 'https://remix-ide.readthedocs.io/en/latest/ai.html',
 }
 
 export class RemixAIDesktopPlugin extends ElectronBasePlugin {
@@ -31,7 +31,7 @@ const clientProfile: Profile = {
   maintainedBy: 'Remix',
   description: 'RemixAI provides AI services to Remix IDE Desktop.',
   kind: '',
-  documentation: 'https://remix-ide.readthedocs.io/en/latest/remixai.html',
+  documentation: 'https://remix-ide.readthedocs.io/en/latest/ai.html',
   methods: ['initializeModelBackend', 'code_completion', 'code_insertion', 'code_generation', 'code_explaining', 'error_explaining', 'solidity_answer']
 }
 


### PR DESCRIPTION
## Description
This pull request updates outdated documentation links across several files in the Remix IDE repository. The changes ensure that the correct path (`/ai.html`) is used instead of the deprecated `/remixai.html`.
  - https://remix-ide.readthedocs.io/en/latest/remixai.html 
  + https://remix-ide.readthedocs.io/en/latest/ai.html

## Commits and Changes
### 1. **fix link remixAIDektop.ts** 
### 2. **fix link remixAIDesktopPlugin.tsx** 
### 3. **fix link remixAIPlugin.tsx** 

![image](https://github.com/user-attachments/assets/734eb296-8297-473c-8fb5-687bc6d77678)
