### PR TITLE
refactor & allow saving already forked state

### DIFF
--- a/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
+++ b/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
@@ -327,6 +327,7 @@ module.exports = {
       .perform(async (done) => {
         const provider = new ethers.providers.JsonRpcProvider('https://go.getblock.io/56f8bc5187aa4ac696348f67545acf38')
         currentBlockNumber = (await provider.getBlockNumber()) as number
+        console.log('getBlockNumber', currentBlockNumber)
         done()
       })
       .click('*[data-id="deployAndRunClearInstances"]') // clear udapp instances
@@ -334,24 +335,30 @@ module.exports = {
       .testContracts('MainnetBlockNumberContract.sol', sources[10]['MainnetBlockNumberContract.sol'], ['MainnetBlockNumberContract'])
       .clickLaunchIcon('udapp')
       .selectContract('MainnetBlockNumberContract')
-      .createContract((currentBlockNumber - 1) + '')
+      .perform((done) => {
+        browser.createContract((currentBlockNumber - 1) + '')
+        .perform(() => {
+          done()
+        })
+      })
+      .clickInstance(0)
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
       .testFunction('last',
         {
           status: '0x1 Transaction mined and execution succeed',
-          'decoded input': { 'bool': 'true' }
+          'decoded output': { '0':'bool: true' }
         })
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
       .testFunction('last',
         {
           status: '0x1 Transaction mined and execution succeed',
-          'decoded input': { 'bool': 'true' }
+          'decoded output': { '0':'bool: true' }
         })
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
       .testFunction('last',
         {
           status: '0x1 Transaction mined and execution succeed',
-          'decoded input': { 'bool': 'true' }
+          'decoded output': { '0':'bool: true' }
         })
       .click('*[data-id="universalDappUiUdappPin"]') // pin the contract for later use by a forked state.
       // Should fork the mainnet VM fork and execute some transaction
@@ -367,17 +374,18 @@ module.exports = {
           locateStrategy: 'xpath'
         }
       )
+      .clickInstance(0)
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
       .testFunction('last',
         {
           status: '0x1 Transaction mined and execution succeed',
-          'decoded input': { 'bool': 'true' }
+          'decoded output': { '0':'bool: true' }
         })
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
       .testFunction('last',
         {
           status: '0x1 Transaction mined and execution succeed',
-          'decoded input': { 'bool': 'true' }
+          'decoded output': { '0':'bool: true' }
         })
       // Should fork the mainnet VM fork again and execute some transaction
       .click('*[data-id="fork-state-icon"]')  
@@ -388,21 +396,22 @@ module.exports = {
       // check toaster for forked state
       .waitForElementVisible(
         {
-          selector: '//*[@data-shared="tooltipPopup" and contains(.,"New environment \'Mainnet fork 1\' created with forked state.")]',
+          selector: '//*[@data-shared="tooltipPopup" and contains(.,"New environment \'Mainnet fork 2\' created with forked state.")]',
           locateStrategy: 'xpath'
         }
       )
+      .clickInstance(0)
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
       .testFunction('last',
         {
           status: '0x1 Transaction mined and execution succeed',
-          'decoded input': { 'bool': 'true' }
+          'decoded output': { '0':'bool: true' }
         })
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
       .testFunction('last',
         {
           status: '0x1 Transaction mined and execution succeed',
-          'decoded input': { 'bool': 'true' }
+          'decoded output': { '0':'bool: true' }
         })
       .clickFunction('getB - call')
       .getAddressAtPosition(1, (address) => {
@@ -698,7 +707,7 @@ contract C {
   }, {
     'MainnetBlockNumberContract.sol': {
       content: `
-      // SPDX-License-Identifier: GPL-3.0
+       // SPDX-License-Identifier: GPL-3.0
 
       pragma solidity >=0.8.2 <0.9.0;
 
@@ -708,7 +717,7 @@ contract C {
               b = blockNumber;
           }
           function checkBlockNumberIsAdvancing()  public returns (bool) {
-              bool ret = b + 1 == block.number;
+              bool ret = b < block.number;
               b = block.number;
               return ret;
           }

--- a/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
+++ b/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
@@ -355,7 +355,7 @@ module.exports = {
         })
       .click('*[data-id="universalDappUiUdappPin"]') // pin the contract for later use by a forked state.
       // Should fork the mainnet VM fork and execute some transaction
-      .click('*[data-id="fork-state-icon"]')  
+      .click('*[data-id="fork-state-icon"]')
       .waitForElementVisible('*[data-id="udappNotifyModalDialogModalTitle-react"]')
       .click('input[data-id="modalDialogForkState"]')
       .setValue('input[data-id="modalDialogForkState"]', 'Mainnet fork 1')
@@ -702,13 +702,13 @@ contract C {
 
       pragma solidity >=0.8.2 <0.9.0;
 
-      contract Test {
+      contract MainnetBlockNumberContract {
           uint b;
           constructor(uint blockNumber) {
               b = blockNumber;
           }
           function checkBlockNumberIsAdvancing()  public returns (bool) {
-              bool ret = block.number > b;
+              bool ret = b + 1 == block.number
               b = block.number;
               return ret;
           }

--- a/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
+++ b/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
@@ -331,7 +331,7 @@ module.exports = {
       })
       .click('*[data-id="deployAndRunClearInstances"]') // clear udapp instances
       .clickLaunchIcon('filePanel')
-      .testContracts('MainnetBlockNumberContract.sol', sources[9]['MainnetBlockNumberContract.sol'], ['MainnetBlockNumberContract'])
+      .testContracts('MainnetBlockNumberContract.sol', sources[10]['MainnetBlockNumberContract.sol'], ['MainnetBlockNumberContract'])
       .clickLaunchIcon('udapp')
       .selectContract('MainnetBlockNumberContract')
       .createContract((currentBlockNumber - 1) + '')

--- a/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
+++ b/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
@@ -708,7 +708,7 @@ contract C {
               b = blockNumber;
           }
           function checkBlockNumberIsAdvancing()  public returns (bool) {
-              bool ret = b + 1 == block.number
+              bool ret = b + 1 == block.number;
               b = block.number;
               return ret;
           }

--- a/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
+++ b/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
@@ -336,30 +336,40 @@ module.exports = {
       .clickLaunchIcon('udapp')
       .selectContract('MainnetBlockNumberContract')
       .perform((done) => {
-        browser.createContract((currentBlockNumber - 1) + '')
+        browser.createContract((currentBlockNumber) + '')
+        .waitForElementPresent('*[data-shared="universalDappUiInstance"]')
         .perform(() => {
           done()
         })
       })
       .clickInstance(0)
+      .clickFunction('getB - call')
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
-      .testFunction('last',
-        {
-          status: '0x1 Transaction mined and execution succeed',
-          'decoded output': { '0':'bool: true' }
-        })
+      .perform((done) => {
+        browser.testFunction('last',
+          {
+            status: '0x1 Transaction mined and execution succeed',
+            'decoded output': { '0':'bool: true' }
+          }).perform(() => done())
+      })
+      .clickFunction('getB - call')
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
-      .testFunction('last',
-        {
-          status: '0x1 Transaction mined and execution succeed',
-          'decoded output': { '0':'bool: true' }
-        })
+      .perform((done) => {
+        browser.testFunction('last',
+          {
+            status: '0x1 Transaction mined and execution succeed',
+            'decoded output': { '0':'bool: true' }
+          }).perform(() => done())
+      })
+      .clickFunction('getB - call')
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
-      .testFunction('last',
-        {
-          status: '0x1 Transaction mined and execution succeed',
-          'decoded output': { '0':'bool: true' }
-        })
+      .perform((done) => {
+        browser.testFunction('last',
+          {
+            status: '0x1 Transaction mined and execution succeed',
+            'decoded output': { '0':'bool: true' }
+          }).perform(() => done())
+      })
       .click('*[data-id="universalDappUiUdappPin"]') // pin the contract for later use by a forked state.
       // Should fork the mainnet VM fork and execute some transaction
       .click('*[data-id="fork-state-icon"]')
@@ -374,19 +384,26 @@ module.exports = {
           locateStrategy: 'xpath'
         }
       )
+      .pause(2000)
       .clickInstance(0)
+      .clickFunction('getB - call')
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
-      .testFunction('last',
-        {
-          status: '0x1 Transaction mined and execution succeed',
-          'decoded output': { '0':'bool: true' }
-        })
+      .perform((done) => {
+        browser.testFunction('last',
+          {
+            status: '0x1 Transaction mined and execution succeed',
+            'decoded output': { '0':'bool: true' }
+          }).perform(() => done())
+      })
+      .clickFunction('getB - call')
       .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
-      .testFunction('last',
-        {
-          status: '0x1 Transaction mined and execution succeed',
-          'decoded output': { '0':'bool: true' }
-        })
+      .perform((done) => {
+        browser.testFunction('last',
+          {
+            status: '0x1 Transaction mined and execution succeed',
+            'decoded output': { '0':'bool: true' }
+          }).perform(() => done())
+      })
       // Should fork the mainnet VM fork again and execute some transaction
       .click('*[data-id="fork-state-icon"]')  
       .waitForElementVisible('*[data-id="udappNotifyModalDialogModalTitle-react"]')
@@ -400,34 +417,51 @@ module.exports = {
           locateStrategy: 'xpath'
         }
       )
+      .pause(2000)
       .clickInstance(0)
-      .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
-      .testFunction('last',
-        {
-          status: '0x1 Transaction mined and execution succeed',
-          'decoded output': { '0':'bool: true' }
-        })
-      .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
-      .testFunction('last',
-        {
-          status: '0x1 Transaction mined and execution succeed',
-          'decoded output': { '0':'bool: true' }
-        })
       .clickFunction('getB - call')
-      .getAddressAtPosition(1, (address) => {
+      .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
+      .perform((done) => {
+        browser.testFunction('last',
+          {
+            status: '0x1 Transaction mined and execution succeed',
+            'decoded output': { '0':'bool: true' }
+          }).perform(() => done())
+      })
+      .clickFunction('getB - call')
+      .clickFunction('checkBlockNumberIsAdvancing - transact (not payable)')
+      .perform((done) => {
+        browser.testFunction('last',
+          {
+            status: '0x1 Transaction mined and execution succeed',
+            'decoded output': { '0':'bool: true' }
+          }).perform(() => done())
+      })
+      .clickFunction('getB - call')
+      .getAddressAtPosition(0, (address) => {
         console.log('Test Fork Mainnet', address)
         addressRef = address
       })
+      // from Mainnet fork 2, check that block number is at `currentBlockNumber` + 6
+      .clickFunction('checkOrigin - transact (not payable)', { types: 'uint256 incr', values: '6'})
       .perform((done) => {
-        browser.verifyCallReturnValue(addressRef, [`0:uint256: ${currentBlockNumber + 7}`]) // checkBlockNumberIsAdvancing is called 7 times
-          .perform(() => done())
+        browser.testFunction('last',
+          {
+            status: '0x1 Transaction mined and execution succeed',
+            'decoded output': { '0':'bool: true' }
+          }).perform(() => done())
       })
-      // switch back to Mainnet fork 1 and check that block number is at `currentBlockNumber` + 5
-      .switchEnvironment('Mainnet fork 1')
-      .clickFunction('getB - call')
+      // switch back to Mainnet fork 1 and check that block number is at `currentBlockNumber` + 4
+      .switchEnvironment('vm-fs-Mainnet fork 1')
+      .pause(2000)
+      .clickInstance(0)
+      .clickFunction('checkOrigin - transact (not payable)', { types: 'uint256 incr', values: '4'})
       .perform((done) => {
-        browser.verifyCallReturnValue(addressRef, [`0:uint256: ${currentBlockNumber + 5}`]) // checkBlockNumberIsAdvancing is called 7 times
-          .perform(() => done())
+        browser.testFunction('last',
+          {
+            status: '0x1 Transaction mined and execution succeed',
+            'decoded output': { '0':'bool: true' }
+          }).perform(() => done())
       })
     }
 }
@@ -707,24 +741,30 @@ contract C {
   }, {
     'MainnetBlockNumberContract.sol': {
       content: `
-       // SPDX-License-Identifier: GPL-3.0
+      // SPDX-License-Identifier: GPL-3.0
 
       pragma solidity >=0.8.2 <0.9.0;
 
       contract MainnetBlockNumberContract {
-          uint b;
-          constructor(uint blockNumber) {
-              b = blockNumber;
-          }
-          function checkBlockNumberIsAdvancing()  public returns (bool) {
-              bool ret = b < block.number;
-              b = block.number;
-              return ret;
-          }
-          function getB() view public returns(uint) {
-              return b;
-          }
+      uint b;
+      uint orgB;
+      constructor(uint blockNumber) {
+          b = blockNumber;
       }
+      function checkBlockNumberIsAdvancing()  public returns (bool) {
+          if (orgB == 0) orgB = block.number;
+          bool ret = b < block.number;
+          b = block.number;
+          return ret;
+      }
+      function getB() view public returns(uint) {
+          return b;
+      }
+      function checkOrigin(uint incr) public returns (bool) {
+        bool ret = orgB + incr == b;
+        return ret;
+      }
+  }
 `
     }
   }

--- a/apps/remix-ide/src/app/files/fileManager.ts
+++ b/apps/remix-ide/src/app/files/fileManager.ts
@@ -351,7 +351,7 @@ export default class FileManager extends Plugin {
 
   async inDepthCopy(src: string, dest: string, customName?: string) {
     const content = await this.readdir(src)
-    let copiedFolderPath = !customName ? dest + '/' + `Copy_${helper.extractNameFromKey(src)}` : dest + '/' + helper.extractNameFromKey(src)
+    let copiedFolderPath = !customName ? dest + '/' + `Copy_${helper.extractNameFromKey(src)}` : dest + '/' + customName
     copiedFolderPath = await helper.createNonClashingDirNameAsync(copiedFolderPath, this)
 
     await this.mkdir(copiedFolderPath)

--- a/apps/remix-ide/src/app/providers/environment-explorer.tsx
+++ b/apps/remix-ide/src/app/providers/environment-explorer.tsx
@@ -90,6 +90,10 @@ export class EnvironmentExplorer extends ViewPlugin {
   async showPinnedContracts (provider) {
     if (await this.call('fileManager', 'exists', `.deploys/pinned-contracts/${provider.name}`)) {
       const files = await this.call('fileManager', 'readdir', `.deploys/pinned-contracts/${provider.name}`)
+      if (!files.length) {
+        await this.call('terminal', 'log', { type: 'info', value: 'No pinned contract.' })
+        return
+      }
       for (const file in files) {
         if (file.endsWith('.json')) {
           const content = JSON.parse(await this.call('fileManager', 'readFile', file))

--- a/apps/remix-ide/src/app/providers/environment-explorer.tsx
+++ b/apps/remix-ide/src/app/providers/environment-explorer.tsx
@@ -90,7 +90,7 @@ export class EnvironmentExplorer extends ViewPlugin {
   async showPinnedContracts (provider) {
     if (await this.call('fileManager', 'exists', `.deploys/pinned-contracts/${provider.name}`)) {
       const files = await this.call('fileManager', 'readdir', `.deploys/pinned-contracts/${provider.name}`)
-      if (!files.length) {
+      if (!Object.keys(files).length) {
         await this.call('terminal', 'log', { type: 'info', value: 'No pinned contract.' })
         return
       }

--- a/apps/remix-ide/src/app/providers/environment-explorer.tsx
+++ b/apps/remix-ide/src/app/providers/environment-explorer.tsx
@@ -90,6 +90,10 @@ export class EnvironmentExplorer extends ViewPlugin {
   async showPinnedContracts (provider) {
     if (await this.call('fileManager', 'exists', `.deploys/pinned-contracts/${provider.name}`)) {
       const files = await this.call('fileManager', 'readdir', `.deploys/pinned-contracts/${provider.name}`)
+      if (!files) {
+        await this.call('terminal', 'log', { type: 'info', value: 'No pinned contract.' })
+        return
+      }
       if (!Object.keys(files).length) {
         await this.call('terminal', 'log', { type: 'info', value: 'No pinned contract.' })
         return

--- a/apps/remix-ide/src/app/providers/environment-explorer.tsx
+++ b/apps/remix-ide/src/app/providers/environment-explorer.tsx
@@ -87,6 +87,21 @@ export class EnvironmentExplorer extends ViewPlugin {
     } else this.call('notification', 'toast', 'Cannot delete the current selected environment')
   }
 
+  async showPinnedContracts (provider) {
+    if (await this.call('fileManager', 'exists', `.deploys/pinned-contracts/${provider.name}`)) {
+      const files = await this.call('fileManager', 'readdir', `.deploys/pinned-contracts/${provider.name}`)
+      for (const file in files) {
+        if (file.endsWith('.json')) {
+          const content = JSON.parse(await this.call('fileManager', 'readFile', file))
+          const msg = `Contract ${content.name} (${content.filePath}) deployed at ${content.address} on ${new Date(content.pinnedAt).toString()}`
+          await this.call('terminal', 'log', { type: 'info', value: msg })
+        }
+      }
+    } else {
+      await this.call('terminal', 'log', { type: 'info', value: 'No pinned contract.' })
+    }
+  }
+
   renderComponent() {
     this.dispatch({
       ...this.state
@@ -98,6 +113,7 @@ export class EnvironmentExplorer extends ViewPlugin {
       <EnvironmentExplorerUI
         pinStateCallback={this.pinStateCallback.bind(this)}
         deleteForkedState={this.deleteForkedState.bind(this)}
+        showPinnedContracts={this.showPinnedContracts.bind(this)}
         profile={profile}
         state={state}
       />

--- a/apps/remix-ide/src/app/providers/style/environment-explorer.css
+++ b/apps/remix-ide/src/app/providers/style/environment-explorer.css
@@ -1,5 +1,5 @@
 .EECellStyle {
-  min-height: 8rem;
+  min-height: 10rem;
   max-width: 12rem;
   min-width: 12rem;
 }

--- a/apps/remix-ide/src/app/providers/vm-provider.tsx
+++ b/apps/remix-ide/src/app/providers/vm-provider.tsx
@@ -133,9 +133,13 @@ export class CancunVMProvider extends BasicVMProvider {
 }
 
 export class ForkedVMStateProvider extends BasicVMProvider {
-  constructor(profile, blockchain, fork) {
+  nodeUrl?: string
+  blockNumber?: string
+  constructor(profile, blockchain, fork: string, nodeUrl?: string, blockNumber?: string) {
     super(profile, blockchain)
     this.blockchain = blockchain
     this.fork = fork
+    this.nodeUrl = nodeUrl
+    this.blockNumber = blockNumber
   }
 }

--- a/apps/remix-ide/src/app/udapp/run-tab.tsx
+++ b/apps/remix-ide/src/app/udapp/run-tab.tsx
@@ -280,7 +280,7 @@ export class RunTab extends ViewPlugin {
       }, this.blockchain, stateDetail.forkName, stateDetail.nodeUrl, stateDetail.blockNumber)
       const isRpcForkedState = !!stateDetail.nodeUrl
       this.engine.register(fvsProvider)
-      await addProvider(pos, providerName, stateDetail.stateName, { baseBlockNumber: stateDetail.baseBlockNumber,  isInjected: false, isVM: true, isRpcForkedState, isVMStateForked: true, statePath: `.states/forked_states/${stateDetail.stateName}.json`, fork: stateDetail.forkName })
+      await addProvider(pos, providerName, stateDetail.stateName, { baseBlockNumber: stateDetail.baseBlockNumber, isInjected: false, isVM: true, isRpcForkedState, isVMStateForked: true, statePath: `.states/forked_states/${stateDetail.stateName}.json`, fork: stateDetail.forkName })
     }
 
     this.on('filePanel', 'workspaceInitializationCompleted', async () => {

--- a/apps/remix-ide/src/app/udapp/run-tab.tsx
+++ b/apps/remix-ide/src/app/udapp/run-tab.tsx
@@ -255,9 +255,9 @@ export class RunTab extends ViewPlugin {
     await addProvider(51, 'vm-paris', 'Remix VM (Paris)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-paris/state.json', fork: 'paris' }, 'settingsVMParisMode', titleVM)
     await addProvider(52, 'vm-london', 'Remix VM (London)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-london/state.json', fork: 'london' }, 'settingsVMLondonMode', titleVM)
     await addProvider(53, 'vm-berlin', 'Remix VM (Berlin)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-berlin/state.json', fork: 'berlin' }, 'settingsVMBerlinMode', titleVM)
-    await addProvider(2, 'vm-mainnet-fork', 'Remix VM - Mainnet fork', { isInjected: false, isVM: true, isRpcForkedState: true, fork: 'cancun' }, 'settingsVMMainnetMode', titleVM)
-    await addProvider(3, 'vm-sepolia-fork', 'Remix VM - Sepolia fork', { isInjected: false, isVM: true, isRpcForkedState: true, fork: 'cancun' }, 'settingsVMSepoliaMode', titleVM)
-    await addProvider(4, 'vm-custom-fork', 'Remix VM - Custom fork', { isInjected: false, isVM: true, isRpcForkedState: true, fork: '' }, 'settingsVMCustomMode', titleVM)
+    await addProvider(2, 'vm-mainnet-fork', 'Remix VM - Mainnet fork', { isInjected: false, isVM: true, isVMStateForked: true, isRpcForkedState: true, fork: 'cancun' }, 'settingsVMMainnetMode', titleVM)
+    await addProvider(3, 'vm-sepolia-fork', 'Remix VM - Sepolia fork', { isInjected: false, isVM: true, isVMStateForked: true, isRpcForkedState: true, fork: 'cancun' }, 'settingsVMSepoliaMode', titleVM)
+    await addProvider(4, 'vm-custom-fork', 'Remix VM - Custom fork', { isInjected: false, isVM: true, isVMStateForked: true, isRpcForkedState: true, fork: '' }, 'settingsVMCustomMode', titleVM)
 
     // Forked VM States
     const addFVSProvider = async(stateFilePath, pos) => {

--- a/apps/remix-ide/src/app/udapp/run-tab.tsx
+++ b/apps/remix-ide/src/app/udapp/run-tab.tsx
@@ -180,7 +180,7 @@ export class RunTab extends ViewPlugin {
       'foundry-provider': ['assets/img/foundry.png']
     }
 
-    const addProvider = async (position: number, name: string, displayName: string, providerConfig: ProviderConfig, fork = '', dataId = '', title = '') => {
+    const addProvider = async (position: number, name: string, displayName: string, providerConfig: ProviderConfig, dataId = '', title = '') => {
       await this.call('blockchain', 'addProvider', {
         position,
         options: {},
@@ -189,14 +189,15 @@ export class RunTab extends ViewPlugin {
         displayName,
         description: descriptions[name] || displayName,
         logos: logos[name],
-        fork,
         config: providerConfig,
         title,
         init: async function () {
-          const options = await udapp.call(name, 'init')
+          const options = await udapp.call(name, 'init')          
           if (options) {
             this.options = options
-            if (options['fork']) this.fork = options['fork']
+            if (options['fork']) this.config.fork = options['fork']
+            if (options['nodeUrl']) this.config.nodeUrl = options['nodeUrl']
+            if (options['blockNumber']) this.config.blockNumber = options['blockNumber']
           }
         },
         provider: new Provider(udapp, name)
@@ -206,13 +207,13 @@ export class RunTab extends ViewPlugin {
     const addCustomInjectedProvider = async (position, event, name, displayName, networkId, urls, nativeCurrency?) => {
       // name = `${name} through ${event.detail.info.name}`
       await this.engine.register([new InjectedCustomProvider(event.detail.provider, name, displayName, networkId, urls, nativeCurrency)])
-      await addProvider(position, name, displayName + ' - ' + event.detail.info.name, { isInjected: true, isVM: false, isRpcForkedState: false })
+      await addProvider(position, name, displayName + ' - ' + event.detail.info.name, { isInjected: true, isVM: false, isRpcForkedState: false, fork: ''})
     }
     const registerInjectedProvider = async (event) => {
       const name = 'injected-' + event.detail.info.name
       const displayName = 'Injected Provider - ' + event.detail.info.name
       await this.engine.register([new InjectedProviderDefault(event.detail.provider, name)])
-      await addProvider(0, name, displayName, { isInjected: true, isVM: false, isRpcForkedState: false })
+      await addProvider(0, name, displayName, { isInjected: true, isVM: false, isRpcForkedState: false, fork: '' })
 
       if (event.detail.info.name === 'MetaMask') {
         await addCustomInjectedProvider(7, event, 'injected-metamask-optimism', 'L2 - Optimism', '0xa', ['https://mainnet.optimism.io'])
@@ -249,14 +250,14 @@ export class RunTab extends ViewPlugin {
 
     // VM
     const titleVM = 'Execution environment is local to Remix.  Data is only saved to browser memory and will vanish upon reload.'
-    await addProvider(1, 'vm-cancun', 'Remix VM (Cancun)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-cancun/state.json' }, 'cancun', 'settingsVMCancunMode', titleVM)
-    await addProvider(50, 'vm-shanghai', 'Remix VM (Shanghai)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-shanghai/state.json' }, 'shanghai', 'settingsVMShanghaiMode', titleVM)
-    await addProvider(51, 'vm-paris', 'Remix VM (Paris)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-paris/state.json' }, 'paris', 'settingsVMParisMode', titleVM)
-    await addProvider(52, 'vm-london', 'Remix VM (London)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-london/state.json' }, 'london', 'settingsVMLondonMode', titleVM)
-    await addProvider(53, 'vm-berlin', 'Remix VM (Berlin)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-berlin/state.json' }, 'berlin', 'settingsVMBerlinMode', titleVM)
-    await addProvider(2, 'vm-mainnet-fork', 'Remix VM - Mainnet fork', { isInjected: false, isVM: true, isRpcForkedState: true }, 'cancun', 'settingsVMMainnetMode', titleVM)
-    await addProvider(3, 'vm-sepolia-fork', 'Remix VM - Sepolia fork', { isInjected: false, isVM: true, isRpcForkedState: true }, 'cancun', 'settingsVMSepoliaMode', titleVM)
-    await addProvider(4, 'vm-custom-fork', 'Remix VM - Custom fork', { isInjected: false, isVM: true, isRpcForkedState: true }, '', 'settingsVMCustomMode', titleVM)
+    await addProvider(1, 'vm-cancun', 'Remix VM (Cancun)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-cancun/state.json', fork: 'cancun' }, 'settingsVMCancunMode', titleVM)
+    await addProvider(50, 'vm-shanghai', 'Remix VM (Shanghai)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-shanghai/state.json', fork: 'shanghai' }, 'settingsVMShanghaiMode', titleVM)
+    await addProvider(51, 'vm-paris', 'Remix VM (Paris)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-paris/state.json', fork: 'paris' }, 'settingsVMParisMode', titleVM)
+    await addProvider(52, 'vm-london', 'Remix VM (London)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-london/state.json', fork: 'london' }, 'settingsVMLondonMode', titleVM)
+    await addProvider(53, 'vm-berlin', 'Remix VM (Berlin)', { isInjected: false, isVM: true, isRpcForkedState: false, statePath: '.states/vm-berlin/state.json', fork: 'berlin' }, 'settingsVMBerlinMode', titleVM)
+    await addProvider(2, 'vm-mainnet-fork', 'Remix VM - Mainnet fork', { isInjected: false, isVM: true, isRpcForkedState: true, fork: 'cancun' }, 'settingsVMMainnetMode', titleVM)
+    await addProvider(3, 'vm-sepolia-fork', 'Remix VM - Sepolia fork', { isInjected: false, isVM: true, isRpcForkedState: true, fork: 'cancun' }, 'settingsVMSepoliaMode', titleVM)
+    await addProvider(4, 'vm-custom-fork', 'Remix VM - Custom fork', { isInjected: false, isVM: true, isRpcForkedState: true, fork: '' }, 'settingsVMCustomMode', titleVM)
 
     // Forked VM States
     const addFVSProvider = async(stateFilePath, pos) => {
@@ -276,9 +277,10 @@ export class RunTab extends ViewPlugin {
         description: descriptions[providerName],
         methods: ['sendAsync', 'init'],
         version: packageJson.version
-      }, this.blockchain, stateDetail.forkName)
+      }, this.blockchain, stateDetail.forkName, stateDetail.nodeUrl, stateDetail.blockNumber)
+      const isRpcForkedState = !!stateDetail.nodeUrl
       this.engine.register(fvsProvider)
-      await addProvider(pos, providerName, stateDetail.stateName, { isInjected: false, isVM: true, isRpcForkedState: false, isVMStateForked: true, statePath: `.states/forked_states/${stateDetail.stateName}.json` }, stateDetail.forkName)
+      await addProvider(pos, providerName, stateDetail.stateName, { isInjected: false, isVM: true, isRpcForkedState, isVMStateForked: true, statePath: `.states/forked_states/${stateDetail.stateName}.json`, fork: stateDetail.forkName })
     }
 
     this.on('filePanel', 'workspaceInitializationCompleted', async () => {
@@ -300,13 +302,13 @@ export class RunTab extends ViewPlugin {
     })
 
     // wallet connect
-    await addProvider(6, 'walletconnect', 'WalletConnect', { isInjected: false, isVM: false, isRpcForkedState: false })
+    await addProvider(6, 'walletconnect', 'WalletConnect', { isInjected: false, isVM: false, isRpcForkedState: false, fork: '' })
 
     // external provider
-    await addProvider(10, 'basic-http-provider', 'Custom - External Http Provider', { isInjected: false, isVM: false, isRpcForkedState: false })
-    await addProvider(20, 'hardhat-provider', 'Dev - Hardhat Provider', { isInjected: false, isVM: false, isRpcForkedState: false })
-    await addProvider(21, 'ganache-provider', 'Dev - Ganache Provider', { isInjected: false, isVM: false, isRpcForkedState: false })
-    await addProvider(22, 'foundry-provider', 'Dev - Foundry Provider', { isInjected: false, isVM: false, isRpcForkedState: false })
+    await addProvider(10, 'basic-http-provider', 'Custom - External Http Provider', { isInjected: false, isVM: false, isRpcForkedState: false, fork: '' })
+    await addProvider(20, 'hardhat-provider', 'Dev - Hardhat Provider', { isInjected: false, isVM: false, isRpcForkedState: false, fork: '' })
+    await addProvider(21, 'ganache-provider', 'Dev - Ganache Provider', { isInjected: false, isVM: false, isRpcForkedState: false, fork: '' })
+    await addProvider(22, 'foundry-provider', 'Dev - Foundry Provider', { isInjected: false, isVM: false, isRpcForkedState: false, fork: '' })
 
     // register injected providers
 

--- a/apps/remix-ide/src/app/udapp/run-tab.tsx
+++ b/apps/remix-ide/src/app/udapp/run-tab.tsx
@@ -280,7 +280,7 @@ export class RunTab extends ViewPlugin {
       }, this.blockchain, stateDetail.forkName, stateDetail.nodeUrl, stateDetail.blockNumber)
       const isRpcForkedState = !!stateDetail.nodeUrl
       this.engine.register(fvsProvider)
-      await addProvider(pos, providerName, stateDetail.stateName, { baseBlockNumber: stateDetail.baseBlockNumber, isInjected: false, isVM: true, isRpcForkedState, isVMStateForked: true, statePath: `.states/forked_states/${stateDetail.stateName}.json`, fork: stateDetail.forkName })
+      await addProvider(pos, providerName, stateDetail.stateName, { nodeUrl: stateDetail.nodeUrl, baseBlockNumber: stateDetail.baseBlockNumber, isInjected: false, isVM: true, isRpcForkedState, isVMStateForked: true, statePath: `.states/forked_states/${stateDetail.stateName}.json`, fork: stateDetail.forkName })
     }
 
     this.on('filePanel', 'workspaceInitializationCompleted', async () => {

--- a/apps/remix-ide/src/app/udapp/run-tab.tsx
+++ b/apps/remix-ide/src/app/udapp/run-tab.tsx
@@ -146,8 +146,8 @@ export class RunTab extends ViewPlugin {
       'vm-paris': 'Deploy to the in-browser virtual machine running the Paris fork.',
       'vm-london': 'Deploy to the in-browser virtual machine running the London fork.',
       'vm-berlin': 'Deploy to the in-browser virtual machine running the Berlin fork.',
-      'vm-mainnet-fork': 'Deploy to a fork of the Ethereum mainnet in the in-browser virtual machine.',
-      'vm-sepolia-fork': 'Deploy to a fork of the Sepolia testnet in the in-browser virtual machine.',
+      'vm-mainnet-fork': 'Deploy to a fork of the Ethereum mainnet latest block in the in-browser virtual machine.',
+      'vm-sepolia-fork': 'Deploy to a fork of the Sepolia testnet latest block in the in-browser virtual machine.',
       'vm-custom-fork': 'Deploy to a fork of a custom network in the in-browser virtual machine.',
       'walletconnect': 'Deploy using WalletConnect.',
       'basic-http-provider': 'Deploy to a Custom local network.',
@@ -280,7 +280,7 @@ export class RunTab extends ViewPlugin {
       }, this.blockchain, stateDetail.forkName, stateDetail.nodeUrl, stateDetail.blockNumber)
       const isRpcForkedState = !!stateDetail.nodeUrl
       this.engine.register(fvsProvider)
-      await addProvider(pos, providerName, stateDetail.stateName, { isInjected: false, isVM: true, isRpcForkedState, isVMStateForked: true, statePath: `.states/forked_states/${stateDetail.stateName}.json`, fork: stateDetail.forkName })
+      await addProvider(pos, providerName, stateDetail.stateName, { baseBlockNumber: stateDetail.baseBlockNumber,  isInjected: false, isVM: true, isRpcForkedState, isVMStateForked: true, statePath: `.states/forked_states/${stateDetail.stateName}.json`, fork: stateDetail.forkName })
     }
 
     this.on('filePanel', 'workspaceInitializationCompleted', async () => {

--- a/apps/remix-ide/src/app/udapp/run-tab.tsx
+++ b/apps/remix-ide/src/app/udapp/run-tab.tsx
@@ -192,7 +192,7 @@ export class RunTab extends ViewPlugin {
         config: providerConfig,
         title,
         init: async function () {
-          const options = await udapp.call(name, 'init')          
+          const options = await udapp.call(name, 'init')
           if (options) {
             this.options = options
             if (options['fork']) this.config.fork = options['fork']
@@ -207,7 +207,7 @@ export class RunTab extends ViewPlugin {
     const addCustomInjectedProvider = async (position, event, name, displayName, networkId, urls, nativeCurrency?) => {
       // name = `${name} through ${event.detail.info.name}`
       await this.engine.register([new InjectedCustomProvider(event.detail.provider, name, displayName, networkId, urls, nativeCurrency)])
-      await addProvider(position, name, displayName + ' - ' + event.detail.info.name, { isInjected: true, isVM: false, isRpcForkedState: false, fork: ''})
+      await addProvider(position, name, displayName + ' - ' + event.detail.info.name, { isInjected: true, isVM: false, isRpcForkedState: false, fork: '' })
     }
     const registerInjectedProvider = async (event) => {
       const name = 'injected-' + event.detail.info.name

--- a/apps/remix-ide/src/blockchain/blockchain.tsx
+++ b/apps/remix-ide/src/blockchain/blockchain.tsx
@@ -977,30 +977,32 @@ export class Blockchain extends Plugin {
       const isForkedVMState = isVM && provider.config.isVMStateForked && !provider.config.isRpcForkedState
       const isForkedRpcState = isVM && provider.config.isVMStateForked && provider.config.isRpcForkedState
 
-      const hhlogs = await this.web3().remix.getHHLogsForTx(txResult.transactionHash)
-      if (hhlogs && hhlogs.length) {
-        const finalLogs = (
-          <div>
+      if (isVM) {
+        const hhlogs = await this.web3().remix.getHHLogsForTx(txResult.transactionHash)
+        if (hhlogs && hhlogs.length) {
+          const finalLogs = (
             <div>
-              <b>console.log:</b>
+              <div>
+                <b>console.log:</b>
+              </div>
+              {hhlogs.map((log) => {
+                let formattedLog
+                // Hardhat implements the same formatting options that can be found in Node.js' console.log,
+                // which in turn uses util.format: https://nodejs.org/dist/latest-v12.x/docs/api/util.html#util_util_format_format_args
+                // For example: console.log("Name: %s, Age: %d", remix, 6) will log 'Name: remix, Age: 6'
+                // We check first arg to determine if 'util.format' is needed
+                if (typeof log[0] === 'string' && (log[0].includes('%s') || log[0].includes('%d'))) {
+                  formattedLog = format(log[0], ...log.slice(1))
+                } else {
+                  formattedLog = log.join(' ')
+                }
+                return <div>{formattedLog}</div>
+              })}
             </div>
-            {hhlogs.map((log) => {
-              let formattedLog
-              // Hardhat implements the same formatting options that can be found in Node.js' console.log,
-              // which in turn uses util.format: https://nodejs.org/dist/latest-v12.x/docs/api/util.html#util_util_format_format_args
-              // For example: console.log("Name: %s, Age: %d", remix, 6) will log 'Name: remix, Age: 6'
-              // We check first arg to determine if 'util.format' is needed
-              if (typeof log[0] === 'string' && (log[0].includes('%s') || log[0].includes('%d'))) {
-                formattedLog = format(log[0], ...log.slice(1))
-              } else {
-                formattedLog = log.join(' ')
-              }
-              return <div>{formattedLog}</div>
-            })}
-          </div>
-        )
-        _paq.push(['trackEvent', 'udapp', 'hardhat', 'console.log'])
-        this.call('terminal', 'logHtml', finalLogs)
+          )
+          _paq.push(['trackEvent', 'udapp', 'hardhat', 'console.log'])
+          this.call('terminal', 'logHtml', finalLogs)
+        }
       }
 
       if (isBasicVMState || isForkedVMState || isForkedRpcState) {

--- a/apps/remix-ide/src/blockchain/blockchain.tsx
+++ b/apps/remix-ide/src/blockchain/blockchain.tsx
@@ -973,8 +973,11 @@ export class Blockchain extends Plugin {
       const provider = this.executionContext.getProviderObject()
       let execResult
       let returnValue = null
+      // a basic in-browser VM state.
       const isBasicVMState = isVM && !provider.config.isVMStateForked && !provider.config.isRpcForkedState
+      // a standard fork of an in-browser state.
       const isForkedVMState = isVM && provider.config.isVMStateForked && !provider.config.isRpcForkedState
+      // a fork of an in-browser state which derive from a live network.
       const isForkedRpcState = isVM && provider.config.isVMStateForked && provider.config.isRpcForkedState
 
       if (isVM) {
@@ -1006,7 +1009,7 @@ export class Blockchain extends Plugin {
       }
 
       if (isBasicVMState || isForkedVMState || isForkedRpcState) {
-        // we don't save the state in case of the isRpcForkedState, only if it's forked
+        // we save the state in case of the isRpcForkedState only if it's forked
         if (!tx.useCall && this.config.get('settings/save-evm-state')) {
           try {
             let state = await this.executionContext.getStateDetails()

--- a/apps/remix-ide/src/blockchain/blockchain.tsx
+++ b/apps/remix-ide/src/blockchain/blockchain.tsx
@@ -1029,7 +1029,7 @@ export class Blockchain extends Plugin {
             console.error(e)
           }
         }
-        
+
         execResult = await this.web3().remix.getExecutionResultFromSimulator(txResult.transactionHash)
         if (execResult) {
           // if it's not the VM, we don't have return value. We only have the transaction, and it does not contain the return value.

--- a/apps/remix-ide/src/blockchain/execution-context.js
+++ b/apps/remix-ide/src/blockchain/execution-context.js
@@ -148,7 +148,7 @@ export class ExecutionContext {
     if (this.customNetWorks[context]) {
       var network = this.customNetWorks[context]
       await network.init()
-      this.currentFork = network.fork
+      this.currentFork = network.config.fork
       this.executionContext = context
       // injected
       web3.setProvider(network.provider)
@@ -215,7 +215,8 @@ export class ExecutionContext {
     const state = {
       db: Object.fromEntries(stateDb.db._database),
       blocks: blocksData.blocks,
-      latestBlockNumber: blocksData.latestBlockNumber
+      latestBlockNumber: blocksData.latestBlockNumber,
+      baseBlockNumber: blocksData.baseBlockNumber
     }
     const stringifyed = JSON.stringify(state, (key, value) => {
       if (key === 'db') {

--- a/apps/remix-ide/src/blockchain/providers/vm.ts
+++ b/apps/remix-ide/src/blockchain/providers/vm.ts
@@ -98,9 +98,10 @@ export class VMProvider {
           this.worker.postMessage({
             cmd: 'init',
             fork: this.executionContext.getCurrentFork(),
-            nodeUrl: provider?.options['nodeUrl'],
+            nodeUrl: blockchainState.nodeUrl || provider?.options['nodeUrl'],
             blockNumber,
             stateDb,
+            baseBlockNumer: blockchainState.baseBlockNumber,
             blocks: blockchainState.blocks
           })
         } catch (e) {

--- a/apps/remix-ide/src/blockchain/providers/worker-vm.ts
+++ b/apps/remix-ide/src/blockchain/providers/worker-vm.ts
@@ -6,7 +6,7 @@ self.onmessage = (e: MessageEvent) => {
   switch (data.cmd) {
   case 'init':
   {
-    provider = new Provider({ fork: data.fork, nodeUrl: data.nodeUrl, blockNumber: data.blockNumber, stateDb: data.stateDb, blocks: data.blocks })
+    provider = new Provider({ baseBlockNumber: data.baseBlockNumer, fork: data.fork, nodeUrl: data.nodeUrl, blockNumber: data.blockNumber, stateDb: data.stateDb, blocks: data.blocks })
     provider.init().then(() => {
       self.postMessage({
         cmd: 'initiateResult',

--- a/libs/remix-lib/src/execution/txRunnerVM.ts
+++ b/libs/remix-lib/src/execution/txRunnerVM.ts
@@ -4,8 +4,7 @@ import { ConsensusType } from '@ethereumjs/common'
 import { LegacyTransaction, FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import { Block } from '@ethereumjs/block'
 import { bytesToHex, Address, hexToBytes } from '@ethereumjs/util'
-import { EVM } from '@ethereumjs/evm'
-import type { Account, AddressLike, BigIntLike } from '@ethereumjs/util'
+import type { AddressLike, BigIntLike } from '@ethereumjs/util'
 import { EventManager } from '../eventManager'
 import { LogsManager } from './logsManager'
 import type { Transaction as InternalTransaction } from './txRunner'
@@ -31,6 +30,7 @@ export class TxRunnerVM {
   blockParentHash
   nextNonceForCall: number
   standaloneTx: boolean
+  baseBlockNumber: string
   getVMObject: () => any
 
   constructor (vmaccounts, api, getVMObject, blocks: Uint8Array[] = []) {
@@ -39,6 +39,7 @@ export class TxRunnerVM {
     // has a default for now for backwards compatibility
     this.getVMObject = getVMObject
     this.commonContext = this.getVMObject().common
+    this.baseBlockNumber = this.getVMObject().baseBlockNumber
     this.pendingTxs = {}
     this.vmaccounts = vmaccounts
     this.queueTxs = []
@@ -155,10 +156,11 @@ export class TxRunnerVM {
       const coinbases = ['0x0e9281e9c6a0808672eaba6bd1220e144c9bb07a', '0x8945a1288dc78a6d8952a92c77aee6730b414778', '0x94d76e24f818426ae84aa404140e8d5f60e10e7e']
       const difficulties = [69762765929000, 70762765929000, 71762765929000]
       const difficulty = this.commonContext.consensusType() === ConsensusType.ProofOfStake ? 0 : difficulties[this.blocks.length % difficulties.length]
+      let blockNumber = this.baseBlockNumber ? parseInt(this.baseBlockNumber) + this.blocks.length : this.blocks.length
       const block = Block.fromBlockData({
         header: {
           timestamp: new Date().getTime() / 1000 | 0,
-          number: this.blocks.length,
+          number: blockNumber,
           coinbase: coinbases[this.blocks.length % coinbases.length],
           difficulty,
           gasLimit,
@@ -206,7 +208,7 @@ export class TxRunnerVM {
   }
 
   runBlockInVm (tx, block, callback) {
-    this.getVMObject().vm.runBlock({ block: block, generate: true, skipNonce: true, skipBlockValidation: true, skipBalance: false }).then((results: RunBlockResult) => {
+    this.getVMObject().vm.runBlock({ block: block, generate: true, skipHeaderValidation: true, skipNonce: true, skipBlockValidation: true, skipBalance: false }).then((results: RunBlockResult) => {
       const result: RunTxResult = results.results[0]
       callback(null, {
         result,

--- a/libs/remix-lib/src/execution/txRunnerVM.ts
+++ b/libs/remix-lib/src/execution/txRunnerVM.ts
@@ -156,7 +156,7 @@ export class TxRunnerVM {
       const coinbases = ['0x0e9281e9c6a0808672eaba6bd1220e144c9bb07a', '0x8945a1288dc78a6d8952a92c77aee6730b414778', '0x94d76e24f818426ae84aa404140e8d5f60e10e7e']
       const difficulties = [69762765929000, 70762765929000, 71762765929000]
       const difficulty = this.commonContext.consensusType() === ConsensusType.ProofOfStake ? 0 : difficulties[this.blocks.length % difficulties.length]
-      let blockNumber = this.baseBlockNumber ? parseInt(this.baseBlockNumber) + this.blocks.length : this.blocks.length
+      const blockNumber = this.baseBlockNumber ? parseInt(this.baseBlockNumber) + this.blocks.length : this.blocks.length
       const block = Block.fromBlockData({
         header: {
           timestamp: new Date().getTime() / 1000 | 0,

--- a/libs/remix-lib/src/execution/txRunnerWeb3.ts
+++ b/libs/remix-lib/src/execution/txRunnerWeb3.ts
@@ -37,7 +37,6 @@ export class TxRunnerWeb3 {
     }
 
     let currentDateTime = new Date();
-    const start = currentDateTime.getTime() / 1000
     const cb = (err, resp) => {
       if (err) {
         return callback(err, resp)

--- a/libs/remix-simulator/src/methods/transactions.ts
+++ b/libs/remix-simulator/src/methods/transactions.ts
@@ -240,7 +240,8 @@ export class Transactions {
   eth_getBlocksData (_, cb) {
     cb(null, {
       blocks: this.txRunnerVMInstance.blocks,
-      latestBlockNumber: this.txRunnerVMInstance.blocks.length - 1
+      latestBlockNumber: this.txRunnerVMInstance.blocks.length - 1,
+      baseBlockNumber: this.vmContext.currentVm.baseBlockNumber
     })
   }
 

--- a/libs/remix-simulator/src/provider.ts
+++ b/libs/remix-simulator/src/provider.ts
@@ -55,7 +55,6 @@ export class Provider {
   pendingRequests: Array<any>
 
   constructor (options: ProviderOptions = {} as ProviderOptions) {
-    console.log(options)
     this.options = options
     this.connected = true
     this.vmContext = new VMContext(options['fork'], options['nodeUrl'], options['blockNumber'], options['stateDb'], options['blocks'], options['baseBlockNumber'])

--- a/libs/remix-simulator/src/provider.ts
+++ b/libs/remix-simulator/src/provider.ts
@@ -36,7 +36,7 @@ export type ProviderOptions = {
   fork?: string,
   nodeUrl?: string,
   blockNumber?: number | 'latest',
-  baseBlockNumber: string, // hex
+  baseBlockNumber?: string, // hex
   stateDb?: State,
   details?: boolean
   blocks?: string[],

--- a/libs/remix-simulator/src/provider.ts
+++ b/libs/remix-simulator/src/provider.ts
@@ -36,6 +36,7 @@ export type ProviderOptions = {
   fork?: string,
   nodeUrl?: string,
   blockNumber?: number | 'latest',
+  baseBlockNumber: string, // hex
   stateDb?: State,
   details?: boolean
   blocks?: string[],
@@ -54,9 +55,10 @@ export class Provider {
   pendingRequests: Array<any>
 
   constructor (options: ProviderOptions = {} as ProviderOptions) {
+    console.log(options)
     this.options = options
     this.connected = true
-    this.vmContext = new VMContext(options['fork'], options['nodeUrl'], options['blockNumber'], options['stateDb'], options['blocks'])
+    this.vmContext = new VMContext(options['fork'], options['nodeUrl'], options['blockNumber'], options['stateDb'], options['blocks'], options['baseBlockNumber'])
 
     this.Accounts = new Web3Accounts(this.vmContext, options)
     this.Transactions = new Transactions(this.vmContext)

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -493,7 +493,7 @@ export class VMContext {
       }
     }, { common })
 
-    let blockchain = await Blockchain.create({ common, validateBlocks: false, validateConsensus: false, genesisBlock })
+    const blockchain = await Blockchain.create({ common, validateBlocks: false, validateConsensus: false, genesisBlock })
     overrideBlockchain(blockchain, this)
 
     const evm = await EVM.create({ common, allowUnlimitedContractSize: true, stateManager, blockchain })

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -393,9 +393,9 @@ const overrideBlockchain = (blockchain: Blockchain, context: VMContext) => {
     }
   }
 
-  blockchain['findCommonAncestor'] = findCommonAncestor
-  blockchain['_rebuildCanonical'] = _rebuildCanonical
-  return blockchain
+  anyBlockchain['findCommonAncestor'] = findCommonAncestor
+  anyBlockchain['_rebuildCanonical'] = _rebuildCanonical
+  return anyBlockchain as Blockchain
 }
 
 /*

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -278,7 +278,6 @@ const overrideBlockchain = (blockchain: Blockchain, context: VMContext) => {
     const ancestorHeaders = new Set<BlockHeader>()
 
     let header = await (blockchain as any)._getHeader((blockchain as any)._headHeaderHash)
-    console.log('findCommonAncestor', header, newHeader)
     if (header.number > newHeader.number) {
       header = await (blockchain as any).getCanonicalHeader(newHeader.number)
       ancestorHeaders.add(header)
@@ -294,7 +293,6 @@ const overrideBlockchain = (blockchain: Blockchain, context: VMContext) => {
         }
       }
     }
-    console.log(header.number, newHeader.number)
     if (header.number !== newHeader.number) {
       throw new Error('Failed to find ancient header')
     }

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -1,7 +1,7 @@
 /* global ethereum */
 'use strict'
 import { hash } from '@remix-project/remix-lib'
-import { bytesToHex, Account, bigIntToHex, MapDB, toBytes, bytesToBigInt, BIGINT_0 } from '@ethereumjs/util'
+import { bytesToHex, Account, bigIntToHex, MapDB, toBytes, bytesToBigInt, BIGINT_0, BIGINT_1, equalsBytes } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 import { Address } from '@ethereumjs/util'
 import { decode } from 'rlp'
@@ -15,8 +15,8 @@ import { Trie } from '@ethereumjs/trie'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { EVMStateManagerInterface, StorageDump } from '@ethereumjs/common'
 import { EVM } from '@ethereumjs/evm'
-import { Blockchain } from '@ethereumjs/blockchain'
-import { Block } from '@ethereumjs/block'
+import { Blockchain, DBSaveLookups } from '@ethereumjs/blockchain'
+import { Block, BlockHeader } from '@ethereumjs/block'
 import { TypedTransaction } from '@ethereumjs/tx'
 import { State } from './provider'
 import { hexToBytes } from 'web3-utils'
@@ -254,7 +254,8 @@ export type CurrentVm = {
   vm: VM,
   web3vm: VmProxy,
   stateManager: EVMStateManagerInterface,
-  common: Common
+  common: Common,
+  baseBlockNumber: string // hex
 }
 
 export class VMCommon extends Common {
@@ -267,6 +268,136 @@ export class VMCommon extends Common {
   }
 }
 
+const overrideBlockchain = (blockchain: Blockchain, context: VMContext) => {
+  const anyBlockchain = blockchain as any
+
+  /**
+   * Find the common ancestor of the new block and the old block.
+   * @param newHeader - the new block header
+   */
+  const findCommonAncestor = async (newHeader: BlockHeader) => {
+    if (!anyBlockchain._headHeaderHash) throw new Error('No head header set')
+    const ancestorHeaders = new Set<BlockHeader>()
+
+    let header = await anyBlockchain._getHeader(anyBlockchain._headHeaderHash)
+    console.log('findCommonAncestor', header)
+    if (header.number > newHeader.number) {
+      header = await anyBlockchain.getCanonicalHeader(newHeader.number)
+      ancestorHeaders.add(header)
+    } else {
+      while (header.number !== newHeader.number && newHeader.number > BIGINT_0) {
+        try {
+          newHeader = await anyBlockchain._getHeader(newHeader.parentHash, newHeader.number - BIGINT_1)
+          ancestorHeaders.add(newHeader)
+        } catch (err) {
+          // parent header not found, we reach the start of the fork, jumping to the beginning.
+          if (context.blocks['0x0']) newHeader = context.blocks['0x0'].header
+          break
+        }
+      }
+    }
+    console.log(header.number, newHeader.number)
+    if (header.number !== newHeader.number) {
+      throw new Error('Failed to find ancient header')
+    }
+    while (!equalsBytes(header.hash(), newHeader.hash()) && header.number > BIGINT_0) {
+      header = await anyBlockchain.getCanonicalHeader(header.number - BIGINT_1)
+      ancestorHeaders.add(header)
+      newHeader = await anyBlockchain._getHeader(newHeader.parentHash, newHeader.number - BIGINT_1)
+      ancestorHeaders.add(newHeader)
+    }
+    if (!equalsBytes(header.hash(), newHeader.hash())) {
+      throw new Error('Failed to find ancient header')
+    }
+    return {
+      commonAncestor: header,
+      ancestorHeaders: Array.from(ancestorHeaders),
+    }
+  }
+
+
+  /**
+   * Given a `header`, put all operations to change the canonical chain directly
+   * into `ops`. This walks the supplied `header` backwards. It is thus assumed
+   * that this header should be canonical header. For each header the
+   * corresponding hash corresponding to the current canonical chain in the DB
+   * is checked. If the number => hash reference does not correspond to the
+   * reference in the DB, we overwrite this reference with the implied number =>
+   * hash reference Also, each `_heads` member is checked; if these point to a
+   * stale hash, then the hash which we terminate the loop (i.e. the first hash
+   * which matches the number => hash of the implied chain) is put as this stale
+   * head hash. The same happens to _headBlockHash.
+   * @param header - The canonical header.
+   * @param ops - The database operations list.
+   * @hidden
+   */
+  const _rebuildCanonical = async (header: BlockHeader, ops: any[]) => {
+    let currentNumber = header.number
+    let currentCanonicalHash: Uint8Array = header.hash()
+
+    // track the staleHash: this is the hash currently in the DB which matches
+    // the block number of the provided header.
+    let staleHash: Uint8Array | false = false
+    let staleHeads: string[] = []
+    let staleHeadBlock = false
+
+    const loopCondition = async () => {
+      staleHash = await anyBlockchain.safeNumberToHash(currentNumber)
+      currentCanonicalHash = header.hash()
+      return staleHash === false || !equalsBytes(currentCanonicalHash, staleHash)
+    }
+
+    while (await loopCondition()) {
+      // handle genesis block
+      const blockHash = header.hash()
+      const blockNumber = header.number
+
+      if (blockNumber === BIGINT_0) {
+        break
+      }
+
+      DBSaveLookups(blockHash, blockNumber).map((op) => {
+        ops.push(op)
+      })
+
+      // mark each key `_heads` which is currently set to the hash in the DB as
+      // stale to overwrite later in `_deleteCanonicalChainReferences`.
+      for (const name of Object.keys(anyBlockchain._heads)) {
+        if (staleHash && equalsBytes(anyBlockchain._heads[name], staleHash)) {
+          staleHeads.push(name)
+        }
+      }
+      // flag stale headBlock for reset
+      if (
+        staleHash &&
+        anyBlockchain._headBlockHash !== undefined &&
+        equalsBytes(anyBlockchain._headBlockHash, staleHash) === true
+      ) {
+        staleHeadBlock = true
+      }
+
+      try {
+        header = await anyBlockchain._getHeader(header.parentHash, --currentNumber)
+      } catch (e) {
+        break  
+      }
+    }
+    // When the stale hash is equal to the blockHash of the provided header,
+    // set stale heads to last previously valid canonical block
+    for (const name of staleHeads) {
+      anyBlockchain._heads[name] = currentCanonicalHash
+    }
+    // set stale headBlock to last previously valid canonical block
+    if (staleHeadBlock) {
+      anyBlockchain._headBlockHash = currentCanonicalHash
+    }
+  }
+
+  blockchain['findCommonAncestor'] = findCommonAncestor
+  blockchain['_rebuildCanonical'] = _rebuildCanonical
+  return blockchain
+}
+
 /*
   trigger contextChanged, web3EndpointChanged
 */
@@ -275,7 +406,6 @@ export class VMContext {
   blockGasLimitDefault: number
   blockGasLimit: number
   blocks: Record<string, Block>
-  latestBlockNumber: string
   blockByTxHash: Record<string, Block>
   txByHash: Record<string, TypedTransaction>
   currentVm: CurrentVm
@@ -283,20 +413,33 @@ export class VMContext {
   logsManager: any // LogsManager
   exeResults: Record<string, TypedTransaction>
   nodeUrl: string
-  blockNumber: number | 'latest'
+  /*
+    This is the actual number of blocks that are added to the state.
+  */
+  latestBlockNumber: string
+  /*
+    This is the number of block that VMContext is instanciated with.
+    The final amount of blocks will be `latestBlockNumber` and the value either `blockNumber` or `baseBlockNumber` + `blockNumber`
+  */
+  private blockNumber: number | 'latest'
+  /*
+    When a VM is using a live state, baseBlockNumber is the number at which the live state is forked.
+  */
+  baseBlockNumber: string
   stateDb: State
   rawBlocks: string[]
   serializedBlocks: Uint8Array[]
 
-  constructor (fork?: string, nodeUrl?: string, blockNumber?: number | 'latest', stateDb?: State, blocksData?: string[]) {
+  constructor (fork?: string, nodeUrl?: string, blockNumber?: number | 'latest', stateDb?: State, blocksData?: string[], baseBlockNumber?: string) {
     this.blockGasLimitDefault = 4300000
     this.blockGasLimit = this.blockGasLimitDefault
     this.currentFork = fork || 'cancun'
     this.nodeUrl = nodeUrl
     this.stateDb = stateDb
-    this.blockNumber = blockNumber
+    this.blockNumber = blockNumber || 0
+    this.baseBlockNumber = baseBlockNumber
     this.blocks = {}
-    this.latestBlockNumber = "0x0"
+    this.latestBlockNumber = '0x0'
     this.blockByTxHash = {}
     this.txByHash = {}
     this.exeResults = {}
@@ -311,27 +454,28 @@ export class VMContext {
 
   async createVm (hardfork) {
     let stateManager: EVMStateManagerInterface
-    if (this.nodeUrl) {
-      let block = this.blockNumber
-      if (this.blockNumber === 'latest') {
-        const provider = new ethers.providers.StaticJsonRpcProvider(this.nodeUrl)
-        block = await provider.getBlockNumber()
-        stateManager = new CustomEthersStateManager({
-          provider: this.nodeUrl,
-          blockTag: '0x' + block.toString(16)
-        })
-        this.blockNumber = block
-      } else {
-        stateManager = new CustomEthersStateManager({
-          provider: this.nodeUrl,
-          blockTag: '0x' + block.toString(16)
-        })
-      }
-    } else {
+    // state trie
+    let trie = null
+    if (this.stateDb) {
       const db = this.stateDb ? new Map(Object.entries(this.stateDb).map(([k, v]) => [k, hexToBytes(v)])) : new Map()
       const mapDb = new MapDB(db)
-      const trie = await Trie.create({ useKeyHashing: true, db: mapDb, useRootPersistence: true })
+      trie = await Trie.create({ useKeyHashing: true, db: mapDb, useRootPersistence: true })
+    }
+    if (this.nodeUrl) {
+      if (this.blockNumber !== -1 && this.blockNumber !== 'latest') {
+        // we already have the right value for the block number
+      } else if (this.blockNumber === 'latest') {
+        // resolve `latest` to the actual block number
+        const provider = new ethers.providers.StaticJsonRpcProvider(this.nodeUrl)
+        this.blockNumber = await provider.getBlockNumber()
+      }
 
+      stateManager = new CustomEthersStateManager({
+        provider: this.nodeUrl,
+        blockTag: this.baseBlockNumber || '0x' + this.blockNumber.toString(16),
+        trie
+      })
+    } else {
       stateManager = new StateManagerCommonStorageDump({ trie })
     }
 
@@ -354,7 +498,9 @@ export class VMContext {
       }
     }, { common })
 
-    const blockchain = await Blockchain.create({ common, validateBlocks: false, validateConsensus: false, genesisBlock })
+    let blockchain = await Blockchain.create({ common, validateBlocks: false, validateConsensus: false, genesisBlock })
+    blockchain = overrideBlockchain(blockchain, this)
+
     const evm = await EVM.create({ common, allowUnlimitedContractSize: true, stateManager, blockchain })
 
     const vm = await VM.create({
@@ -364,6 +510,27 @@ export class VMContext {
       blockchain,
       evm
     })
+
+    let latestBlockNumberTemp
+    if (this.nodeUrl) {
+      if (!this.baseBlockNumber && this.blockNumber !== 'latest') {
+        // the baseBlockNumber isn't set.
+        // this means we are likely loading a VM mainnet fork from scratch,
+        // so we take the current live block number as the baseBlockNumber.
+        this.baseBlockNumber = '0x' + this.blockNumber.toString(16)
+        latestBlockNumberTemp = this.baseBlockNumber
+      } else if (this.baseBlockNumber && this.blockNumber !== 'latest') {
+        // the baseBlockNumber is set.
+        // this means we are likely loading a VM mainnet fork from a previously saved state,
+        // the latestBlockNumber is baseBlockNumber + 
+        latestBlockNumberTemp = '0x' + (parseInt(this.baseBlockNumber) + blocks.length).toString(16)      
+      }
+    } else {
+      // it's a standard VM so everything starts from 0.
+      this.baseBlockNumber = '0x0'
+      latestBlockNumberTemp = '0x0'
+    }
+
     // VmProxy and VMContext are very intricated.
     // VmProxy is used to track the EVM execution (to listen on opcode execution, in order for instance to generate the VM trace)
     const web3vm = new VmProxy(this)
@@ -374,7 +541,13 @@ export class VMContext {
       await blockchain.putBlock(block)
       this.addBlock(block, false, false, web3vm)
     }
-    return { vm, web3vm, stateManager, common, blocks }
+
+    if (latestBlockNumberTemp) {
+      this.latestBlockNumber = latestBlockNumberTemp
+    }
+    
+    console.log('creating vm', hardfork, this.nodeUrl, this.blockNumber, this.stateDb, this.rawBlocks, this.latestBlockNumber, this.blockNumber, this.baseBlockNumber)
+    return { vm, web3vm, stateManager, common, blocks, baseBlockNumber: this.baseBlockNumber }
   }
 
   getCurrentFork () {
@@ -394,17 +567,23 @@ export class VMContext {
   }
 
   addBlock (block: Block, genesis?: boolean, isCall?: boolean, web3vm?: VmProxy) {
-    let blockNumber = bigIntToHex(block.header.number)
-    if (blockNumber === '0x') {
-      blockNumber = '0x0'
+    let blockNumber
+    if (genesis) {
+      blockNumber = 0
+    } else if (this.baseBlockNumber) {
+      blockNumber = BigInt(this.baseBlockNumber) + block.header.number
+    } else {
+      blockNumber = block.header.number
     }
-
+    let blockNumberHex = bigIntToHex(blockNumber)
+    if (blockNumberHex === '0x') blockNumberHex = '0x0'
+  
     this.blocks[bytesToHex(block.hash())] = block
-    this.blocks[blockNumber] = block
-    this.latestBlockNumber = blockNumber
+    this.blocks[blockNumberHex] = block
+    this.latestBlockNumber = blockNumberHex
 
-    if (!isCall && !genesis && web3vm) this.logsManager.checkBlock(blockNumber, block, web3vm)
-    if (!isCall && !genesis && !web3vm) this.logsManager.checkBlock(blockNumber, block, this.web3())
+    if (!isCall && !genesis && web3vm) this.logsManager.checkBlock(blockNumberHex, block, web3vm)
+    if (!isCall && !genesis && !web3vm) this.logsManager.checkBlock(blockNumberHex, block, this.web3())
   }
 
   trackTx (txHash, block, tx) {

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -535,11 +535,6 @@ export class VMContext {
       this.addBlock(block, false, false, web3vm)
     }
 
-    if (latestBlockNumberTemp) {
-      this.latestBlockNumber = latestBlockNumberTemp
-    }
-
-    console.log('creating vm', hardfork, this.nodeUrl, this.blockNumber, this.stateDb, this.rawBlocks, this.latestBlockNumber, this.baseBlockNumber, this.blocks)
     return { vm, web3vm, stateManager, common, blocks, baseBlockNumber: this.baseBlockNumber }
   }
 

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -524,6 +524,10 @@ export class VMContext {
       latestBlockNumberTemp = '0x' + this.blockNumber.toString(16)
     }
 
+    if (latestBlockNumberTemp) {
+      this.latestBlockNumber = latestBlockNumberTemp
+    }
+
     // VmProxy and VMContext are very intricated.
     // VmProxy is used to track the EVM execution (to listen on opcode execution, in order for instance to generate the VM trace)
     const web3vm = new VmProxy(this)

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -454,12 +454,11 @@ export class VMContext {
   async createVm (hardfork) {
     let stateManager: EVMStateManagerInterface
     // state trie
-    let trie = null
-    if (this.stateDb) {
-      const db = this.stateDb ? new Map(Object.entries(this.stateDb).map(([k, v]) => [k, hexToBytes(v)])) : new Map()
-      const mapDb = new MapDB(db)
-      trie = await Trie.create({ useKeyHashing: true, db: mapDb, useRootPersistence: true })
-    }
+
+    const db = this.stateDb ? new Map(Object.entries(this.stateDb).map(([k, v]) => [k, hexToBytes(v)])) : new Map()
+    const mapDb = new MapDB(db)
+    const trie = await Trie.create({ useKeyHashing: true, db: mapDb, useRootPersistence: true })
+
     if (this.nodeUrl) {
       if (this.blockNumber !== -1 && this.blockNumber !== 'latest') {
         // we already have the right value for the block number

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -528,7 +528,7 @@ export class VMContext {
     } else {
       // it's a standard VM so everything starts from 0.
       this.baseBlockNumber = '0x0'
-      latestBlockNumberTemp = '0x0'
+      latestBlockNumberTemp = '0x' + this.blockNumber.toString(16)
     }
 
     // VmProxy and VMContext are very intricated.
@@ -546,7 +546,7 @@ export class VMContext {
       this.latestBlockNumber = latestBlockNumberTemp
     }
     
-    console.log('creating vm', hardfork, this.nodeUrl, this.blockNumber, this.stateDb, this.rawBlocks, this.latestBlockNumber, this.blockNumber, this.baseBlockNumber)
+    console.log('creating vm', hardfork, this.nodeUrl, this.blockNumber, this.stateDb, this.rawBlocks, this.latestBlockNumber, this.baseBlockNumber, this.blocks)
     return { vm, web3vm, stateManager, common, blocks, baseBlockNumber: this.baseBlockNumber }
   }
 

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -171,13 +171,11 @@ class CustomEthersStateManager extends StateManagerCommonStorageDump {
     let storage = await super.getContractStorage(address, key)
     if (storage && storage.length > 0) return storage
     else {
-      console.log('getContractStorage', this.blockTag)
       storage = toBytes(await this.provider.getStorageAt(
         address.toString(),
         bytesToBigInt(key),
         this.blockTag)
       )
-      console.log('putContractStorage', address.toString(), bytesToHex(key), bytesToHex(storage))
       await super.putContractStorage(address, key, storage)
       return storage
     }

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -504,28 +504,23 @@ export class VMContext {
       evm
     })
 
-    let latestBlockNumberTemp
     if (this.nodeUrl) {
       if (!this.baseBlockNumber && this.blockNumber !== 'latest') {
         // the baseBlockNumber isn't set.
         // this means we are likely loading a VM mainnet fork from scratch,
         // so we take the current live block number as the baseBlockNumber.
         this.baseBlockNumber = '0x' + this.blockNumber.toString(16)
-        latestBlockNumberTemp = this.baseBlockNumber
+        this.latestBlockNumber = this.baseBlockNumber
       } else if (this.baseBlockNumber && this.blockNumber !== 'latest') {
         // the baseBlockNumber is set.
         // this means we are likely loading a VM mainnet fork from a previously saved state,
         // the latestBlockNumber is baseBlockNumber +
-        latestBlockNumberTemp = '0x' + (parseInt(this.baseBlockNumber) + blocks.length).toString(16)
+        this.latestBlockNumber = '0x' + (parseInt(this.baseBlockNumber) + blocks.length).toString(16)
       }
     } else {
       // it's a standard VM so everything starts from 0.
       this.baseBlockNumber = '0x0'
-      latestBlockNumberTemp = '0x' + this.blockNumber.toString(16)
-    }
-
-    if (latestBlockNumberTemp) {
-      this.latestBlockNumber = latestBlockNumberTemp
+      this.latestBlockNumber = '0x' + this.blockNumber.toString(16)
     }
 
     // VmProxy and VMContext are very intricated.

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -315,7 +315,6 @@ const overrideBlockchain = (blockchain: Blockchain, context: VMContext) => {
     }
   }
 
-
   /**
    * Given a `header`, put all operations to change the canonical chain directly
    * into `ops`. This walks the supplied `header` backwards. It is thus assumed
@@ -338,7 +337,7 @@ const overrideBlockchain = (blockchain: Blockchain, context: VMContext) => {
     // track the staleHash: this is the hash currently in the DB which matches
     // the block number of the provided header.
     let staleHash: Uint8Array | false = false
-    let staleHeads: string[] = []
+    const staleHeads: string[] = []
     let staleHeadBlock = false
 
     const loopCondition = async () => {
@@ -379,7 +378,7 @@ const overrideBlockchain = (blockchain: Blockchain, context: VMContext) => {
       try {
         header = await anyBlockchain._getHeader(header.parentHash, --currentNumber)
       } catch (e) {
-        break  
+        break
       }
     }
     // When the stale hash is equal to the blockHash of the provided header,
@@ -522,8 +521,8 @@ export class VMContext {
       } else if (this.baseBlockNumber && this.blockNumber !== 'latest') {
         // the baseBlockNumber is set.
         // this means we are likely loading a VM mainnet fork from a previously saved state,
-        // the latestBlockNumber is baseBlockNumber + 
-        latestBlockNumberTemp = '0x' + (parseInt(this.baseBlockNumber) + blocks.length).toString(16)      
+        // the latestBlockNumber is baseBlockNumber +
+        latestBlockNumberTemp = '0x' + (parseInt(this.baseBlockNumber) + blocks.length).toString(16)
       }
     } else {
       // it's a standard VM so everything starts from 0.
@@ -545,7 +544,7 @@ export class VMContext {
     if (latestBlockNumberTemp) {
       this.latestBlockNumber = latestBlockNumberTemp
     }
-    
+
     console.log('creating vm', hardfork, this.nodeUrl, this.blockNumber, this.stateDb, this.rawBlocks, this.latestBlockNumber, this.baseBlockNumber, this.blocks)
     return { vm, web3vm, stateManager, common, blocks, baseBlockNumber: this.baseBlockNumber }
   }
@@ -577,7 +576,7 @@ export class VMContext {
     }
     let blockNumberHex = bigIntToHex(blockNumber)
     if (blockNumberHex === '0x') blockNumberHex = '0x0'
-  
+
     this.blocks[bytesToHex(block.hash())] = block
     this.blocks[blockNumberHex] = block
     this.latestBlockNumber = blockNumberHex

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -455,7 +455,7 @@ export class VMContext {
     const trie = await Trie.create({ useKeyHashing: true, db: mapDb, useRootPersistence: true })
 
     if (this.nodeUrl) {
-      if (this.blockNumber !== -1 && this.blockNumber !== 'latest') {
+      if (this.blockNumber !== 'latest') {
         // we already have the right value for the block number
       } else if (this.blockNumber === 'latest') {
         // resolve `latest` to the actual block number

--- a/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
+++ b/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
@@ -122,7 +122,7 @@ export const EnvironmentExplorerUI = (props: environmentExplorerUIProps) => {
                     </span>
                   </CustomTooltip>
                   }
-                  { provider.config.isVMStateForked && provider.config.statePath && <CustomTooltip
+                  { false && provider.config.isVMStateForked && provider.config.statePath && <CustomTooltip
                     placement="auto"
                     tooltipId={`overlay-tooltip-${provider.name}`}
                     tooltipText="Show Pinned Contracts in the terminal"

--- a/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
+++ b/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
@@ -21,27 +21,30 @@ const defaultSections: environmentExplorerUIGridSections = {
     title: 'Deploy to an In-browser Forked State.',
     keywords: ['Forked State'],
     providers: [],
-    filterFn: (provider) => provider.config.isVMStateForked,
+    filterFn: (provider) => provider.config.isVMStateForked || provider.config.isRpcForkedState,
     descriptionFn: (provider) => {
-      const { latestBlock, timestamp } = JSON.parse(provider.description)
-      return (
-        <>
-          <div><b>Latest Block: </b>{parseInt(latestBlock)}</div>
-          <CustomTooltip
-            placement="auto"
-            tooltipId="overlay-tooltip-forkedAt"
-            tooltipText={`Forked at: ${(new Date(timestamp)).toLocaleString()}`}
-          >
-            <div><b>Forked at: </b>{(new Date(timestamp)).toDateString()}</div>
-          </CustomTooltip>
-        </>)
+      if (provider.config.baseBlockNumber) {
+        const { latestBlock, timestamp } = JSON.parse(provider.description)
+        return (
+          <>
+            <div><b>Latest Block: </b>{parseInt(latestBlock)}</div>
+            {provider.config.baseBlockNumber && <div><b>Forked at Block </b>{parseInt(provider.config.baseBlockNumber)}</div>}
+            <CustomTooltip
+              placement="auto"
+              tooltipId="overlay-tooltip-forkedAt"
+              tooltipText={`Forked on: ${(new Date(timestamp)).toLocaleString()}`}
+            >
+              <div><b>Forked on: </b>{(new Date(timestamp)).toDateString()}</div>
+            </CustomTooltip>
+          </>)
+      } else if (provider.config.statePath) {
+        // At this point we don't have any state in the browser, we start from the latest block
+        return (
+          <>
+            <div><b>{provider.description}</b></div>
+          </>)
+      }      
     }
-  },
-  'Remix forked VMs': {
-    title: 'Deploy to a Live forked Virtual Machine.',
-    keywords: ['Remix forked VMs'],
-    providers: [],
-    filterFn: (provider) => provider.config.isRpcForkedState
   },
   'Externals': {
     title: 'Deploy to an external Provider.',
@@ -102,7 +105,7 @@ export const EnvironmentExplorerUI = (props: environmentExplorerUIProps) => {
                   }}
                 >
                   <div data-id={`${provider.name}desc`}>{(section.descriptionFn && section.descriptionFn(provider)) || provider.description}</div>
-                  { provider.config.isVMStateForked && <CustomTooltip
+                  { provider.config.isVMStateForked && provider.config.statePath && <CustomTooltip
                     placement="auto"
                     tooltipId={`overlay-tooltip-${provider.name}`}
                     tooltipText="Delete Environment Immediately"

--- a/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
+++ b/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
@@ -27,7 +27,7 @@ const defaultSections: environmentExplorerUIGridSections = {
         const { latestBlock, timestamp } = JSON.parse(provider.description)
         return (
           <>
-            <div><b>Latest Block: </b>{parseInt(latestBlock)}</div>
+            <div><b>Latest Block: </b>{provider.config.baseBlockNumber && provider.config.baseBlockNumber !== '0x0' ? parseInt(provider.config.baseBlockNumber) + parseInt(latestBlock) : parseInt(latestBlock)}</div>
             <CustomTooltip
               placement="auto"
               tooltipId="overlay-tooltip-forkedAt"
@@ -35,7 +35,7 @@ const defaultSections: environmentExplorerUIGridSections = {
             >
               <div>
                 {
-                  provider.config.baseBlockNumber !== '0x' && <div><b>Forked at Block </b>{parseInt(provider.config.baseBlockNumber)}</div>
+                  provider.config.baseBlockNumber && provider.config.baseBlockNumber !== '0x0' && <div><b>Origin Block: </b>{parseInt(provider.config.baseBlockNumber)}</div>
                 }
                 <b>Forked on: </b>{(new Date(timestamp)).toDateString()}
               </div>

--- a/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
+++ b/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
@@ -32,12 +32,13 @@ const defaultSections: environmentExplorerUIGridSections = {
               placement="auto"
               tooltipId="overlay-tooltip-forkedAt"
               tooltipText={`Forked on: ${(new Date(timestamp)).toLocaleString()}}`}
-            >                       
-            <div>
-              {
-                provider.config.baseBlockNumber !== '0x' && <div><b>Forked at Block </b>{parseInt(provider.config.baseBlockNumber)}</div>
-              } 
-            <b>Forked on: </b>{(new Date(timestamp)).toDateString()}</div>
+            >
+              <div>
+                {
+                  provider.config.baseBlockNumber !== '0x' && <div><b>Forked at Block </b>{parseInt(provider.config.baseBlockNumber)}</div>
+                }
+                <b>Forked on: </b>{(new Date(timestamp)).toDateString()}
+              </div>
             </CustomTooltip>
           </>)
       } else {
@@ -46,7 +47,7 @@ const defaultSections: environmentExplorerUIGridSections = {
           <>
             <div><b>{provider.description}</b></div>
           </>)
-      }      
+      }
     }
   },
   'Externals': {

--- a/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
+++ b/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
@@ -28,16 +28,19 @@ const defaultSections: environmentExplorerUIGridSections = {
         return (
           <>
             <div><b>Latest Block: </b>{parseInt(latestBlock)}</div>
-            {provider.config.baseBlockNumber && <div><b>Forked at Block </b>{parseInt(provider.config.baseBlockNumber)}</div>}
             <CustomTooltip
               placement="auto"
               tooltipId="overlay-tooltip-forkedAt"
-              tooltipText={`Forked on: ${(new Date(timestamp)).toLocaleString()}`}
-            >
-              <div><b>Forked on: </b>{(new Date(timestamp)).toDateString()}</div>
+              tooltipText={`Forked on: ${(new Date(timestamp)).toLocaleString()}}`}
+            >                       
+            <div>
+              {
+                provider.config.baseBlockNumber !== '0x' && <div><b>Forked at Block </b>{parseInt(provider.config.baseBlockNumber)}</div>
+              } 
+            <b>Forked on: </b>{(new Date(timestamp)).toDateString()}</div>
             </CustomTooltip>
           </>)
-      } else if (provider.config.statePath) {
+      } else {
         // At this point we don't have any state in the browser, we start from the latest block
         return (
           <>
@@ -115,6 +118,19 @@ export const EnvironmentExplorerUI = (props: environmentExplorerUIProps) => {
                       className="btn btn-sm mt-1 border border-danger"
                     >
                           Delete Environment
+                    </span>
+                  </CustomTooltip>
+                  }
+                  { provider.config.isVMStateForked && provider.config.statePath && <CustomTooltip
+                    placement="auto"
+                    tooltipId={`overlay-tooltip-${provider.name}`}
+                    tooltipText="Delete Environment Immediately"
+                  >
+                    <span
+                      onClick={async () => props.showPinnedContracts(provider)}
+                      className="btn btn-sm mt-1 border border-info"
+                    >
+                          Show Pinned Contracts
                     </span>
                   </CustomTooltip>
                   }

--- a/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
+++ b/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
@@ -31,7 +31,7 @@ const defaultSections: environmentExplorerUIGridSections = {
             <CustomTooltip
               placement="auto"
               tooltipId="overlay-tooltip-forkedAt"
-              tooltipText={`Forked on: ${(new Date(timestamp)).toLocaleString()}}`}
+              tooltipText={`Forked on: ${(new Date(timestamp)).toLocaleString()}`}
             >
               <div>
                 {
@@ -45,7 +45,7 @@ const defaultSections: environmentExplorerUIGridSections = {
         // At this point we don't have any state in the browser, we start from the latest block
         return (
           <>
-            <div><b>{provider.description}</b></div>
+            <div>{provider.description}</div>
           </>)
       }
     }
@@ -125,7 +125,7 @@ export const EnvironmentExplorerUI = (props: environmentExplorerUIProps) => {
                   { provider.config.isVMStateForked && provider.config.statePath && <CustomTooltip
                     placement="auto"
                     tooltipId={`overlay-tooltip-${provider.name}`}
-                    tooltipText="Delete Environment Immediately"
+                    tooltipText="Show Pinned Contracts in the terminal"
                   >
                     <span
                       onClick={async () => props.showPinnedContracts(provider)}

--- a/libs/remix-ui/environment-explorer/src/lib/types/index.ts
+++ b/libs/remix-ui/environment-explorer/src/lib/types/index.ts
@@ -1,7 +1,7 @@
 import { Plugin } from '@remixproject/engine'
 import { Profile } from '@remixproject/plugin-utils'
 
-export type ProvidersSection = `Injected` | 'Remix VMs' | 'Externals' | 'Remix forked VMs' | 'Forked States'
+export type ProvidersSection = `Injected` | 'Remix VMs' | 'Externals' | 'Forked States'
 
 export type environmentExplorerUIProps = {
   state: {
@@ -35,6 +35,7 @@ export type ProviderConfig = {
   statePath?: string,
   blockNumber?: string
   nodeUrl?: string
+  baseBlockNumber?: string
 }
 
 export type Provider = {

--- a/libs/remix-ui/environment-explorer/src/lib/types/index.ts
+++ b/libs/remix-ui/environment-explorer/src/lib/types/index.ts
@@ -46,7 +46,7 @@ export type Provider = {
   name: string
   displayName: string
   logo?: string,
-  logos?: string[],  
+  logos?: string[],
   description?: string
   config: ProviderConfig
   title: string

--- a/libs/remix-ui/environment-explorer/src/lib/types/index.ts
+++ b/libs/remix-ui/environment-explorer/src/lib/types/index.ts
@@ -31,7 +31,10 @@ export type ProviderConfig = {
   isInjected: boolean
   isRpcForkedState?: boolean
   isVMStateForked?: boolean
-  statePath?: string
+  fork: string
+  statePath?: string,
+  blockNumber?: string
+  nodeUrl?: string
 }
 
 export type Provider = {
@@ -41,8 +44,7 @@ export type Provider = {
   name: string
   displayName: string
   logo?: string,
-  logos?: string[],
-  fork: string
+  logos?: string[],  
   description?: string
   config: ProviderConfig
   title: string

--- a/libs/remix-ui/environment-explorer/src/lib/types/index.ts
+++ b/libs/remix-ui/environment-explorer/src/lib/types/index.ts
@@ -9,6 +9,7 @@ export type environmentExplorerUIProps = {
     pinnedProviders: string[]
   }
   deleteForkedState (provider: Provider): Promise<void>
+  showPinnedContracts (provider: Provider): Promise<void>
   pinStateCallback (provider: Provider, pinned: boolean): Promise<void>
   profile: Profile
 }

--- a/libs/remix-ui/run-tab/src/lib/components/environment.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/environment.tsx
@@ -67,7 +67,7 @@ export function EnvironmentUI(props: EnvironmentProps) {
     let context = currentProvider.name
     context = context.replace('vm-fs-', '')
 
-    let stateTemp = `.states/forked_states/state_temp.json`
+    const stateTemp = `.states/forked_states/state_temp.json`
     let statePath = currentProvider.config.statePath
     if (!statePath) {
       // if the current provider doesn't have a saved state, we dump the current state from memory.
@@ -76,7 +76,7 @@ export function EnvironmentUI(props: EnvironmentProps) {
       statePath = stateTemp
       await props.runTabPlugin.call('fileManager', 'writeFile', statePath, state)
     }
-    
+
     vmStateName.current = `${context}_${Date.now()}`
     const contextExists = await props.runTabPlugin.call('fileManager', 'exists', statePath)
     if (contextExists) {
@@ -96,7 +96,7 @@ export function EnvironmentUI(props: EnvironmentProps) {
           try {
             await props.runTabPlugin.call('fileManager', 'remove', stateTemp)
           } catch (e) {
-            // we can silent that.  
+            // we can silent that.
           }
 
           // we also need to copy the pinned contracts:

--- a/libs/remix-ui/run-tab/src/lib/components/environment.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/environment.tsx
@@ -95,8 +95,10 @@ export function EnvironmentUI(props: EnvironmentProps) {
 
         // we also need to copy the pinned contracts:
         if (await props.runTabPlugin.call('fileManager', 'exists', `.deploys/pinned-contracts/${currentProvider.name}`)) {
-          // await props.runTabPlugin.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${vmStateName.current}`)
-          await props.runTabPlugin.call('fileManager', 'copyDir', `.deploys/pinned-contracts/${currentProvider.name}`, `.deploys/pinned-contracts`, 'vm-fs-' + vmStateName.current)
+          const files = await props.runTabPlugin.call('fileManager', 'readdir', `.deploys/pinned-contracts/${currentProvider.name}`)
+          if (files && files.length) {
+            await props.runTabPlugin.call('fileManager', 'copyDir', `.deploys/pinned-contracts/${currentProvider.name}`, `.deploys/pinned-contracts`, 'vm-fs-' + vmStateName.current)
+          }
         }
         _paq.push(['trackEvent', 'udapp', 'forkState', `forked from ${context}`])
       },

