### PR TITLE
fix: dead links to `hardforks` in CLI help text

### DIFF
--- a/libs/remix-tests/src/run.ts
+++ b/libs/remix-tests/src/run.ts
@@ -52,7 +52,7 @@ commander
   .option('-o, --optimize <bool>', 'enable/disable optimization', mapOptimize)
   .option('-r, --runs <number>', 'set runs (e.g: 150, 250 etc)')
   .option('-v, --verbose <level>', 'set verbosity level (0 to 5)', mapVerbosity)
-  .option('-f, --fork <string>', 'set hard fork (e.g: istanbul, berlin etc. See full list of hard forks here: https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/common/src/hardforks)')
+  .option('-f, --fork <string>', 'set hard fork (e.g: istanbul, berlin etc. See full list of hard forks here: https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/common/src/hardforks.ts)')
   .option('-n, --nodeUrl <string>', 'set node url (e.g: https://mainnet.infura.io/v3/your-api-key)')
   .option('-b, --blockNumber <string>', 'set block number (e.g: 123456)')
   .option('-k, --killProcess <bool>', 'kill process when tests fail')

--- a/libs/remix-tests/tests/testRunner.cli.spec.ts
+++ b/libs/remix-tests/tests/testRunner.cli.spec.ts
@@ -45,7 +45,7 @@ Options:
   -v, --verbose <level>       set verbosity level (0 to 5)
   -f, --fork <string>         set hard fork (e.g: istanbul, berlin etc. See
                               full list of hard forks here:
-                              https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/common/src/hardforks)
+                              https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/common/src/hardforks.ts)
   -n, --nodeUrl <string>      set node url (e.g:
                               https://mainnet.infura.io/v3/your-api-key)
   -b, --blockNumber <string>  set block number (e.g: 123456)


### PR DESCRIPTION
Hi! The `--fork` option description in the CLI (`remix-tests`) contained a broken link to the list of supported hard forks. Previously, it pointed to the [`hardforks` directory](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/common/src/hardforks), which resulted in a 404 error.

My change aligns with the fix proposed in [Pull Request #2911](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2911), where the link structure was [updated](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2911/files#diff-9b9d68281d741e3b33507481522e4232a3f192ff861a5fa2d46a75656992e0f4).  