### PR TITLE
docs: fix broken links in the code

### DIFF
--- a/apps/remix-ide/src/app/plugins/code-format/index.ts
+++ b/apps/remix-ide/src/app/plugins/code-format/index.ts
@@ -6,7 +6,7 @@ import loc from 'prettier-plugin-solidity/src/loc.js';
 import { parse } from './parser'
 
 // https://prettier.io/docs/en/plugins.html#languages
-// https://github.com/ikatyang/linguist-languages/blob/master/data/Solidity.json
+// https://github.com/ikatyang/linguist-languages/blob/master/data/Solidity.js
 const languages = [
   {
     linguistLanguageId: 237469032,

--- a/libs/remix-debug/src/solidity-decoder/types/Mapping.ts
+++ b/libs/remix-debug/src/solidity-decoder/types/Mapping.ts
@@ -62,7 +62,7 @@ export class Mapping extends RefType {
 }
 
 function getMappingLocation (key, position) {
-  // mapping storage location described at http://solidity.readthedocs.io/en/develop/miscellaneous.html#layout-of-state-variables-in-storage
+  // mapping storage location described at http://solidity.readthedocs.io/en/v0.6.6/miscellaneous.html#layout-of-state-variables-in-storage
   // > the value corresponding to a mapping key k is located at keccak256(k . p) where . is concatenation.
 
   // key should be a hex string, and position an int


### PR DESCRIPTION
Hi! I updated two broken links in the code:

- In `index.ts`, fixed the link to `Solidity.js`, the old one was dead.  
- In `Mapping.ts`, updated the Solidity docs link to point to the correct version.

Just comment fixes, no logic changes.
