### PR TITLE
Fix OpenZeppelin ERC20 Contract Path

### DIFF
--- a/apps/remix-ide-e2e/src/tests/terminal.test.ts
+++ b/apps/remix-ide-e2e/src/tests/terminal.test.ts
@@ -69,7 +69,7 @@ module.exports = {
       .pause(1000)
       .executeScriptInTerminal('remix.execute(\'resolveExternalUrlAndSave.js\')')
       .waitForElementContainsText('*[data-id="terminalJournal"]', 'Implementation of the {IERC20} interface.', 60000)
-      .openFile('.deps/github/OpenZeppelin/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol')
+      .openFile('.deps/github/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol')
   },
 
   'Call Remix File Resolver (internal URL) from a script #group3': function (browser: NightwatchBrowser) {


### PR DESCRIPTION
This PR updates the terminal.test.ts file to correct the path for opening the OpenZeppelin ERC20 contract in the Remix IDE. The previous file path was incorrect, and this fix ensures that the contract is accessed from the proper GitHub repository structure.