### PR TITLE
refactor & allow saving already forked state

### DIFF
--- a/apps/remix-ide/src/blockchain/blockchain.tsx
+++ b/apps/remix-ide/src/blockchain/blockchain.tsx
@@ -12,6 +12,8 @@ import { NodeProvider } from './providers/node'
 import { execution, EventManager, helpers } from '@remix-project/remix-lib'
 import { etherScanLink } from './helper'
 import { logBuilder, cancelUpgradeMsg, cancelProxyMsg, addressToString } from '@remix-ui/helper'
+import { Provider } from '@remix-ui/environment-explorer'
+
 const { txFormat, txExecution, typeConversion, txListener: Txlistener, TxRunner, TxRunnerWeb3, txHelper } = execution
 const { txResultHelper } = helpers
 const { resultToRemixTx } = txResultHelper
@@ -44,6 +46,15 @@ export type Transaction = {
   timestamp?: number
 }
 
+/*
+export type ProviderConfig = {
+  isVM: boolean
+  isInjected: boolean
+  isRpcForkedState?: boolean
+  isVMStateForked?: boolean
+  statePath?: string
+}
+
 export type Provider = {
   options: { [key: string]: string }
   dataId: string
@@ -53,16 +64,13 @@ export type Provider = {
   logos?: string[],
   fork: string
   description?: string
-  isInjected: boolean
-  isVM: boolean
-  isForkedState: boolean
-  isForkedVM: boolean
+  config: ProviderConfig
   title: string
   init: () => Promise<void>
   provider:{
     sendAsync: (payload: any) => Promise<void>
   }
-}
+}*/
 
 export class Blockchain extends Plugin {
   active: boolean

--- a/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
+++ b/libs/remix-ui/environment-explorer/src/lib/components/environment-explorer-ui.tsx
@@ -9,19 +9,19 @@ const defaultSections: environmentExplorerUIGridSections = {
     title: 'Deploy using a Browser Extension.',
     keywords: ['Injected'],
     providers: [],
-    filterFn: (provider) => provider.isInjected
+    filterFn: (provider) => provider.config.isInjected
   },
   'Remix VMs': {
     title: 'Deploy to an In-browser Virtual Machine.',
     keywords: ['Remix VMs'],
     providers: [],
-    filterFn: (provider) => provider.isVM && !provider.isForkedVM
+    filterFn: (provider) => provider.config.isVM && !provider.config.isVMStateForked && !provider.config.isRpcForkedState
   },
   'Forked States': {
     title: 'Deploy to an In-browser Forked State.',
     keywords: ['Forked State'],
     providers: [],
-    filterFn: (provider) => provider.isForkedState,
+    filterFn: (provider) => provider.config.isVMStateForked,
     descriptionFn: (provider) => {
       const { latestBlock, timestamp } = JSON.parse(provider.description)
       return (
@@ -38,16 +38,16 @@ const defaultSections: environmentExplorerUIGridSections = {
     }
   },
   'Remix forked VMs': {
-    title: 'Deploy to a Remix forked Virtual Machine.',
+    title: 'Deploy to a Live forked Virtual Machine.',
     keywords: ['Remix forked VMs'],
     providers: [],
-    filterFn: (provider) => provider.isForkedVM
+    filterFn: (provider) => provider.config.isRpcForkedState
   },
   'Externals': {
     title: 'Deploy to an external Provider.',
     keywords: ['Externals'],
     providers: [],
-    filterFn: (provider) => (!provider.isInjected && !provider.isVM && !provider.isForkedState && !provider.isForkedVM)
+    filterFn: (provider) => (!provider.config.isInjected && !provider.config.isVM && !provider.config.isRpcForkedState && !provider.config.isVMStateForked)
   },
 }
 export const EnvironmentExplorerUI = (props: environmentExplorerUIProps) => {
@@ -102,7 +102,7 @@ export const EnvironmentExplorerUI = (props: environmentExplorerUIProps) => {
                   }}
                 >
                   <div data-id={`${provider.name}desc`}>{(section.descriptionFn && section.descriptionFn(provider)) || provider.description}</div>
-                  { provider.isForkedState && <CustomTooltip
+                  { provider.config.isVMStateForked && <CustomTooltip
                     placement="auto"
                     tooltipId={`overlay-tooltip-${provider.name}`}
                     tooltipText="Delete Environment Immediately"

--- a/libs/remix-ui/environment-explorer/src/lib/types/index.ts
+++ b/libs/remix-ui/environment-explorer/src/lib/types/index.ts
@@ -26,7 +26,16 @@ export type environmentExplorerUIGridSections = {
   [key in ProvidersSection]: environmentExplorerUIGridSection
 }
 
+export type ProviderConfig = {
+  isVM: boolean
+  isInjected: boolean
+  isRpcForkedState?: boolean
+  isVMStateForked?: boolean
+  statePath?: string
+}
+
 export type Provider = {
+  position: number
   options: { [key: string]: string }
   dataId: string
   name: string
@@ -35,13 +44,10 @@ export type Provider = {
   logos?: string[],
   fork: string
   description?: string
-  isInjected: boolean
-  isVM: boolean
-  isForkedState: boolean
-  isForkedVM: boolean
+  config: ProviderConfig
   title: string
   init: () => Promise<void>
-  provider: {
+  provider:{
     sendAsync: (payload: any) => Promise<void>
   }
 }

--- a/libs/remix-ui/run-tab/src/lib/components/environment.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/environment.tsx
@@ -1,7 +1,8 @@
 // eslint-disable-next-line no-use-before-define
 import React, { useRef } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
-import { EnvironmentProps, Provider } from '../types'
+import { EnvironmentProps } from '../types'
+import { Provider } from '@remix-ui/environment-explorer'
 import { Dropdown } from 'react-bootstrap'
 import { CustomMenu, CustomToggle, CustomTooltip } from '@remix-ui/helper'
 const _paq = (window._paq = window._paq || [])
@@ -9,9 +10,9 @@ const _paq = (window._paq = window._paq || [])
 export function EnvironmentUI(props: EnvironmentProps) {
   const vmStateName = useRef('')
 
-  Object.entries(props.providers.providerList.filter((provider) => { return provider.isVM }))
-  Object.entries(props.providers.providerList.filter((provider) => { return provider.isInjected }))
-  Object.entries(props.providers.providerList.filter((provider) => { return !(provider.isVM || provider.isInjected) }))
+  Object.entries(props.providers.providerList.filter((provider) => { return provider.config.isVM }))
+  Object.entries(props.providers.providerList.filter((provider) => { return provider.config.isInjected }))
+  Object.entries(props.providers.providerList.filter((provider) => { return !(provider.config.isVM || provider.config.isInjected) }))
 
   const handleChangeExEnv = (env: string) => {
     const provider = props.providers.providerList.find((exEnv) => exEnv.name === env)
@@ -65,14 +66,14 @@ export function EnvironmentUI(props: EnvironmentProps) {
     _paq.push(['trackEvent', 'udapp', 'forkState', `forkState clicked`])
     const context = currentProvider.name
     vmStateName.current = `${context}_${Date.now()}`
-    const contextExists = await props.runTabPlugin.call('fileManager', 'exists', `.states/${context}/state.json`)
+    const contextExists = await props.runTabPlugin.call('fileManager', 'exists', currentProvider.config.statePath)
     if (contextExists) {
       props.modal(
         intl.formatMessage({ id: 'udapp.forkStateTitle' }),
         forkStatePrompt(vmStateName.current),
         intl.formatMessage({ id: 'udapp.fork' }),
         async () => {
-          let currentStateDb = await props.runTabPlugin.call('fileManager', 'readFile', `.states/${context}/state.json`)
+          let currentStateDb = await props.runTabPlugin.call('fileManager', 'readFile', currentProvider.config.statePath)
           currentStateDb = JSON.parse(currentStateDb)
           currentStateDb.stateName = vmStateName.current
           currentStateDb.forkName = currentProvider.fork
@@ -121,12 +122,12 @@ export function EnvironmentUI(props: EnvironmentProps) {
     <div className="udapp_crow">
       <label id="selectExEnv" className="udapp_settingsLabel w-100">
         <FormattedMessage id="udapp.environment" />
-        { currentProvider && currentProvider.isVM && isSaveEvmStateChecked && <CustomTooltip placement={'auto-end'} tooltipClasses="text-wrap" tooltipId="forkStatetooltip" tooltipText={<FormattedMessage id="udapp.forkStateTitle" />}>
+        { currentProvider && currentProvider.config.isVM && isSaveEvmStateChecked && <CustomTooltip placement={'auto-end'} tooltipClasses="text-wrap" tooltipId="forkStatetooltip" tooltipText={<FormattedMessage id="udapp.forkStateTitle" />}>
           <i className="udapp_infoDeployAction ml-2 fas fa-code-branch" style={{ cursor: 'pointer' }} onClick={forkState} data-id="fork-state-icon"></i>
         </CustomTooltip> }
-        { currentProvider && currentProvider.isVM && isSaveEvmStateChecked && <CustomTooltip placement={'auto-end'} tooltipClasses="text-wrap" tooltipId="deleteVMStatetooltip" tooltipText={<FormattedMessage id="udapp.resetVmStateTitle" />}>
+        { currentProvider && currentProvider.config.isVM && isSaveEvmStateChecked && !currentProvider.config.isVMStateForked && !currentProvider.config.isRpcForkedState && <CustomTooltip placement={'auto-end'} tooltipClasses="text-wrap" tooltipId="deleteVMStatetooltip" tooltipText={<FormattedMessage id="udapp.resetVmStateTitle" />}>
           <span onClick={resetVmState} style={{ cursor: 'pointer', float: 'right', textTransform: 'none' }}>
-            <i className="udapp_infoDeployAction ml-2 fas fa-refresh" data-id="delete-state-icon"></i>
+            <i className="udapp_infoDeployAction ml-2 fas fa-refresh fa-solid fa-rotate-right" data-id="delete-state-icon"></i>
             <span className="ml-1" style = {{ textTransform: 'none', fontSize: '13px' }}>Reset State</span>
           </span>
         </CustomTooltip> }
@@ -155,7 +156,7 @@ export function EnvironmentUI(props: EnvironmentProps) {
                 No provider pinned
               </span>
             </Dropdown.Item>}
-            { (props.providers.providerList.filter((provider) => { return provider.isInjected })).map(({ name, displayName }) => (
+            { (props.providers.providerList.filter((provider) => { return provider.config.isInjected })).map(({ name, displayName }) => (
               <Dropdown.Item
                 key={name}
                 onClick={async () => {
@@ -168,8 +169,8 @@ export function EnvironmentUI(props: EnvironmentProps) {
                 </span>
               </Dropdown.Item>
             ))}
-            { props.providers.providerList.filter((provider) => { return provider.isInjected }).length !== 0 && <Dropdown.Divider className='border-secondary'></Dropdown.Divider> }
-            { (props.providers.providerList.filter((provider) => { return provider.isVM })).map(({ displayName, name }) => (
+            { props.providers.providerList.filter((provider) => { return provider.config.isInjected }).length !== 0 && <Dropdown.Divider className='border-secondary'></Dropdown.Divider> }
+            { (props.providers.providerList.filter((provider) => { return provider.config.isVM })).map(({ displayName, name }) => (
               <Dropdown.Item
                 key={name}
                 onClick={() => {
@@ -182,8 +183,8 @@ export function EnvironmentUI(props: EnvironmentProps) {
                 </span>
               </Dropdown.Item>
             ))}
-            { props.providers.providerList.filter((provider) => { return provider.isVM }).length !== 0 && <Dropdown.Divider className='border-secondary'></Dropdown.Divider> }
-            { (props.providers.providerList.filter((provider) => { return !(provider.isVM || provider.isInjected) })).map(({ displayName, name }) => (
+            { props.providers.providerList.filter((provider) => { return provider.config.isVM }).length !== 0 && <Dropdown.Divider className='border-secondary'></Dropdown.Divider> }
+            { (props.providers.providerList.filter((provider) => { return !(provider.config.isVM || provider.config.isInjected) })).map(({ displayName, name }) => (
               <Dropdown.Item
                 key={name}
                 onClick={() => {

--- a/libs/remix-ui/run-tab/src/lib/types/index.ts
+++ b/libs/remix-ui/run-tab/src/lib/types/index.ts
@@ -3,6 +3,7 @@ import { CompilerAbstract } from '@remix-project/remix-solidity'
 import { ContractData, FuncABI, OverSizeLimit } from '@remix-project/core-plugin'
 import { RunTab } from './run-tab'
 import { SolcInput, SolcOutput } from '@openzeppelin/upgrades-core'
+import { Provider } from '@remix-ui/environment-explorer'
 import { LayoutCompatibilityReport } from '@openzeppelin/upgrades-core/dist/storage/report'
 import { CheckStatus } from '../run-tab'
 export interface RunTabProps {
@@ -22,6 +23,7 @@ export interface ContractList {
   [file: string]: Contract[]
 }
 
+/*
 export type Provider = {
   name: string
   displayName: string
@@ -35,8 +37,11 @@ export type Provider = {
   fork: boolean
   isVM: boolean
   isInjected: boolean
+  isRpcForkedState?: boolean
+  isVMStateForked?: boolean
+  statePath?: string
   position: number
-}
+}*/
 
 export interface RunTabState {
   accounts: {


### PR DESCRIPTION
- refactor: set a `config` property instead of having all the properties flat.
- refactor the `Provider` type.
- add a new property: `isRpcForkedState`, `statePath` and `isVMStateForked`