--- a/libs/remix-ui/run-tab/src/lib/components/environment.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/environment.tsx
@@ -93,7 +93,17 @@ export function EnvironmentUI(props: EnvironmentProps) {
           currentStateDb.savingTimestamp = Date.now()
           await props.runTabPlugin.call('fileManager', 'writeFile', `.states/forked_states/${vmStateName.current}.json`, JSON.stringify(currentStateDb, null, 2))
           props.runTabPlugin.emit('vmStateForked', vmStateName.current)
-          await props.runTabPlugin.call('fileManager', 'remove', stateTemp)
+          try {
+            await props.runTabPlugin.call('fileManager', 'remove', stateTemp)
+          } catch (e) {
+            // we can silent that.  
+          }
+
+          // we also need to copy the pinned contracts:
+          if (await props.runTabPlugin.call('fileManager', 'exists', `.deploys/pinned-contracts/${currentProvider.name}`)) {
+            // await props.runTabPlugin.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${vmStateName.current}`)
+            await props.runTabPlugin.call('fileManager', 'copyDir', `.deploys/pinned-contracts/${currentProvider.name}`, `.deploys/pinned-contracts`, 'vm-fs-' + vmStateName.current)
+          }
           _paq.push(['trackEvent', 'udapp', 'forkState', `forked from ${context}`])
         },
         intl.formatMessage({ id: 'udapp.cancel' }),

