### PR TITLE
Terminology Update: Replace 'Master' with 'Main' and Grammar Fixes

### DIFF
--- a/apps/remix-ide-e2e/src/local-plugin/.browserslistrc
+++ b/apps/remix-ide-e2e/src/local-plugin/.browserslistrc
@@ -10,7 +10,7 @@
 last 1 Chrome version
 last 1 Firefox version
 last 2 Edge major versions
-last 2 Safari major version
+last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR
 not IE 9-11 # For IE 9-11 support, remove 'not'.

--- a/automation.md
+++ b/automation.md
@@ -18,7 +18,7 @@
  
  - **Autorebase** will automatically rebase the branch (when a new commit lands on master).
  
-   It won't automatically merge to master (this can be done with the first automation).
+   It won't automatically merge into the main branch (this can be done with the first automation).
    
    It is activated by adding the `autorebase` label.
  


### PR DESCRIPTION
Updated Terminology for Branch Merging

Old Phrase: "It won't automatically merge to master."
New Phrase: "It won't automatically merge into the main branch."
File Updated: automation.md (or the relevant file name)
Reason for Change: This change reflects the modern terminology of referring to the default branch as "main" instead of "master," promoting inclusivity and aligning with current best practices in software development.
Minor Grammar Correction

Old Phrase: "last 2 Safari major version"
New Phrase: "last 2 Safari major versions"
File Updated: browser_support.md (or the relevant file name)
Reason for Change: Correcting the grammatical error ensures clarity and accuracy in communication.