### PR TITLE
fix metamask signing

### DIFF
--- a/apps/remix-ide/src/blockchain/providers/injected.ts
+++ b/apps/remix-ide/src/blockchain/providers/injected.ts
@@ -43,7 +43,7 @@ export class InjectedProvider {
     try {
       const personal = new Personal(this.executionContext.web3().currentProvider)
       message = isHexString(message) ? message : Web3.utils.utf8ToHex(message)
-      personal.sign(message, account, passphrase)
+      personal.sign(message, account, '')
         .then(signedData => cb(undefined, bytesToHex(messageHash), signedData))
         .catch(error => cb(error, bytesToHex(messageHash), undefined))
     } catch (e) {

--- a/apps/remix-ide/src/blockchain/providers/injected.ts
+++ b/apps/remix-ide/src/blockchain/providers/injected.ts
@@ -39,15 +39,15 @@ export class InjectedProvider {
   }
 
   signMessage (message, account, _passphrase, cb) {
-    message = isHexString(message) ? message : Web3.utils.utf8ToHex(message)
     const messageHash = hashPersonalMessage(Buffer.from(message))
     try {
       const personal = new Personal(this.executionContext.web3().currentProvider)
-      personal.sign(messageHash, account, '').then((signedData) => {
-        cb(null, bytesToHex(messageHash), signedData)
-      }).catch((error => cb(error)))
+      message = isHexString(message) ? message : Web3.utils.utf8ToHex(message)
+      personal.sign(message, account, passphrase)
+        .then(signedData => cb(undefined, bytesToHex(messageHash), signedData))
+        .catch(error => cb(error, bytesToHex(messageHash), undefined))
     } catch (e) {
       cb(e.message)
-    }
+    }    
   }
 }

--- a/apps/remix-ide/src/blockchain/providers/injected.ts
+++ b/apps/remix-ide/src/blockchain/providers/injected.ts
@@ -1,5 +1,6 @@
 import { Web3 } from 'web3'
 import { hashPersonalMessage, isHexString, bytesToHex } from '@ethereumjs/util'
+import { Personal } from 'web3-eth-personal'
 import { ExecutionContext } from '../execution-context'
 
 export class InjectedProvider {
@@ -41,7 +42,8 @@ export class InjectedProvider {
     message = isHexString(message) ? message : Web3.utils.utf8ToHex(message)
     const messageHash = hashPersonalMessage(Buffer.from(message))
     try {
-      this.executionContext.web3().personal.sign(messageHash, account).then((signedData) => {
+      const personal = new Personal(this.executionContext.web3().currentProvider)
+      personal.sign(messageHash, account).then((signedData) => {
         cb(null, bytesToHex(messageHash), signedData)
       }).catch((error => cb(error)))
     } catch (e) {

--- a/apps/remix-ide/src/blockchain/providers/injected.ts
+++ b/apps/remix-ide/src/blockchain/providers/injected.ts
@@ -48,6 +48,6 @@ export class InjectedProvider {
         .catch(error => cb(error, bytesToHex(messageHash), undefined))
     } catch (e) {
       cb(e.message)
-    }    
+    }
   }
 }

--- a/apps/remix-ide/src/blockchain/providers/injected.ts
+++ b/apps/remix-ide/src/blockchain/providers/injected.ts
@@ -43,6 +43,7 @@ export class InjectedProvider {
     try {
       const personal = new Personal(this.executionContext.web3().currentProvider)
       message = isHexString(message) ? message : Web3.utils.utf8ToHex(message)
+      // see https://docs.metamask.io/wallet/reference/json-rpc-methods/personal_sign/
       personal.sign(message, account, '')
         .then(signedData => cb(undefined, bytesToHex(messageHash), signedData))
         .catch(error => cb(error, bytesToHex(messageHash), undefined))

--- a/apps/remix-ide/src/blockchain/providers/injected.ts
+++ b/apps/remix-ide/src/blockchain/providers/injected.ts
@@ -41,7 +41,7 @@ export class InjectedProvider {
     message = isHexString(message) ? message : Web3.utils.utf8ToHex(message)
     const messageHash = hashPersonalMessage(Buffer.from(message))
     try {
-      this.executionContext.web3().eth.sign(messageHash, account).then((signedData) => {
+      this.executionContext.web3().personal.sign(messageHash, account).then((signedData) => {
         cb(null, bytesToHex(messageHash), signedData)
       }).catch((error => cb(error)))
     } catch (e) {

--- a/apps/remix-ide/src/blockchain/providers/injected.ts
+++ b/apps/remix-ide/src/blockchain/providers/injected.ts
@@ -43,7 +43,7 @@ export class InjectedProvider {
     const messageHash = hashPersonalMessage(Buffer.from(message))
     try {
       const personal = new Personal(this.executionContext.web3().currentProvider)
-      personal.sign(messageHash, account).then((signedData) => {
+      personal.sign(messageHash, account, '').then((signedData) => {
         cb(null, bytesToHex(messageHash), signedData)
       }).catch((error => cb(error)))
     } catch (e) {


### PR DESCRIPTION
This fixes signing message with metamask.
I've got confused on one of my last PR, this causes to break metamask signing.
The reason is that even if metamask uses `personal.sign`, it doesn't not make use of the password property, what I was thinking to be a bug was actually correct..