### PR TITLE
refactor(terminal): unify gpt and sol-gpt command handling

### DIFF
--- a/libs/remix-ui/terminal/src/lib/remix-ui-terminal.tsx
+++ b/libs/remix-ui/terminal/src/lib/remix-ui-terminal.tsx
@@ -235,12 +235,7 @@ export const RemixUiTerminal = (props: RemixUiTerminalProps) => {
     try {
       if (script.trim().startsWith('git')) {
         // await this.call('git', 'execute', script) code might be used in the future
-        // TODO: rm gpt or redirect gpt to sol-pgt
-      } else if (script.trim().startsWith('gpt')) {
-        call('terminal', 'log',{ type: 'warn', value: `> ${script}` })
-        await call('remixAI', 'solidity_answer', script) // No streaming supported in terminal
-        _paq.push(['trackEvent', 'ai', 'remixAI', 'askFromTerminal'])
-      } else if (script.trim().startsWith('sol-gpt')) {
+      } else if (script.trim().startsWith('gpt') || script.trim().startsWith('sol-gpt')) {
         call('terminal', 'log',{ type: 'warn', value: `> ${script}` })
         await call('remixAI', 'solidity_answer', script) // No streaming supported in terminal
         _paq.push(['trackEvent', 'ai', 'remixAI', 'askFromTerminal'])


### PR DESCRIPTION
This commit unifies the handling of 'gpt' and 'sol-gpt' terminal commands to reduce code duplication and improve maintainability. Both commands now share the same execution path and functionality, making the codebase more consistent.

Changes made:
- Combined the conditions for 'gpt' and 'sol-gpt' commands
- Removed redundant code block
- Resolved TODO comment about gpt command handling

The functionality remains the same, but the code is now more maintainable and cleaner.