### PR TITLE
Fix loading deps which use module name remapping

### DIFF
--- a/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
+++ b/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
@@ -199,8 +199,10 @@ const sources = [
   },
   {
     'Untitled10.sol': { content: 'pragma solidity ^0.8.0; import "@module_remapping/token/ERC20/ERC20.sol"; contract test15 {}' },
-    'package.json': { content: `"dependencies": {
+    'package.json': { content: `{
+    "dependencies": {
       "@module_remapping": "npm:@openzeppelin/contracts@^4.9.0"
-  },` }
+  }
+}` }
   }
 ]

--- a/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
+++ b/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
@@ -154,7 +154,7 @@ module.exports = {
       .waitForElementVisible('[data-id="fileSystemModalDialogModalBody-react"]')
       .click('[data-id="fileSystemModalDialogModalBody-react"]')
       .waitForElementVisible('[data-id="modalDialogCustomPromptTextClone"]')
-      .setValue('[data-id="modalDialogCustomPromptTextClone"]', 'https://github.com/yann300/remix-reward')
+      .setValue('[data-id="modalDialogCustomPromptTextClone"]', 'https://github.com/remix-project-org/remix-reward')
       .click('[data-id="fileSystem-modal-footer-ok-react"]')
       .waitForElementPresent('.fa-spinner')
       .waitForElementNotPresent('.fa-spinner', 120000)

--- a/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
+++ b/apps/remix-ide-e2e/src/tests/solidityImport.test.ts
@@ -115,6 +115,34 @@ module.exports = {
       .verifyContracts(['test13', 'ERC20'], { wait: 30000 })
   },
 
+  'Test NPM Import (with unpkg.com) and the package.json contains a module remapping #group3': function (browser: NightwatchBrowser) {
+    browser
+      .setSolidityCompilerVersion('soljson-v0.8.7+commit.e28d00a7.js')
+      .waitForElementPresent({
+        selector: `//*[@data-id='compilerloaded' and @data-version='soljson-v0.8.7+commit.e28d00a7.js']`,
+        locateStrategy: 'xpath',
+        timeout: 120000
+      })
+      .clickLaunchIcon('filePanel')
+      .click('li[data-id="treeViewLitreeViewItemREADME.txt"')
+      .addFile('package.json', sources[9]['package.json'])
+      .addFile('Untitled10.sol', sources[9]['Untitled10.sol'])      
+      // avoid invalid source issues
+      .isVisible({
+        selector: '*[data-id="treeViewLitreeViewItem.deps/npm/@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol"]',
+        timeout: 120000,
+        suppressNotFoundErrors: true
+      })
+      .clickLaunchIcon('solidity')
+      .click('[data-id="compilerContainerCompileBtn"]')
+      .clickLaunchIcon('filePanel')
+      .isVisible({
+        selector: '*[data-id="treeViewLitreeViewItem.deps/npm/@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol"]',
+        timeout: 120000,
+      })
+      .verifyContracts(['test15', 'ERC20'], { wait: 30000 })
+  },
+
   'Test NPM Import (the version is specified in package.json) #group4': function (browser: NightwatchBrowser) {
     browser
       // clone https://github.com/yann300/remix-reward
@@ -168,5 +196,11 @@ const sources = [
   },
   {
     'Untitled9.sol': { content: 'pragma solidity ^0.8.0; import "@openzeppelin/contracts/token/ERC20/ERC20.sol"; contract test13 {}' }
+  },
+  {
+    'Untitled10.sol': { content: 'pragma solidity ^0.8.0; import "@module_remapping/token/ERC20/ERC20.sol"; contract test15 {}' },
+    'package.json': { content: `"dependencies": {
+      "@module_remapping": "npm:@openzeppelin/contracts@^4.9.0"
+  },` }
   }
 ]

--- a/libs/remix-url-resolver/src/resolve.ts
+++ b/libs/remix-url-resolver/src/resolve.ts
@@ -275,7 +275,7 @@ function getPkg(pkg, yarnLock, packageLock, deps, url, fetchUrl) {
     } else {
       // const versionSemver = semver.minVersion(version)
       fetchUrl = url.replace(pkg, `${pkg}@${version}`)
-      return encodeURIComponent(fetchUrl)
+      return fetchUrl
     }
   }
   return null

--- a/libs/remix-url-resolver/src/resolve.ts
+++ b/libs/remix-url-resolver/src/resolve.ts
@@ -275,7 +275,7 @@ function getPkg(pkg, yarnLock, packageLock, deps, url, fetchUrl) {
     } else {
       // const versionSemver = semver.minVersion(version)
       fetchUrl = url.replace(pkg, `${pkg}@${version}`)
-      return fetchUrl
+      return encodeURIComponent(fetchUrl)
     }
   }
   return null

