### PR TITLE
fix outdated Solidity documentation links

### DIFF
--- a/apps/remix-dapp/src/components/UniversalDappUI/lowLevelInteractions.tsx
+++ b/apps/remix-dapp/src/components/UniversalDappUI/lowLevelInteractions.tsx
@@ -141,7 +141,7 @@ export function LowLevelInteractions(props: any) {
                   // receive method added to solidity v0.6.x. use this as diff.
                   instance.solcVersion.canReceive === false ? (
                     <a
-                      href={`https://solidity.readthedocs.io/en/v${instance.solcVersion.version}/contracts.html`}
+                      href={`https://docs.soliditylang.org/en/v${instance.solcVersion.version}/contracts.html`}
                       target="_blank"
                       rel="noreferrer"
                     >
@@ -152,7 +152,7 @@ export function LowLevelInteractions(props: any) {
                     </a>
                   ) : (
                     <a
-                      href={`https://solidity.readthedocs.io/en/v${instance.solcVersion.version}/contracts.html#receive-ether-function`}
+                      href={`https://docs.soliditylang.org/en/v${instance.solcVersion.version}/contracts.html#receive-ether-function`}
                       target="_blank"
                       rel="noreferrer"
                     >

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/blockTimestamp.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/blockTimestamp.ts
@@ -30,14 +30,14 @@ export default class blockTimestamp implements AnalyzerModule {
         warning: `Use of "now": "now" does not mean current time. "now" is an alias for "block.timestamp". 
                   "block.timestamp" can be influenced by miners to a certain degree, be careful.`,
         location: item.src,
-        more: `https://solidity.readthedocs.io/en/${version}/units-and-global-variables.html?highlight=block.timestamp#block-and-transaction-properties`
+        more: `https://docs.soliditylang.org/en/${version}/units-and-global-variables.html?highlight=block.timestamp#block-and-transaction-properties`
       }
     }).concat(this.warningblockTimestampNodes.map((item) => {
       return {
         warning: `Use of "block.timestamp": "block.timestamp" can be influenced by miners to a certain degree. 
                   That means that a miner can "choose" the block.timestamp, to a certain degree, to change the outcome of a transaction in the mined block.`,
         location: item.src,
-        more: `https://solidity.readthedocs.io/en/${version}/units-and-global-variables.html?highlight=block.timestamp#block-and-transaction-properties`
+        more: `https://docs.soliditylang.org/en/${version}/units-and-global-variables.html?highlight=block.timestamp#block-and-transaction-properties`
       }
     }))
   }

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/constantFunctions.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/constantFunctions.ts
@@ -72,13 +72,13 @@ export default class constantFunctions implements AnalyzerModule {
             warnings.push({
               warning: `${funcName} : Potentially should be constant/view/pure but is not. ${comments}`,
               location: func.node.src,
-              more: `https://solidity.readthedocs.io/en/${version}/contracts.html#view-functions`
+              more: `https://docs.soliditylang.org/en/${version}/contracts.html#view-functions`
             })
           } else {
             warnings.push({
               warning: `${funcName} : Is constant but potentially should not be. ${comments}`,
               location: func.node.src,
-              more: `https://solidity.readthedocs.io/en/${version}/contracts.html#view-functions`
+              more: `https://docs.soliditylang.org/en/${version}/contracts.html#view-functions`
             })
           }
         }

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/deleteDynamicArrays.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/deleteDynamicArrays.ts
@@ -24,7 +24,7 @@ export default class deleteDynamicArrays implements AnalyzerModule {
       return {
         warning: 'The "delete" operation when applied to a dynamically sized array in Solidity generates code to delete each of the elements contained. If the array is large, this operation can surpass the block gas limit and raise an OOG exception. Also nested dynamically sized objects can produce the same results.',
         location: node.src,
-        more: `https://solidity.readthedocs.io/en/${version}/types.html#delete`
+        more: `https://docs.soliditylang.org/en/${version}/types.html#delete`
       }
     })
   }

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/etherTransferInLoop.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/etherTransferInLoop.ts
@@ -39,7 +39,7 @@ export default class etherTransferInLoop implements AnalyzerModule {
       return {
         warning: 'Ether payout should not be done in a loop: Due to the block gas limit, transactions can only consume a certain amount of gas. The number of iterations in a loop can grow beyond the block gas limit which can cause the complete contract to be stalled at a certain point. If required then make sure that number of iterations are low and you trust each address involved.',
         location: node.src,
-        more: `https://solidity.readthedocs.io/en/${version}/security-considerations.html#gas-limit-and-loops`
+        more: `https://docs.soliditylang.org/en/${version}/security-considerations.html#gas-limit-and-loops`
       }
     })
   }

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/forLoopIteratesOverDynamicArray.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/forLoopIteratesOverDynamicArray.ts
@@ -30,7 +30,7 @@ export default class forLoopIteratesOverDynamicArray implements AnalyzerModule {
       return {
         warning: 'Loops that do not have a fixed number of iterations, for example, loops that depend on storage values, have to be used carefully. Due to the block gas limit, transactions can only consume a certain amount of gas. The number of iterations in a loop can grow beyond the block gas limit which can cause the complete contract to be stalled at a certain point. \n Additionally, using unbounded loops incurs in a lot of avoidable gas costs. Carefully test how many items at maximum you can pass to such functions to make it successful.',
         location: node.src,
-        more: `https://solidity.readthedocs.io/en/${version}/security-considerations.html#gas-limit-and-loops`
+        more: `https://docs.soliditylang.org/en/${version}/security-considerations.html#gas-limit-and-loops`
       }
     })
   }

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/guardConditions.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/guardConditions.ts
@@ -24,7 +24,7 @@ export default class guardConditions implements AnalyzerModule {
       return {
         warning: 'Use "assert(x)" if you never ever want x to be false, not in any circumstance (apart from a bug in your code). Use "require(x)" if x can be false, due to e.g. invalid input or a failing external component.',
         location: node.src,
-        more: `https://solidity.readthedocs.io/en/${version}/control-structures.html#error-handling-assert-require-revert-and-exceptions`
+        more: `https://docs.soliditylang.org/en/${version}/control-structures.html#error-handling-assert-require-revert-and-exceptions`
       }
     })
   }

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/inlineAssembly.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/inlineAssembly.ts
@@ -25,7 +25,7 @@ export default class inlineAssembly implements AnalyzerModule {
         warning: `The Contract uses inline assembly, this is only advised in rare cases. 
                   Additionally static analysis modules do not parse inline Assembly, this can lead to wrong analysis results.`,
         location: node.src,
-        more: `https://solidity.readthedocs.io/en/${version}/assembly.html`
+        more: `https://docs.soliditylang.org/en/${version}/assembly.html`
       }
     })
   }

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/lowLevelCalls.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/lowLevelCalls.ts
@@ -47,26 +47,26 @@ export default class lowLevelCalls implements AnalyzerModule {
         text = `Use of "call": should be avoided whenever possible. 
                   It can lead to unexpected behavior if return value is not handled properly. 
                   Please use Direct Calls via specifying the called contract's interface.`
-        morehref = `https://solidity.readthedocs.io/en/${version}/control-structures.html?#external-function-calls`
+        morehref = `https://docs.soliditylang.org/en/${version}/control-structures.html?#external-function-calls`
         break
       case lowLevelCallTypes.CALLCODE:
         text = `Use of "callcode": should be avoided whenever possible. 
                   External code, that is called can change the state of the calling contract and send ether from the caller's balance. 
                   If this is wanted behaviour, use the Solidity library feature if possible.`
-        morehref = `https://solidity.readthedocs.io/en/${version}/contracts.html#libraries`
+        morehref = `https://docs.soliditylang.org/en/${version}/contracts.html#libraries`
         break
       case lowLevelCallTypes.DELEGATECALL:
         text = `Use of "delegatecall": should be avoided whenever possible. 
                   External code, that is called can change the state of the calling contract and send ether from the caller's balance. 
                   If this is wanted behaviour, use the Solidity library feature if possible.`
-        morehref = `https://solidity.readthedocs.io/en/${version}/contracts.html#libraries`
+        morehref = `https://docs.soliditylang.org/en/${version}/contracts.html#libraries`
         break
       case lowLevelCallTypes.SEND:
         text = `Use of "send": "send" does not throw an exception when not successful, make sure you deal with the failure case accordingly. 
                   Use "transfer" whenever failure of the ether transfer should rollback the whole transaction. 
                   Note: if you "send/transfer" ether to a contract the fallback function is called, the callees fallback function is very limited due to the limited amount of gas provided by "send/transfer". 
                   No state changes are possible but the callee can log the event or revert the transfer. "send/transfer" is syntactic sugar for a "call" to the fallback function with 2300 gas and a specified ether value.`
-        morehref = `https://solidity.readthedocs.io/en/${version}/security-considerations.html#sending-and-receiving-ether`
+        morehref = `https://docs.soliditylang.org/en/${version}/security-considerations.html#sending-and-receiving-ether`
         break
       }
       return { warning: text, more: morehref, location: item.node.src }

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/selfdestruct.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/selfdestruct.ts
@@ -40,7 +40,7 @@ export default class selfdestruct implements AnalyzerModule {
             warnings.push({
               warning: 'Use of selfdestruct: No code after selfdestruct is executed. Selfdestruct is a terminal.',
               location: node.src,
-              more: `https://solidity.readthedocs.io/en/${version}/introduction-to-smart-contracts.html#deactivate-and-self-destruct`
+              more: `https://docs.soliditylang.org/en/${version}/introduction-to-smart-contracts.html#deactivate-and-self-destruct`
             })
             hasSelf = false
           }

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/stringBytesLength.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/stringBytesLength.ts
@@ -27,7 +27,7 @@ export default class stringBytesLength implements AnalyzerModule {
       return [{
         warning: '"bytes" and "string" lengths are not the same since strings are assumed to be UTF-8 encoded (according to the ABI definition) therefore one character is not necessarily encoded in one byte of data.',
         location: this.bytesLengthChecks[0].src,
-        more: `https://solidity.readthedocs.io/en/${version}/abi-spec.html#argument-encoding`
+        more: `https://docs.soliditylang.org/en/${version}/abi-spec.html#argument-encoding`
       }]
     } else {
       return []

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/thisLocal.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/thisLocal.ts
@@ -24,7 +24,7 @@ export default class thisLocal implements AnalyzerModule {
       return {
         warning: 'Use of "this" for local functions: Never use "this" to call functions in the same contract, it only consumes more gas than normal local calls.',
         location: item.src,
-        more: `https://solidity.readthedocs.io/en/${version}/control-structures.html#external-function-calls`
+        more: `https://docs.soliditylang.org/en/${version}/control-structures.html#external-function-calls`
       }
     })
   }

