### PR TITLE
Fix Vyper runtime bytecode vs bytecode in the compilation UI

### DIFF
--- a/apps/vyper/src/app/utils/compiler.tsx
+++ b/apps/vyper/src/app/utils/compiler.tsx
@@ -31,8 +31,6 @@ const compileReturnType = (output, contract): VyperCompilationResult => {
   const normal = normalizeContractPath(contract)[2]
   const abi = temp[normal]['abi']
   const evm = _.merge(temp[normal]['evm'])
-  const depByteCode = evm.deployedBytecode
-  const runtimeBytecode = evm.bytecode
   const methodIdentifiers = evm.methodIdentifiers
   // TODO: verify this is correct
   const version = output.version || '0.4.0'
@@ -52,8 +50,8 @@ const compileReturnType = (output, contract): VyperCompilationResult => {
   } = {
     contractName: normal,
     abi,
-    bytecode: depByteCode,
-    runtimeBytecode,
+    bytecode: evm.bytecode,
+    runtimeBytecode: evm.deployedBytecode,
     ir: '',
     methodIdentifiers,
     version,


### PR DESCRIPTION
I noticed the Vyper UI has the "Runtime Bytecode" and the "Bytecode" (creation bytecode) fields swapped in the UI:

<img width="1290" alt="image" src="https://github.com/user-attachments/assets/90ec1a66-9951-4942-bcfa-33c84c7d2e87" />

<details>
<summary>Example contract</summary>

```vyper
# pragma version ^0.4.0

OWNER: public(immutable(address))
MY_IMMUTABLE: public(immutable(uint256))

@deploy
def __init__(val: uint256):
    OWNER = msg.sender
    MY_IMMUTABLE = val


@external
@view
def get_my_immutable() -> uint256:
  return MY_IMMUTABLE
```
</details>


I've compiled and deployed this test contract to [0xB89B7EBdF192Da742A681772C0Ed9D33E31c1ce9](https://holesky.otterscan.io/address/0xB89B7EBdF192Da742A681772C0Ed9D33E31c1ce9/contract) on Holesky. You can see the runtime bytecode code, starting with `0x5f35...` corresponds to the "Bytecode" in the UI and the creation bytecode ([tx payload](https://holesky.otterscan.io/tx/0xd9b3db6bbe693a0aa8feebea814c3653014e19568e30f77722cecfed9cfd9f05])) corresponds to "Runtime Bytecode" in the UI.

This was because they were being assigned the other way around. 

This PR fixes the false assignment.