### PR TITLE
Improve documentation grammar and clarity

### DIFF
--- a/apps/remixdesktop/TEST.md
+++ b/apps/remixdesktop/TEST.md
@@ -1,4 +1,4 @@
-# How run and write tests for Remix Desktop
+# How to run and write tests for Remix Desktop
 
 
 ### Basic procedure of local testing
@@ -107,7 +107,7 @@ module.exports = {
 
 Always use this, it avoids trouble: 
 ```
-rowser.hideToolTips()
+browser.hideToolTips()
 ```
 
 

--- a/libs/remix-tests/README.md
+++ b/libs/remix-tests/README.md
@@ -52,7 +52,7 @@ Example to understand the use of special methods can be found [here in tests](te
 
 #### Use a different sender `msg.sender`
 
-It is quite common that a contract need to be tested in different situation.
+It is quite common that a contract needs to be tested in different situation.
 Especially being able to set before hand the sender account (`msg.sender`) used for a specific tests suite enable quite a lot a new test use cases.
 please checkout this [test contract](tests/various_sender/sender_and_value_test.sol) for an example.
 Note that `TestsAccounts` is filled with all the accounts available in `web3.eth.accounts()`.
@@ -208,7 +208,7 @@ Loading remote solc version v0.7.4+commit.3f05b770 ...
 	 returned: 1
 ```
 
-:point_right: remix-test can also be used for continuous integration testing. See example [Su Squares contract](https://github.com/su-squares/ethereum-contract/tree/e542f37d4f8f6c7b07d90a6554424268384a4186) and [Travis build](https://travis-ci.org/su-squares/ethereum-contract/builds/446186067) 
+:point_right: remix-test can also be used for continuous integration testing. See an example [Su Squares contract](https://github.com/su-squares/ethereum-contract/tree/e542f37d4f8f6c7b07d90a6554424268384a4186) and [Travis build](https://travis-ci.org/su-squares/ethereum-contract/builds/446186067) 
 
 #### As a Library for development 
 

--- a/libs/remix-ws-templates/src/templates/rln/README.md
+++ b/libs/remix-ws-templates/src/templates/rln/README.md
@@ -33,6 +33,4 @@ This script:
 
 - generate a witness and a proof of execution with `messageId`equal to 0.
 
-- generate a witness and a proof of execution with `messageId`equal to 0.
-
 - generating 2 proofs (two different messages) with the same `messageId` reveal the two points of the polynomial necessary to deduct the `identitySecret` (using `shamirRecovery`).


### PR DESCRIPTION


## Files Changed
1. apps/remixdesktop/TEST.md
2. libs/remix-tests/README.md
3. libs/remix-ws-templates/src/templates/rln/README.md

## Detailed Changes

### 1. Title Clarity in apps/remixdesktop/TEST.md
- Old: "How run and write tests for Remix Desktop"
- New: "How to run and write tests for Remix Desktop"
Reason: Added missing "to" for proper English grammar and readability

### 2. Component Name in apps/remixdesktop/TEST.md
- Old: "rowser.hideToolTips()"
- New: "browser.hideToolTips()"
Reason: Fixed typo in API method name for correct functionality reference

### 3. Grammar Fix in libs/remix-tests/README.md
- Old: "need to be tested"
- New: "needs to be tested"
Reason: Corrected subject-verb agreement as "contract" (singular) requires "needs"

### 4. Article Addition in libs/remix-tests/README.md
- Old: "See example"
- New: "See an example"
Reason: Added missing article "an" for proper English grammar

### 5. Content Cleanup in libs/remix-ws-templates/src/templates/rln/README.md
- Removed: "generate a witness and a proof of execution with `messageId`equal to 0."
Reason: Removed duplicate line to improve documentation clarity

## Summary
These changes improve the documentation by:
- Fixing grammatical errors
- Correcting method names
- Removing redundant content
- Enhancing overall readability


