### PR TITLE
Fixed comment typo Update securityAgent.ts

### DIFF
--- a/libs/remix-ai-core/src/agents/securityAgent.ts
+++ b/libs/remix-ai-core/src/agents/securityAgent.ts
@@ -2,7 +2,7 @@
 import * as fs from 'fs';
 
 class SecurityAgent {
-  private codebase: string[]; // list of code base file
+  private codebase: string[]; // list of code base files
   public currentFile: string;
 
   constructor(codebasePath: string) {


### PR DESCRIPTION
I noticed a typo in the comment for the `codebase` variable.
The original comment read, "list of code base file", but the plural form was missing.
I’ve corrected it to "list of code base **files**" for better clarity and accuracy. 