### PR TITLE
fix: minor typos

### DIFF
--- a/libs/remix-debug/src/code/codeManager.ts
+++ b/libs/remix-debug/src/code/codeManager.ts
@@ -134,25 +134,25 @@ export class CodeManager {
     return findNodeAtInstructionIndex('FunctionDefinition', instIndex, sourceMap, ast)
   }
 
-  private retrieveCodeAndTrigger (codeMananger, address, stepIndex, tx) {
-    codeMananger.getCode(address).then((result) => {
-      this.retrieveIndexAndTrigger(codeMananger, address, stepIndex, result.instructions)
+  private retrieveCodeAndTrigger (codeManager, address, stepIndex, tx) {
+    codeManager.getCode(address).then((result) => {
+      this.retrieveIndexAndTrigger(codeManager, address, stepIndex, result.instructions)
     }).catch((error) => {
       return console.log(error)
     })
   }
 
-  private async retrieveIndexAndTrigger (codeMananger, address, step, code) {
+  private async retrieveIndexAndTrigger (codeManager, address, step, code) {
     let result
     const next = []
     const returnInstructionIndexes = []
     const outOfGasInstructionIndexes = []
 
     try {
-      result = codeMananger.getInstructionIndex(address, step)
+      result = codeManager.getInstructionIndex(address, step)
       for (let i = 1; i < 6; i++) {
         if (this.traceManager.inRange(step + i)) {
-          next.push(codeMananger.getInstructionIndex(address, step + i))
+          next.push(codeManager.getInstructionIndex(address, step + i))
         }
       }
 
@@ -177,7 +177,7 @@ export class CodeManager {
       return console.log(error)
     }
     try {
-      codeMananger.event.trigger('changed', [code, address, result, next, returnInstructionIndexes, outOfGasInstructionIndexes])
+      codeManager.event.trigger('changed', [code, address, result, next, returnInstructionIndexes, outOfGasInstructionIndexes])
     } catch (e) {
       console.log('dispatching event failed', e)
     }

--- a/libs/remix-ui/home-tab/src/lib/components/homeTabFile.tsx
+++ b/libs/remix-ui/home-tab/src/lib/components/homeTabFile.tsx
@@ -127,7 +127,7 @@ function HomeTabFile({ plugin }: HomeTabFileProps) {
     plugin.verticalIcons.select('filePanel')
   }
 
-  const handleSwichToRecentWorkspace = async (e, workspaceName) => {
+  const handleSwitchToRecentWorkspace = async (e, workspaceName) => {
     e.preventDefault()
     plugin.call('sidePanel', 'showContent', 'filePanel')
     plugin.verticalIcons.select('filePanel')
@@ -146,17 +146,17 @@ function HomeTabFile({ plugin }: HomeTabFileProps) {
                 Recent Workspaces
               </label>
               {state.recentWorkspaces[0] && state.recentWorkspaces[0] !== '' && (
-                <a className="cursor-pointer mb-1 ml-2" href="#" onClick={(e) => handleSwichToRecentWorkspace(e, state.recentWorkspaces[0])}>
+                <a className="cursor-pointer mb-1 ml-2" href="#" onClick={(e) => handleSwitchToRecentWorkspace(e, state.recentWorkspaces[0])}>
                   {state.recentWorkspaces[0]}
                 </a>
               )}
               {state.recentWorkspaces[1] && state.recentWorkspaces[1] !== '' && (
-                <a className="cursor-pointer mb-1 ml-2" href="#" onClick={(e) => handleSwichToRecentWorkspace(e, state.recentWorkspaces[1])}>
+                <a className="cursor-pointer mb-1 ml-2" href="#" onClick={(e) => handleSwitchToRecentWorkspace(e, state.recentWorkspaces[1])}>
                   {state.recentWorkspaces[1]}
                 </a>
               )}
               {state.recentWorkspaces[2] && state.recentWorkspaces[2] !== '' && (
-                <a className="cursor-pointer ml-2" href="#" onClick={(e) => handleSwichToRecentWorkspace(e, state.recentWorkspaces[2])}>
+                <a className="cursor-pointer ml-2" href="#" onClick={(e) => handleSwitchToRecentWorkspace(e, state.recentWorkspaces[2])}>
                   {state.recentWorkspaces[2]}
                 </a>
               )}

--- a/libs/remix-ui/run-tab/src/lib/actions/deploy.ts
+++ b/libs/remix-ui/run-tab/src/lib/actions/deploy.ts
@@ -61,9 +61,9 @@ export const getSelectedContract = (contractName: string, compiler: CompilerAbst
       return txHelper.getConstructorInterface(contract.object.abi)
     },
     getConstructorInputs: () => {
-      const constructorInteface = txHelper.getConstructorInterface(contract.object.abi)
+      const constructorInterface = txHelper.getConstructorInterface(contract.object.abi)
 
-      return txHelper.inputParametersDeclarationToString(constructorInteface.inputs)
+      return txHelper.inputParametersDeclarationToString(constructorInterface.inputs)
     },
     isOverSizeLimit: async (args: string) => {
       const encodedParams = await txFormat.encodeParams(args, txHelper.getConstructorInterface(contract.object.abi))


### PR DESCRIPTION
**This pull request addresses minor issues in the codebase:**
Corrected `codeMananger` to `codeManager` x7
Corrected `handleSwichToRecentWorkspace` to `handleSwitchToRecentWorkspace` x4
Corrected `constructorInteface` to `constructorInterface` x2