--- a/libs/remix-url-resolver/src/resolve.ts
+++ b/libs/remix-url-resolver/src/resolve.ts
@@ -136,7 +136,6 @@ export class RemixURLResolver {
   * Handle an import statement based on NPM
   * @param url The url of the NPM import statement
   */
-
   async handleNpmImport(url: string): Promise<HandlerResponse> {
     if (!url) throw new Error('url is empty')
     let fetchUrl = url
@@ -144,45 +143,16 @@ export class RemixURLResolver {
     if (this.getDependencies && !isVersioned) {
       try {
         const { deps, yarnLock, packageLock } = await this.getDependencies()
-        let matchLength = 0
-        let pkg
         if (deps) {
-          Object.keys(deps).map((dep) => {
-            const reg = new RegExp(dep + '/', 'g')
-            const match = url.match(reg)
-            if (match && match.length > 0 && matchLength < match[0].length) {
-              matchLength = match[0].length
-              pkg = dep
-            }
-          })
-          if (pkg) {
-            let version
-            if (yarnLock) {
-              // yarn.lock
-              const regex = new RegExp(`"${pkg}@(.*)"`, 'g')
-              const yarnVersion = regex.exec(yarnLock)
-              if (yarnVersion && yarnVersion.length > 1) {
-                version = yarnVersion[1]
-              }
-            }
-            if (!version && packageLock && packageLock['dependencies'] && packageLock['dependencies'][pkg] && packageLock['dependencies'][pkg]['version']) {
-              // package-lock.json
-              version = packageLock['dependencies'][pkg]['version']
-            }
-            if (!version) {
-              // package.json
-              version = deps[pkg]
-            }
-            if (version) {
-              // If the entry is pointing to a github repo, redirect to correct handler instead of continuing
-              if (version.startsWith("github:")) {
-                const [, repo, tag] = version.match(/github:([^#]+)#(.+)/);
-                const filePath = url.replace(/^[^/]+\//, '');
-                return this.handleGithubCall(repo, `blob/${tag}/${filePath}`);
-              }
-              const versionSemver = semver.minVersion(version)
-              fetchUrl = url.replace(pkg, `${pkg}@${versionSemver.version}`)
-            }
+          // Packages have usually a slash in the name which make it difficult to distinguish them from a path.
+          // we first try to resolve the path with a slash. packages like @openzepplin/contracts will be resolved in that case.
+          let transformedUrl = getPkg(fetchUrl.split('/')[0] + '/' + fetchUrl.split('/')[1], yarnLock, packageLock, deps, url, fetchUrl)
+          if (!transformedUrl) {
+            // then we fallback to the case where the package doesn't have a slash in its name.
+            transformedUrl = getPkg(fetchUrl.split('/')[0], yarnLock, packageLock, deps, url, fetchUrl)
+          }
+          if (transformedUrl) {
+            fetchUrl = transformedUrl
           }
         }
       } catch (e) {
@@ -268,4 +238,45 @@ export class RemixURLResolver {
 // see npm semver-regex
 function semverRegex() {
   return /(?<=^v?|\sv?)(?:(?:0|[1-9]\d{0,9}?)\.){2}(?:0|[1-9]\d{0,9})(?:-(?:--+)?(?:0|[1-9]\d*|\d*[a-z]+\d*)){0,100}(?=$| |\+|\.)(?:(?<=-\S+)(?:\.(?:--?|[\da-z-]*[a-z-]\d*|0|[1-9]\d*)){1,100}?)?(?!\.)(?:\+(?:[\da-z]\.?-?){1,100}?(?!\w))?(?!\+)/gi;
+}
+
+function getPkg(pkg, yarnLock, packageLock, deps, url, fetchUrl) {
+  let version
+  if (yarnLock) {
+    // yarn.lock
+    const regex = new RegExp(`"${pkg}@(.*)"`, 'g')
+    const yarnVersion = regex.exec(yarnLock)
+    if (yarnVersion && yarnVersion.length > 1) {
+      version = yarnVersion[1]
+    }
+  }
+  if (!version && packageLock && packageLock['packages'] && packageLock['packages']['node_modules/' + pkg] && packageLock['packages']['node_modules/' + pkg]['version']) {
+    // package-lock.json version 3
+    version = packageLock['packages']['node_modules/' + pkg]['version']
+  }
+  if (!version && packageLock && packageLock['dependencies'] && packageLock['dependencies'][pkg] && packageLock['dependencies'][pkg]['version']) {
+    // package-lock.json version 2
+    version = packageLock['dependencies'][pkg]['version']
+  }
+  // package.json
+  if (deps[pkg]) {
+    version = deps[pkg]
+  }
+  if (version) {
+    // If the entry is pointing to a github repo, redirect to correct handler instead of continuing
+    if (version.startsWith("github:")) {
+      const [, repo, tag] = version.match(/github:([^#]+)#(.+)/);
+      const filePath = url.replace(/^[^/]+\//, '');
+      return this.handleGithubCall(repo, `blob/${tag}/${filePath}`);
+    }
+    if (version.startsWith('npm:')) {
+      fetchUrl = url.replace(pkg, version.replace('npm:', ''))
+      return fetchUrl
+    } else {
+      // const versionSemver = semver.minVersion(version)
+      fetchUrl = url.replace(pkg, `${pkg}@${version}`)
+      return fetchUrl
+    }
+  }
+  return null
 }


### PR DESCRIPTION
- L273: check if the version contains `npm:` and replace the value if this is the case.
- resolving deps would only work before for dependencies that are specified in the package.json, not the sub-deps present in yarn or in package-lock.json.
So instead of looking at the deps L150 and then trying to resolve the version, we just infer the package name from the fetchUrl.