--- a/libs/remix-ui/run-tab/src/lib/components/environment.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/environment.tsx
@@ -66,52 +66,43 @@ export function EnvironmentUI(props: EnvironmentProps) {
     _paq.push(['trackEvent', 'udapp', 'forkState', `forkState clicked`])
     let context = currentProvider.name
     context = context.replace('vm-fs-', '')
-
-    const stateTemp = `.states/forked_states/state_temp.json`
-    let statePath = currentProvider.config.statePath
-    if (!statePath) {
-      // if the current provider doesn't have a saved state, we dump the current state from memory.
-      // state_temp.json is removed after the operation completes
-      const state = await props.runTabPlugin.blockchain.executionContext.getStateDetails()
-      statePath = stateTemp
-      await props.runTabPlugin.call('fileManager', 'writeFile', statePath, state)
+    
+    let currentStateDb
+    try {
+      currentStateDb = JSON.parse(await props.runTabPlugin.blockchain.executionContext.getStateDetails())
+    } catch (e) {
+      props.runTabPlugin.call('notification', 'toast', `State not available to fork. ${e.message}`)
+      return
+    }
+    
+    if (Object.keys(currentStateDb.db).length === 0) {
+      props.runTabPlugin.call('notification', 'toast', `State not available to fork, as no transactions have been made for selected environment & selected workspace.`)
+      return
     }
 
-    vmStateName.current = `${context}_${Date.now()}`
-    const contextExists = await props.runTabPlugin.call('fileManager', 'exists', statePath)
-    if (contextExists) {
-      props.modal(
-        intl.formatMessage({ id: 'udapp.forkStateTitle' }),
-        forkStatePrompt(vmStateName.current),
-        intl.formatMessage({ id: 'udapp.fork' }),
-        async () => {
-          let currentStateDb = await props.runTabPlugin.call('fileManager', 'readFile', statePath)
-          currentStateDb = JSON.parse(currentStateDb)
-          currentStateDb.stateName = vmStateName.current
-          currentStateDb.forkName = currentProvider.config.fork
-          currentStateDb.nodeUrl = currentProvider.config.nodeUrl
-          currentStateDb.savingTimestamp = Date.now()
-          await props.runTabPlugin.call('fileManager', 'writeFile', `.states/forked_states/${vmStateName.current}.json`, JSON.stringify(currentStateDb, null, 2))
-          props.runTabPlugin.emit('vmStateForked', vmStateName.current)
-          try {
-            await props.runTabPlugin.call('fileManager', 'remove', stateTemp)
-          } catch (e) {
-            // we can silent that.
-          }
+    vmStateName.current = `${context}_${Date.now()}`    
+    props.modal(
+      intl.formatMessage({ id: 'udapp.forkStateTitle' }),
+      forkStatePrompt(vmStateName.current),
+      intl.formatMessage({ id: 'udapp.fork' }),
+      async () => {
+        currentStateDb.stateName = vmStateName.current
+        currentStateDb.forkName = currentProvider.config.fork
+        currentStateDb.nodeUrl = currentProvider.config.nodeUrl
+        currentStateDb.savingTimestamp = Date.now()
+        await props.runTabPlugin.call('fileManager', 'writeFile', `.states/forked_states/${vmStateName.current}.json`, JSON.stringify(currentStateDb, null, 2))
+        props.runTabPlugin.emit('vmStateForked', vmStateName.current)        
 
-          // we also need to copy the pinned contracts:
-          if (await props.runTabPlugin.call('fileManager', 'exists', `.deploys/pinned-contracts/${currentProvider.name}`)) {
-            // await props.runTabPlugin.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${vmStateName.current}`)
-            await props.runTabPlugin.call('fileManager', 'copyDir', `.deploys/pinned-contracts/${currentProvider.name}`, `.deploys/pinned-contracts`, 'vm-fs-' + vmStateName.current)
-          }
-          _paq.push(['trackEvent', 'udapp', 'forkState', `forked from ${context}`])
-        },
-        intl.formatMessage({ id: 'udapp.cancel' }),
-        () => {
-          props.runTabPlugin.call('fileManager', 'remove', stateTemp)
+        // we also need to copy the pinned contracts:
+        if (await props.runTabPlugin.call('fileManager', 'exists', `.deploys/pinned-contracts/${currentProvider.name}`)) {
+          // await props.runTabPlugin.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${vmStateName.current}`)
+          await props.runTabPlugin.call('fileManager', 'copyDir', `.deploys/pinned-contracts/${currentProvider.name}`, `.deploys/pinned-contracts`, 'vm-fs-' + vmStateName.current)
         }
-      )
-    } else props.runTabPlugin.call('notification', 'toast', `State not available to fork, as no transactions have been made for selected environment & selected workspace.`)
+        _paq.push(['trackEvent', 'udapp', 'forkState', `forked from ${context}`])
+      },
+      intl.formatMessage({ id: 'udapp.cancel' }),
+      () => {}
+    )
   }
 
   const resetVmState = async() => {

--- a/libs/remix-ui/run-tab/src/lib/components/environment.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/environment.tsx
@@ -66,7 +66,7 @@ export function EnvironmentUI(props: EnvironmentProps) {
     _paq.push(['trackEvent', 'udapp', 'forkState', `forkState clicked`])
     let context = currentProvider.name
     context = context.replace('vm-fs-', '')
-    
+
     let currentStateDb
     try {
       currentStateDb = JSON.parse(await props.runTabPlugin.blockchain.executionContext.getStateDetails())
@@ -74,13 +74,13 @@ export function EnvironmentUI(props: EnvironmentProps) {
       props.runTabPlugin.call('notification', 'toast', `State not available to fork. ${e.message}`)
       return
     }
-    
+
     if (Object.keys(currentStateDb.db).length === 0) {
       props.runTabPlugin.call('notification', 'toast', `State not available to fork, as no transactions have been made for selected environment & selected workspace.`)
       return
     }
 
-    vmStateName.current = `${context}_${Date.now()}`    
+    vmStateName.current = `${context}_${Date.now()}`
     props.modal(
       intl.formatMessage({ id: 'udapp.forkStateTitle' }),
       forkStatePrompt(vmStateName.current),
@@ -91,7 +91,7 @@ export function EnvironmentUI(props: EnvironmentProps) {
         currentStateDb.nodeUrl = currentProvider.config.nodeUrl
         currentStateDb.savingTimestamp = Date.now()
         await props.runTabPlugin.call('fileManager', 'writeFile', `.states/forked_states/${vmStateName.current}.json`, JSON.stringify(currentStateDb, null, 2))
-        props.runTabPlugin.emit('vmStateForked', vmStateName.current)        
+        props.runTabPlugin.emit('vmStateForked', vmStateName.current)
 
         // we also need to copy the pinned contracts:
         if (await props.runTabPlugin.call('fileManager', 'exists', `.deploys/pinned-contracts/${currentProvider.name}`)) {

--- a/libs/remix-ui/run-tab/src/lib/components/environment.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/environment.tsx
@@ -96,7 +96,7 @@ export function EnvironmentUI(props: EnvironmentProps) {
         // we also need to copy the pinned contracts:
         if (await props.runTabPlugin.call('fileManager', 'exists', `.deploys/pinned-contracts/${currentProvider.name}`)) {
           const files = await props.runTabPlugin.call('fileManager', 'readdir', `.deploys/pinned-contracts/${currentProvider.name}`)
-          if (files && files.length) {
+          if (files && Object.keys(files).length) {
             await props.runTabPlugin.call('fileManager', 'copyDir', `.deploys/pinned-contracts/${currentProvider.name}`, `.deploys/pinned-contracts`, 'vm-fs-' + vmStateName.current)
           }
         }

--- a/libs/remix-ui/run-tab/src/lib/types/execution-context.d.ts
+++ b/libs/remix-ui/run-tab/src/lib/types/execution-context.d.ts
@@ -32,4 +32,5 @@ export class ExecutionContext {
   _updateChainContext(): Promise<void>;
   listenOnLastBlock(): void;
   txDetailsLink(network: any, hash: any): any;
+  getStateDetails(): Promise<string>
 }


### PR DESCRIPTION
partially_fix https://github.com/ethereum/remix-project/issues/5611

- `Remix VM mainnet fork` doesn't keep the state anymore (reloading it will use a new state).
- It is now possible to fork ``Remix VM mainnet fork` it self. In that case the state will be saved with a baseBlockNumber (the block when the fork occured).
- in the general case, pinned contracts are copied over when a state is forked.