### PR TITLE
Verification plugin: Decode BigNumbers to decimal values, not to objects

### DIFF
--- a/apps/contract-verification/src/app/components/ConstructorArguments.tsx
+++ b/apps/contract-verification/src/app/components/ConstructorArguments.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useRef, useState } from 'react'
-import { ethers } from 'ethers'
+import { BigNumber, ethers } from 'ethers'
 
 import { AppContext } from '../AppContext'
 import { ContractDropdownSelection } from './ContractDropdown'
@@ -30,7 +30,12 @@ export const ConstructorArguments: React.FC<ConstructorArgumentsProps> = ({ abiE
         constructorArgs.map((inp) => inp.type),
         value
       )
-      const decoded = decodedObj.map((val) => JSON.stringify(val))
+      const decoded = decodedObj.map((val) => {
+        if (val instanceof BigNumber) {
+          return val.toString()
+        }
+        return JSON.stringify(val)
+      })
       return { decoded, errorMessage: '' }
     } catch (e) {
       console.error(e)
@@ -107,9 +112,7 @@ export const ConstructorArguments: React.FC<ConstructorArgumentsProps> = ({ abiE
       <div className="d-flex py-1 align-items-center custom-control custom-checkbox">
         <input className="form-check-input custom-control-input" type="checkbox" id="toggleRawInputSwitch" checked={toggleRawInput} onChange={() => setToggleRawInput(!toggleRawInput)} />
         <label className="m-0 form-check-label custom-control-label" style={{ paddingTop: '2px' }} htmlFor="toggleRawInputSwitch">
-          <FormattedMessage
-            id="contract-verification.constructorArgumentsToggleRawInput"
-          />
+          <FormattedMessage id="contract-verification.constructorArgumentsToggleRawInput" />
         </label>
       </div>
       {toggleRawInput ? (
@@ -129,10 +132,7 @@ export const ConstructorArguments: React.FC<ConstructorArgumentsProps> = ({ abiE
           {abiEncodedConstructorArgs && (
             <div>
               <label className="form-check-label" htmlFor="rawAbiEncodingResult">
-                <FormattedMessage
-                  id="contract-verification.constructorArgumentsRawAbiEncodingResult"
-                  defaultMessage="ABI-encoded constructor arguments"
-                /> :
+                <FormattedMessage id="contract-verification.constructorArgumentsRawAbiEncodingResult" defaultMessage="ABI-encoded constructor arguments" /> :
               </label>
               <textarea className="form-control" rows={5} disabled value={abiEncodedConstructorArgs} id="rawAbiEncodingResult" style={{ opacity: 0.5 }} />
             </div>


### PR DESCRIPTION
Fixes a problem where numbers were transformed to this BigNumber object in the constructor argument fields:

<img width="392" alt="Screenshot_2025-03-05_at_3 39 03_PM" src="https://github.com/user-attachments/assets/0ac0aa5f-e9c6-4771-bed2-28e40b368c17" />
