### PR TITLE
fix: correct stderr event handler in `git.ts`

### DIFF
--- a/apps/remixdesktop/test/lib/git.ts
+++ b/apps/remixdesktop/test/lib/git.ts
@@ -25,7 +25,7 @@ export async function getGitLog(path: string): Promise<string> {
         git.stdout.on('data', function (data) {
             logs += data.toString()
         })
-        git.stderr.on('err', function (data) {
+        git.stderr.on('data', function (data) {
             reject(data.toString())
         })
         git.on('close', function () {


### PR DESCRIPTION
This PR fixes the stderr event handler in the getGitLog function. Changed the event name from 'err' to 'data' to match the Node.js standard event naming and maintain consistency with other similar handlers in the codebase.

Changes made:
- Changed git.stderr.on('err') to git.stderr.on('data') in getGitLog function