### PR TITLE
fix: correct typo in `txRunnerVM.ts` - queusTxs to queueTxs

### DIFF
--- a/libs/remix-lib/src/execution/txRunner.ts
+++ b/libs/remix-lib/src/execution/txRunner.ts
@@ -16,7 +16,7 @@ export type Transaction = {
 export class TxRunner {
   event
   pendingTxs
-  queusTxs
+  queueTxs
   opt
   internalRunner
   constructor (internalRunner, opt) {
@@ -25,7 +25,7 @@ export class TxRunner {
     this.event = new EventManager()
 
     this.pendingTxs = {}
-    this.queusTxs = []
+    this.queueTxs = []
   }
 
   rawRun (args: Transaction, confirmationCb, gasEstimationForceSend, promptCb, cb) {
@@ -42,14 +42,14 @@ export class TxRunner {
 
 function run (self, tx: Transaction, stamp, confirmationCb, gasEstimationForceSend = null, promptCb = null, callback = null) {
   if (Object.keys(self.pendingTxs).length) {
-    return self.queusTxs.push({ tx, stamp, confirmationCb, gasEstimationForceSend, promptCb, callback })
+    return self.queueTxs.push({ tx, stamp, confirmationCb, gasEstimationForceSend, promptCb, callback })
   }
   self.pendingTxs[stamp] = tx
   self.execute(tx, confirmationCb, gasEstimationForceSend, promptCb, function (error, result) {
     delete self.pendingTxs[stamp]
     if (callback && typeof callback === 'function') callback(error, result)
-    if (self.queusTxs.length) {
-      const next = self.queusTxs.pop()
+    if (self.queueTxs.length) {
+      const next = self.queueTxs.pop()
       run(self, next.tx, next.stamp, next.confirmationCb, next.gasEstimationForceSend, next.promptCb, next.callback)
     }
   })

--- a/libs/remix-lib/src/execution/txRunnerVM.ts
+++ b/libs/remix-lib/src/execution/txRunnerVM.ts
@@ -24,7 +24,7 @@ export class TxRunnerVM {
   blockNumber
   pendingTxs
   vmaccounts
-  queusTxs
+  queueTxs
   blocks: Uint8Array[]
   logsManager
   commonContext
@@ -41,7 +41,7 @@ export class TxRunnerVM {
     this.commonContext = this.getVMObject().common
     this.pendingTxs = {}
     this.vmaccounts = vmaccounts
-    this.queusTxs = []
+    this.queueTxs = []
     /*
       txHash is generated using the nonce,
       in order to have unique transaction hash, we need to keep using different nonce (in case of a call)


### PR DESCRIPTION
Fixed a typo in the variable name in `libs/remix-lib/src/execution/txRunnerVM.ts`:
- Changed `queusTxs` to `queueTxs` (added missing 'e' in the word "queue")

This change improves code readability and maintains proper English spelling.