### PR TITLE
Fix CarouselProps Typo and Update ABI File Validation Logic

### DIFF
--- a/libs/remix-ui/home-tab/src/lib/components/types/carouselTypes.ts
+++ b/libs/remix-ui/home-tab/src/lib/components/types/carouselTypes.ts
@@ -34,7 +34,7 @@ export interface CarouselProps {
   beforeChange?: (nextSlide: number, state: StateCallBack) => void; // Change callback before sliding every time. `(previousSlide, currentState) => ...`
   sliderClass?: string; // Use this to style your own track list.
   itemClass?: string; // Use this to style your own Carousel item. For example add padding-left and padding-right
-  itemAriaLabel?: string; // Use this to add your own Carousel item aria-label.if it is not defined the child aria label will be applied if the child dont have one than a default empty string will be applied
+  itemAriaLabel?: string; // Use this to add your own Carousel item aria-label.if it is not defined the child aria label will be applied if the child doesn't have one, then a default empty string will be applied
   containerClass?: string; // Use this to style the whole container. For example add padding to allow the "dots" or "arrows" to go to other places without being overflown.
   className?: string; // Use this to style the whole container with styled-components
   dotListClass?: string; // Use this to style the dot list.

--- a/libs/remix-ui/run-tab/src/lib/actions/deploy.ts
+++ b/libs/remix-ui/run-tab/src/lib/actions/deploy.ts
@@ -22,7 +22,7 @@ const txHelper = remixLib.execution.txHelper
 const txFormat = remixLib.execution.txFormat
 
 const loadContractFromAddress = (plugin: RunTab, address, confirmCb, cb) => {
-  if (/.(.abi)$/.exec(plugin.config.get('currentFile'))) {
+  if (/\.(abi)$/.exec(plugin.config.get('currentFile'))) {
     confirmCb(() => {
       let abi
       try {


### PR DESCRIPTION
**Description:**
This pull request addresses two key updates:

`CarouselProps Update`: Fixed a grammatical error in the `itemAriaLabel` property description, changing `dont` to `doesn't` for improved clarity and correctness.
`ABI File Validation`: Updated the regular expression in `loadContractFromAddress` to ensure robust validation of `.abi` files when determining the current file in the Remix IDE.
These changes enhance code readability and reliability in handling `.abi` file operations and improve the accuracy of inline comments for better developer understanding.






