### PR TITLE
fix: Fix usage of constant in winningProposal function

### DIFF
--- a/libs/remix-debug/test/sol/ballot.sol
+++ b/libs/remix-debug/test/sol/ballot.sol
@@ -54,7 +54,7 @@ contract Ballot {
         proposals[toProposal].voteCount += sender.weight;
     }
 
-    function winningProposal() public constant returns (uint8 _winningProposal) {
+    function winningProposal() public view returns (uint8 _winningProposal) {
         uint256 winningVoteCount = 0;
         for (uint8 prop = 0; prop < proposals.length; prop++)
             if (proposals[prop].voteCount > winningVoteCount) {


### PR DESCRIPTION
Hi there! I came across a small issue in the Solidity contract. In the `winningProposal` function, the keyword `constant` was used, but in newer versions of Solidity, it should be replaced with `view` for functions that only read from the blockchain state and don't modify it.

Here’s what I changed:

- Replaced `constant` with `view` in the `winningProposal` function definition:
  
  Before:
  ```solidity
  function winningProposal() public constant returns (uint8 _winningProposal) {
  ```

  After:
  ```solidity
  function winningProposal() public view returns (uint8 _winningProposal) {
  ```

This small fix ensures that the contract is in line with the newer Solidity versions.