### PR TITLE
docs: Fix grammatical inconsistency Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ import panelJson from './panel.json';
 import enJson from '../en';
 
 // There may have some untranslated content. Always fill in the gaps with EN JSON.
-// No need for a defaultMessage prop when render a FormattedMessage component.
+// No need for a defaultMessage prop when rendering a FormattedMessage component.
 export default Object.assign({}, enJson, {
   ...panelJson,
 })


### PR DESCRIPTION
While reviewing the documentation, I noticed a grammatical error in the "How to add another language support?" section. 

The phrase "render a FormattedMessage component" was inconsistent with the gerund form used throughout the rest of the text. I updated it to "**rendering a FormattedMessage component**" for better grammatical alignment and consistency.  

Thanks for Remix!