### PR TITLE
Refined text by fixing typos and improving clarity

### DIFF
--- a/apps/vyper/.browserslistrc
+++ b/apps/vyper/.browserslistrc
@@ -10,7 +10,7 @@
 last 1 Chrome version
 last 1 Firefox version
 last 2 Edge major versions
-last 2 Safari major version
+last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR
 not IE 9-11 # For IE 9-11 support, remove 'not'.

--- a/libs/remix-ws-templates/src/templates/rln/templates/groth16_verifier.sol.ejs
+++ b/libs/remix-ws-templates/src/templates/rln/templates/groth16_verifier.sol.ejs
@@ -4,7 +4,7 @@
 
     This file is generated with [snarkJS](https://github.com/iden3/snarkjs).
 
-    snarkJS is a free software: you can redistribute it and/or modify it
+    snarkJS is free software: you can redistribute it and/or modify it
     under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.

--- a/libs/remix-ws-templates/src/templates/rln/templates/plonk_verifier.sol.ejs
+++ b/libs/remix-ws-templates/src/templates/rln/templates/plonk_verifier.sol.ejs
@@ -4,7 +4,7 @@
 
     This file is generated with [snarkJS](https://github.com/iden3/snarkjs).
 
-    snarkJS is a free software: you can redistribute it and/or modify it
+    snarkJS is free software: you can redistribute it and/or modify it
     under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.


### PR DESCRIPTION
This pull request addresses the following errors in the documentation:

"version" -> "versions"
"snarkJS is a free software" -> "snarkJS is free software" (SnarkJS is a free software" is incorrect because "software" is uncountable in English and doesn’t take the article "a." The correct phrase is "snarkJS is free software.)

I hope my correction will contribute to the project's development. Thank you for the time you gave me.