### PR TITLE
fix: correct CheckTxStatus import paths

### DIFF
--- a/apps/remix-dapp/src/components/UiTerminal/RenderCall.tsx
+++ b/apps/remix-dapp/src/components/UiTerminal/RenderCall.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shortenHexData } from '@remix-ui/helper';
-import CheckTxStatus from './ChechTxStatus';
+import CheckTxStatus from './CheckTxStatus';
 import showTable from './Table';
 import { execution } from '@remix-project/remix-lib';
 

--- a/apps/remix-dapp/src/components/UiTerminal/RenderKnownTransactions.tsx
+++ b/apps/remix-dapp/src/components/UiTerminal/RenderKnownTransactions.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CheckTxStatus from './ChechTxStatus';
+import CheckTxStatus from './CheckTxStatus';
 import Context from './Context';
 import showTable from './Table';
 import { execution } from '@remix-project/remix-lib';


### PR DESCRIPTION
I noticed that the imports for `CheckTxStatus` were slightly off in `RenderCall.tsx` and `RenderKnownTransactions.tsx`. 
This PR just fixes those paths so everything references the right file. No functional changes—just tidying up!
