### PR TITLE
Typos+code fix

### DIFF
--- a/apps/circuit-compiler/src/app/app.tsx
+++ b/apps/circuit-compiler/src/app/app.tsx
@@ -144,7 +144,7 @@ function App() {
 
       dispatch({ type: 'SET_COMPILER_FEEDBACK', payload: report })
     } catch (e) {
-      if (process.platform === 'win32' && err.message.includes('3221225781')) return dispatch({ type: 'SET_COMPILER_FEEDBACK', payload: 'The compiler failed to start because of some missing dependecies. Please install or repair the Microsoft Visual C++ Redistributable package to resolve this issue.' })
+      if (process.platform === 'win32' && err.message.includes('3221225781')) return dispatch({ type: 'SET_COMPILER_FEEDBACK', payload: 'The compiler failed to start because of some missing dependencies. Please install or repair the Microsoft Visual C++ Redistributable package to resolve this issue.' })
       dispatch({ type: 'SET_COMPILER_FEEDBACK', payload: err.message })
     }
   }

--- a/apps/remix-dapp/src/locales/en/terminal.json
+++ b/apps/remix-dapp/src/locales/en/terminal.json
@@ -15,7 +15,7 @@
   "terminal.welcomeText8": "Right-click on a JavaScript file in the file explorer and then click `Run`",
   "terminal.welcomeText9": "The following libraries are accessible",
   "terminal.welcomeText10": "Type the library name to see available commands",
-  "terminal.text1": "This type of command has been deprecated and is not functionning anymore. Please run remix.help() to list available commands.",
+  "terminal.text1": "This type of command has been deprecated and is not functioning anymore. Please run remix.help() to list available commands.",
   "terminal.hideTerminal": "Hide Terminal",
   "terminal.showTerminal": "Show Terminal",
   "terminal.clearConsole": "Clear console",

--- a/apps/remix-ide/src/app/tabs/locale-module.js
+++ b/apps/remix-ide/src/app/tabs/locale-module.js
@@ -38,7 +38,7 @@ export class LocaleModule extends Plugin {
       config: Registry.getInstance().get('config') && Registry.getInstance().get('config').api
     }
     this.locales = {}
-    locales.map((locale) => {
+    locales.forEach((locale) => {
       this.locales[locale.code.toLocaleLowerCase()] = locale
     })
     this._paq = _paq


### PR DESCRIPTION
# Fix: Replaced `map` with `forEach` and corrected typos in comments

## What was changed
1. **Replaced `map` with `forEach`** in `locale-module.js` to correctly iterate over the array without creating an unused array.
2. **Corrected typos** in comments to improve clarity and professionalism.

## Why these changes were made
- **Replacing `map` with `forEach`** ensures the proper method is used for iterating over the array without unnecessary overhead or misuse of `.map()`.
- **Fixing typos** enhances the clarity and readability of the codebase, making it more professional and easier to understand.

## Additional Notes
- These changes focus on improving the semantics and maintainability of the code without affecting its functionality.
