### PR TITLE
Why "px" is important app.css

### DIFF
--- a/apps/vyper/src/app/app.css
+++ b/apps/vyper/src/app/app.css
@@ -95,7 +95,7 @@ html, body, #root, main {
 }
 
 #result .copy {
-  padding: 5x;
+  padding: 5px;
   font-size: 0.8rem;
   margin: 10px;
 }


### PR DESCRIPTION
Without "px", the value is not recognized by the browser, so the style won't be applied.
