### PR TITLE
fix typos: correct spelling in comments and types

### DIFF
--- a/apps/remixdesktop/test/types/index.d.ts
+++ b/apps/remixdesktop/test/types/index.d.ts
@@ -24,7 +24,7 @@ declare module 'nightwatch' {
     journalLastChildIncludes(val: string): NightwatchBrowser
     executeScriptInTerminal(script: string): NightwatchBrowser
     clearEditableContent(cssSelector: string): NightwatchBrowser
-    journalChildIncludes(val: string, opts = {shouldHaveOnlyOneOccurence: boolean}): NightwatchBrowser
+    journalChildIncludes(val: string, opts = {shouldHaveOnlyOneOccurrence: boolean}): NightwatchBrowser
     debugTransaction(index: number): NightwatchBrowser
     checkElementStyle(cssSelector: string, styleProperty: string, expectedResult: string): NightwatchBrowser
     openFile(name: string): NightwatchBrowser

--- a/libs/remix-ui/editor/src/lib/syntaxes/move.ts
+++ b/libs/remix-ui/editor/src/lib/syntaxes/move.ts
@@ -230,7 +230,7 @@ export const moveTokenProvider = {
       [/[;,.]/, "delimiter"],
 
       // strings
-      [/"([^"\\]|\\.)*$/, "string.invalid"], // non-teminated string
+      [/"([^"\\]|\\.)*$/, "string.invalid"], // non-terminated string
       [/"/, { token: "string.quote", bracket: "@open", next: "@string" }],
 
       // characters

--- a/libs/remix-ui/editor/src/lib/syntaxes/solidity.ts
+++ b/libs/remix-ui/editor/src/lib/syntaxes/solidity.ts
@@ -1384,7 +1384,7 @@ export const solidityTokensProvider = {
       [/[;,.]/, 'delimiter'],
 
       // strings
-      [/"([^"\\]|\\.)*$/, 'string.invalid'], // non-teminated string
+      [/"([^"\\]|\\.)*$/, 'string.invalid'], // non-terminated string
       [/"/, 'string', '@string'],
 
       // characters

--- a/libs/remix-ui/editor/src/lib/syntaxes/zokrates.ts
+++ b/libs/remix-ui/editor/src/lib/syntaxes/zokrates.ts
@@ -117,7 +117,7 @@ export const zokratesTokensProvider = {
       [/[;,.]/, "delimiter"],
 
       // strings
-      [/"([^"\\]|\\.)*$/, "string.invalid"], // non-teminated string
+      [/"([^"\\]|\\.)*$/, "string.invalid"], // non-terminated string
       [/"/, { token: "string.quote", bracket: "@open", next: "@string" }],
     ],
 

--- a/libs/remix-ui/git/src/components/panels/clone.tsx
+++ b/libs/remix-ui/git/src/components/panels/clone.tsx
@@ -58,7 +58,7 @@ export const Clone = (props: CloneProps) => {
   }
 
   const [cloneAllBranches, setcloneAllBranches] = useLocalStorage(
-    "GITHUB_CLONE_ALL_BRANCES",
+    "GITHUB_CLONE_ALL_BRANCHES",
     false
   );
 


### PR DESCRIPTION
This PR fixes spelling mistakes in several files:
- Corrects `non-teminated` to `non-terminated` in syntax comments
- Fixes `shouldHaveOnlyOneOccurence` to `shouldHaveOnlyOneOccurrence` in type definitions