### PR TITLE
Verification plugin: Disable verification when Etherscan is selected and no constructor arguments are provided

### DIFF
--- a/apps/contract-verification/src/app/components/ConstructorArguments.tsx
+++ b/apps/contract-verification/src/app/components/ConstructorArguments.tsx
@@ -44,12 +44,16 @@ export const ConstructorArguments: React.FC<ConstructorArgumentsProps> = ({ abiE
 
   const constructorArgsInInitialState = useRef(true)
   useEffect(() => {
+    // Ensures that error is not reset when tabs are switched
+    if ((!abiEncodingError && !abiEncodedConstructorArgs) || !constructorArgsInInitialState.current) {
+      setAbiEncodingError(constructorArgs?.length === 0 ? '' : 'Some constructor arguments are missing')
+    }
+
     if (constructorArgsInInitialState.current) {
       constructorArgsInInitialState.current = false
       return
     }
     setAbiEncodedConstructorArgs('')
-    setAbiEncodingError('')
     setConstructorArgsValues(Array(constructorArgs?.length ?? 0).fill(''))
   }, [constructorArgs])
 
@@ -60,7 +64,7 @@ export const ConstructorArguments: React.FC<ConstructorArgumentsProps> = ({ abiE
     // if any constructorArgsValue is falsey (empty etc.), don't encode yet
     if (changedConstructorArgsValues.some((value) => !value)) {
       setAbiEncodedConstructorArgs('')
-      setAbiEncodingError('')
+      setAbiEncodingError('Some constructor arguments are missing')
       return
     }
 
@@ -112,7 +116,7 @@ export const ConstructorArguments: React.FC<ConstructorArgumentsProps> = ({ abiE
         <div>
           {' '}
           <textarea className="form-control" rows={5} placeholder="0x00000000000000000000000000000000d41867734bbee4c6863d9255b2b06ac1..." value={abiEncodedConstructorArgs} onChange={(e) => handleRawConstructorArgs(e.target.value)} />
-          {abiEncodingError && <div className="text-danger small">{abiEncodingError}</div>}
+          {abiEncodedConstructorArgs && abiEncodingError && <div className="text-danger small">{abiEncodingError}</div>}
         </div>
       ) : (
         <div>
@@ -133,7 +137,7 @@ export const ConstructorArguments: React.FC<ConstructorArgumentsProps> = ({ abiE
               <textarea className="form-control" rows={5} disabled value={abiEncodedConstructorArgs} id="rawAbiEncodingResult" style={{ opacity: 0.5 }} />
             </div>
           )}
-          {abiEncodingError && <div className="text-danger small">{abiEncodingError}</div>}
+          {constructorArgsValues.some((value) => !!value) && abiEncodingError && <div className="text-danger small">{abiEncodingError}</div>}
         </div>
       )}
     </div>

--- a/apps/contract-verification/src/app/views/VerifyView.tsx
+++ b/apps/contract-verification/src/app/views/VerifyView.tsx
@@ -270,7 +270,7 @@ export const VerifyView = () => {
         (!!contractAddressError || !contractAddress) ? <FormattedMessage id="contract-verification.contractAddressError" defaultMessage="Please provide a valid contract address." /> :
           !selectedChain ? <FormattedMessage id="contract-verification.chainError" defaultMessage="Please select the chain." /> :
             !selectedContract ? <FormattedMessage id="contract-verification.selectedContractError" defaultMessage="Please select the contract." /> :
-              enabledVerifiers['Etherscan'] && !abiEncodedConstructorArgs && !!abiEncodingError ? <FormattedMessage id="contract-verification.constructorArgumentsError" defaultMessage="Etherscan requires constructor arguments." /> :
+              enabledVerifiers['Etherscan'] && !abiEncodedConstructorArgs && !!abiEncodingError ? <FormattedMessage id="contract-verification.constructorArgumentsError" defaultMessage="Must provide constructor arguments if verifying on Etherscan" /> :
                 ((hasProxy && !!proxyAddressError) || (hasProxy && !proxyAddress)) ? <FormattedMessage id="contract-verification.proxyAddressError" defaultMessage="Please provide a valid proxy address." /> :
                   <FormattedMessage id="contract-verification.generalVerifyError" defaultMessage={"Please provide all necessary data to verify"} />) // Is not expected to be a case
         : <FormattedMessage id="contract-verification.verifyButtonTooltip" defaultMessage="Verify the contract on the selected chains with the selected verifiers." />}>

--- a/apps/contract-verification/src/app/views/VerifyView.tsx
+++ b/apps/contract-verification/src/app/views/VerifyView.tsx
@@ -25,7 +25,7 @@ export const VerifyView = () => {
   const sourcifySupported = useSourcifySupported(selectedChain, chainSettings)
 
   const noVerifierEnabled = VERIFIERS.every((verifierId) => !validConfiguration(chainSettings, verifierId) || (verifierId === 'Sourcify' && !sourcifySupported)) || Object.values(enabledVerifiers).every((enabled) => !enabled)
-  const submitDisabled = !!contractAddressError || !contractAddress || !selectedChain || !selectedContract || (hasProxy && !!proxyAddressError) || (hasProxy && !proxyAddress) || noVerifierEnabled
+  const submitDisabled = !!contractAddressError || !contractAddress || !selectedChain || !selectedContract || (hasProxy && !!proxyAddressError) || (hasProxy && !proxyAddress) || noVerifierEnabled || (enabledVerifiers['Etherscan'] && !abiEncodedConstructorArgs && !!abiEncodingError)
 
   // Enable all verifiers with valid configuration
   useEffect(() => {
@@ -270,8 +270,9 @@ export const VerifyView = () => {
         (!!contractAddressError || !contractAddress) ? <FormattedMessage id="contract-verification.contractAddressError" defaultMessage="Please provide a valid contract address." /> :
           !selectedChain ? <FormattedMessage id="contract-verification.chainError" defaultMessage="Please select the chain." /> :
             !selectedContract ? <FormattedMessage id="contract-verification.selectedContractError" defaultMessage="Please select the contract." /> :
-              ((hasProxy && !!proxyAddressError) || (hasProxy && !proxyAddress)) ? <FormattedMessage id="contract-verification.proxyAddressError" defaultMessage="Please provide a valid proxy address." /> :
-                <FormattedMessage id="contract-verification.generalVerifyError" defaultMessage={"Please provide all necessary data to verify"} />) // Is not expected to be a case
+              enabledVerifiers['Etherscan'] && !abiEncodedConstructorArgs && !!abiEncodingError ? <FormattedMessage id="contract-verification.constructorArgumentsError" defaultMessage="Etherscan requires constructor arguments." /> :
+                ((hasProxy && !!proxyAddressError) || (hasProxy && !proxyAddress)) ? <FormattedMessage id="contract-verification.proxyAddressError" defaultMessage="Please provide a valid proxy address." /> :
+                  <FormattedMessage id="contract-verification.generalVerifyError" defaultMessage={"Please provide all necessary data to verify"} />) // Is not expected to be a case
         : <FormattedMessage id="contract-verification.verifyButtonTooltip" defaultMessage="Verify the contract on the selected chains with the selected verifiers." />}>
         <button type="submit" className="w-100 btn btn-primary mt-3" disabled={submitDisabled}>
           <FormattedMessage id="contract-verification.verifyButton" defaultMessage="Verify" />


### PR DESCRIPTION
We wanted to improve the user feedback on the verification plugin a little. Etherscan is the only verifier that requires constructor arguments. Before this change, the user could hit the verify button even if no constructor arguments are provided. With this change, the verify button gets disabled if Etherscan is selected and no constructor arguments are provided.