--- a/libs/remix-analyzer/src/solidity-analyzer/modules/txOrigin.ts
+++ b/libs/remix-analyzer/src/solidity-analyzer/modules/txOrigin.ts
@@ -25,7 +25,7 @@ export default class txOrigin implements AnalyzerModule {
         warning: `Use of tx.origin: "tx.origin" is useful only in very exceptional cases. 
                   If you use it for authentication, you usually want to replace it by "msg.sender", because otherwise any contract you call can act on your behalf.`,
         location: item.src,
-        more: `https://solidity.readthedocs.io/en/${version}/security-considerations.html#tx-origin`
+        more: `https://docs.soliditylang.org/en/${version}/security-considerations.html#tx-origin`
       }
     })
   }

--- a/libs/remix-debug/src/solidity-decoder/types/Mapping.ts
+++ b/libs/remix-debug/src/solidity-decoder/types/Mapping.ts
@@ -62,7 +62,7 @@ export class Mapping extends RefType {
 }
 
 function getMappingLocation (key, position) {
-  // mapping storage location described at http://solidity.readthedocs.io/en/develop/miscellaneous.html#layout-of-state-variables-in-storage
+  // mapping storage location described at https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html
   // > the value corresponding to a mapping key k is located at keccak256(k . p) where . is concatenation.
 
   // key should be a hex string, and position an int


### PR DESCRIPTION
Previously, the code contained links to `solidity.readthedocs.io`, but this domain is no longer active, and all requests are now redirected to `docs.soliditylang.org`. However, some old links led to non-existent pages after the redirect, causing accessibility issues with the documentation.

This PR fixes the links by pointing them directly to the correct pages, avoiding unnecessary redirects and navigation errors.