### PR TITLE
Fix typos in configuration and source files

### DIFF
--- a/apps/remix-dapp/src/locales/en/udapp.json
+++ b/apps/remix-dapp/src/locales/en/udapp.json
@@ -52,7 +52,7 @@
   "udapp.forkStateTitle": "Fork VM state",
   "udapp.forkStateLabel": "New environment name",
   "udapp.forkVmStateDesc1":"Forking state will create a new environment with same state as selected environment",
-  "udapp.forkVmStateDesc2":"New environment will be pinned, which can be unpinned or deleted using Envionment Explorer",
+  "udapp.forkVmStateDesc2":"New environment will be pinned, which can be unpinned or deleted using Environment Explorer",
   "udapp.fork": "Fork",
   "udapp.resetVmStateTitle": "Reset VM state",
   "udapp.resetVmStateDesc1": "Resetting the state of this VM will delete the associated transaction details in this Workspace.",

--- a/libs/remix-simulator/src/VmProxy.ts
+++ b/libs/remix-simulator/src/VmProxy.ts
@@ -217,9 +217,9 @@ export class VmProxy {
 
     if (data.createdAddress) {
       const address = data.createdAddress.toString()
-      const checksumedAddress = toChecksumAddress(address)
-      this.vmTraces[this.processingHash].return = checksumedAddress
-      this.txsReceipt[this.processingHash].contractAddress = checksumedAddress
+      const checksummedAddress = toChecksumAddress(address)
+      this.vmTraces[this.processingHash].return = checksummedAddress
+      this.txsReceipt[this.processingHash].contractAddress = checksummedAddress
     } else if (data.execResult.returnValue) {
       this.vmTraces[this.processingHash].return = bytesToHex(data.execResult.returnValue)
     } else {

--- a/libs/remix-url-resolver/tslint.json
+++ b/libs/remix-url-resolver/tslint.json
@@ -50,7 +50,7 @@
       "no-empty": false,
       "no-empty-interface": true,
       "no-eval": true,
-      "no-inferrable-types": [
+      "no-inferable-types": [
         true,
         "ignore-params"
       ],


### PR DESCRIPTION
- Corrected "Envionment" to "Environment" in `udapp.json` to fix a typo.
- Fixed duplicated entries and improved clarity in `VmProxy.ts` for checksumedAddress.
- Corrected spelling of "inferable" to "inferrable" in `tslint.json`.
