### PR TITLE
fixed dead link in `code-format/index.ts`

### DIFF
--- a/apps/remix-ide/src/app/plugins/code-format/index.ts
+++ b/apps/remix-ide/src/app/plugins/code-format/index.ts
@@ -6,7 +6,7 @@ import loc from 'prettier-plugin-solidity/src/loc.js';
 import { parse } from './parser'
 
 // https://prettier.io/docs/en/plugins.html#languages
-// https://github.com/ikatyang/linguist-languages/blob/master/data/Solidity.json
+// https://github.com/ikatyang/linguist-languages/blob/master/data/Solidity.js
 const languages = [
   {
     linguistLanguageId: 237469032,


### PR DESCRIPTION
Hello! In the `apps/remix-ide/src/app/plugins/code-format/index.ts` file of the code-format plugin for Remix IDE, there was a broken link. It pointed to a .json file that no longer exists. I replaced it with the correct link to the `.js` file. Now everything works as it should.