### PR TITLE
Avoid variable shadowing by renaming inner `url` to ensure code clarity and functionality.

### DIFF
--- a/libs/remix-ai-core/src/agents/codeExplainAgent.ts
+++ b/libs/remix-ai-core/src/agents/codeExplainAgent.ts
@@ -1,4 +1,4 @@
-// interactive code explaining and highlight security vunerabilities
+// interactive code explaining and highlight security vulnerabilities
 import * as fs from 'fs';
 
 export class CodeExplainAgent {

--- a/libs/remix-url-resolver/src/resolve.ts
+++ b/libs/remix-url-resolver/src/resolve.ts
@@ -105,7 +105,7 @@ export class RemixURLResolver {
     // eslint-disable-next-line no-useless-catch
     try {
         const bzz = new Bzz({ url: this.protocol + '//swarm-gateways.net' })
-        const swarmUrl = bzz.getDownloadURL(cleanUrl, { mode: 'raw' }) // изменено название переменной
+        const swarmUrl = bzz.getDownloadURL(cleanUrl, { mode: 'raw' }) // variable name changed
         const response: AxiosResponse = await axios.get(swarmUrl, { transformResponse: []})
         return { content: response.data, cleanUrl }
     } catch (e) {

--- a/libs/remix-url-resolver/src/resolve.ts
+++ b/libs/remix-url-resolver/src/resolve.ts
@@ -101,17 +101,17 @@ export class RemixURLResolver {
     }
   }
 
-  async handleSwarm(url: string, cleanUrl: string): Promise<HandlerResponse> {
+ async handleSwarm(url: string, cleanUrl: string): Promise<HandlerResponse> {
     // eslint-disable-next-line no-useless-catch
     try {
-      const bzz = new Bzz({ url: this.protocol + '//swarm-gateways.net' })
-      const url = bzz.getDownloadURL(cleanUrl, { mode: 'raw' })
-      const response: AxiosResponse = await axios.get(url, { transformResponse: []})
-      return { content: response.data, cleanUrl }
+        const bzz = new Bzz({ url: this.protocol + '//swarm-gateways.net' })
+        const swarmUrl = bzz.getDownloadURL(cleanUrl, { mode: 'raw' }) // изменено название переменной
+        const response: AxiosResponse = await axios.get(swarmUrl, { transformResponse: []})
+        return { content: response.data, cleanUrl }
     } catch (e) {
-      throw e
+        throw e
     }
-  }
+ }
 
   /**
   * Handle an import statement based on IPFS

--- a/libs/remix-url-resolver/src/resolve.ts
+++ b/libs/remix-url-resolver/src/resolve.ts
@@ -101,17 +101,17 @@ export class RemixURLResolver {
     }
   }
 
- async handleSwarm(url: string, cleanUrl: string): Promise<HandlerResponse> {
+  async handleSwarm(url: string, cleanUrl: string): Promise<HandlerResponse> {
     // eslint-disable-next-line no-useless-catch
     try {
-        const bzz = new Bzz({ url: this.protocol + '//swarm-gateways.net' })
-        const swarmUrl = bzz.getDownloadURL(cleanUrl, { mode: 'raw' }) // variable name changed
-        const response: AxiosResponse = await axios.get(swarmUrl, { transformResponse: []})
-        return { content: response.data, cleanUrl }
+      const bzz = new Bzz({ url: this.protocol + '//swarm-gateways.net' })
+      const swarmUrl = bzz.getDownloadURL(cleanUrl, { mode: 'raw' }) // variable name changed
+      const response: AxiosResponse = await axios.get(swarmUrl, { transformResponse: []})
+      return { content: response.data, cleanUrl }
     } catch (e) {
-        throw e
+      throw e
     }
- }
+  }
 
   /**
   * Handle an import statement based on IPFS


### PR DESCRIPTION
Redefining the variable `url` inside the function causes a naming conflict: the inner variable shadows the function parameter. This can lead to errors or unexpected behavior since the outer `url` becomes inaccessible. Renaming resolves the conflict and ensures code readability and correctness.
