### PR TITLE
fix: fix incorrect MIME type for favicon in HTML Update index.html

### DIFF
--- a/apps/remix-ide/src/index.html
+++ b/apps/remix-ide/src/index.html
@@ -26,7 +26,7 @@
 	<meta http-equiv="X-UA-Compatible" content="chrome=1">
 	<title>Remix - Ethereum IDE</title>
 	<link rel="stylesheet" href="assets/css/pygment_trac.css">
-	<link rel="icon" type="x-icon" href="assets/img/remix-logo-blue.png">
+	<link rel="icon" type="image/x-icon" href="assets/img/remix-logo-blue.png">
 	<link rel="stylesheet" href="assets/css/intro.js/4.1.0/introjs.min.css">
 	<link rel="stylesheet" href="assets/fontawesome/css/all.css">
 	<script src="assets/js/browserfs.min.js"></script>


### PR DESCRIPTION
`image/x-icon` is the correct MIME type for the favicon, while `x-icon` is outdated and might not be properly recognized.