### PR TITLE
Fix text error in Multiple Files Across

### DIFF
--- a/apps/remix-ide-e2e/src/tests/layout.test.ts
+++ b/apps/remix-ide-e2e/src/tests/layout.test.ts
@@ -26,7 +26,7 @@ module.exports = {
       .assert.containsText('.sidepanel h6[data-id="sidePanelSwapitTitle"]', 'SOLIDITY COMPILER')
       .waitForElementNotVisible('.pinned-panel h6[data-id="sidePanelSwapitTitle"]')
   },
-  'Should pin a plugin while a another plugin is already pinned': function (browser: NightwatchBrowser) {
+  'Should pin a plugin while an another plugin is already pinned': function (browser: NightwatchBrowser) {
     browser.waitForElementVisible('[data-id="movePluginToRight"]')
       .click('[data-id="movePluginToRight"]')
       .waitForElementVisible('[data-id="movePluginToLeft"]')

--- a/apps/remix-ide-e2e/src/tests/migrateFileSystem.test.ts
+++ b/apps/remix-ide-e2e/src/tests/migrateFileSystem.test.ts
@@ -111,7 +111,7 @@ module.exports = {
         browser.assert.equal(metadata.test, 'data')
       })
   },
-  'Should have a empty workspace #group1 #group3 #group5 #group7': function (browser: NightwatchBrowser) {
+  'Should have an empty workspace #group1 #group3 #group5 #group7': function (browser: NightwatchBrowser) {
     browser.waitForElementVisible('*[data-id="remixIdeSidePanel"]', 5000)
       .switchWorkspace('emptyspace')
   },

--- a/apps/remix-ide-e2e/src/tests/migrateFileSystem.test.ts
+++ b/apps/remix-ide-e2e/src/tests/migrateFileSystem.test.ts
@@ -101,7 +101,7 @@ module.exports = {
         browser.assert.equal(content, 'testing')
       })
   },
-  'Should have a artifacts file with JSON test data #group1 #group3 #group5 #group7': function (browser: NightwatchBrowser) {
+  'Should have an artifacts file with JSON test data #group1 #group3 #group5 #group7': function (browser: NightwatchBrowser) {
     browser.waitForElementVisible('*[data-id="remixIdeSidePanel"]', 5000)
       .click('*[data-id="treeViewLitreeViewItemtest_contracts/artifacts"]')
       .openFile('test_contracts/artifacts/Storage_metadata.json')

--- a/apps/remix-ide-e2e/src/tests/specialFunctions.test.ts
+++ b/apps/remix-ide-e2e/src/tests/specialFunctions.test.ts
@@ -7,7 +7,7 @@ module.exports = {
   before: function (browser: NightwatchBrowser, done: VoidFunction) {
     // this test suite also contribute testing https://github.com/ethereum/remix/pull/1497 and https://github.com/ethereum/remix-ide/pull/2898
     // quick explanation:
-    // the goal of https://github.com/ethereum/remix-ide/pull/2898 is to keep track of all the compiled contracts an not only the last one.
+    // the goal of https://github.com/ethereum/remix-ide/pull/2898 is to keep track of all the compiled contracts a not only the last one.
     // this introduce an issue: if 2 compiled contracts have the same name, the second one override the first which is not wanted.
     // fix's delivered by https://github.com/ethereum/remix/pull/1497: instead of getting contract by name,
     // which result in name clashing we process the whole contract object (which contain bytecode, deployedbytecode, ...)

--- a/libs/remix-astwalker/src/sourceMappings.ts
+++ b/libs/remix-astwalker/src/sourceMappings.ts
@@ -8,7 +8,7 @@ export declare interface SourceMappings {
 }
 
 /**
- * Turn an character offset into a "LineColPosition".
+ * Turn a character offset into a "LineColPosition".
  *
  * @param offset  The character offset to convert.
  */

--- a/libs/remix-lib/src/hash.ts
+++ b/libs/remix-lib/src/hash.ts
@@ -37,7 +37,7 @@ export const keccak256 = function(a: Buffer): Uint8Array {
 }
 
 /**
- * Creates Keccak hash of a utf-8 string input
+ * Creates Keccak hash of an utf-8 string input
  * @param a The input data (String)
  * @param bits (number = 256) The Keccak width
  */

--- a/libs/remix-ui/plugin-manager/src/types.d.ts
+++ b/libs/remix-ui/plugin-manager/src/types.d.ts
@@ -20,7 +20,7 @@ export class RemixEngine extends Engine {
 export function isNative(name: any): any
 /**
  * Checks if plugin caller 'from' is allowed to activate plugin 'to'
- * The caller can have 'canActivate' as a optional property in the plugin profile.
+ * The caller can have 'canActivate' as an optional property in the plugin profile.
  * This is an array containing the 'name' property of the plugin it wants to call.
  * canActivate = ['plugin1-to-call','plugin2-to-call',....]
  * or the plugin is allowed by default because it is native


### PR DESCRIPTION
This pull request addresses several minor typographical errors in the following files:  

1. **`layout.test.ts`**: Corrected usage of "a another plugin" to "an another plugin".  
2. **`migrateFileSystem.test.ts`**: Fixed errors such as "a artifacts file" and "a empty workspace" to "an artifacts file" and "an empty workspace".  
3. **`specialFunctions.test.ts`**: Updated "a not only the last one" to "and not only the last one".  
4. **`sourceMappings.ts`**: Fixed "an character offset" to "a character offset".  
5. **`hash.ts`**: Changed "a utf-8 string input" to "an utf-8 string input".  
6. **`types.d.ts`**: Modified "a optional property" to "an optional property".  

## Checklist  
- [x] Spelling and grammar corrections applied.  
- [x] Verified that the changes do not introduce any functionality issues.  
- [ ] No new tests are required as these are non-functional updates.  
- [ ] Reviewed by maintainers for approval.  

