### PR TITLE
fixed issue#5674

### DIFF
--- a/libs/remix-ui/run-tab/src/lib/actions/account.ts
+++ b/libs/remix-ui/run-tab/src/lib/actions/account.ts
@@ -31,7 +31,7 @@ export const fillAccountsList = async (plugin: RunTab, dispatch: React.Dispatch<
       const provider = plugin.blockchain.getProvider()
 
       if (provider && provider.startsWith('injected')) {
-        const selectedAddress = plugin.blockchain.getInjectedWeb3Address()
+        const selectedAddress = plugin.blockchain.getInjectedWeb3Address() || Object.keys(loadedAccounts)[0]; //Setting default account to first account
         if (!(Object.keys(loadedAccounts).includes(toChecksumAddress(selectedAddress)))) setAccount(dispatch, null)
       }
       dispatch(fetchAccountsListSuccess(loadedAccounts))


### PR DESCRIPTION
for injected providers, it was looking for a selected account by default. if there's no selected account(-null), toChecksumAddress() was throwing an error, causing the dispatcher to propagate the error. My fix sets the first account as default selected account - once the user explicitly sets an account, it behaves as usual

This fix also addresses #5604 ,  issue #5666  (where it is identified that "the environment dropdown still shows Injected provider but the accounts list is empty") and #5432 

The issue - 
![Screenshot 2025-01-29 at 3 21 56 AM](https://github.com/user-attachments/assets/4b1e79ac-6755-4593-8ceb-7c352f772e5a)

After the fix - 
![Screenshot 2025-01-29 at 3 23 49 AM](https://github.com/user-attachments/assets/a7d3a812-3ded-41ea-8f64-a84a62b69c0c)

