### PR TITLE
Refactor variable names and property casing for consistency and clarity

### DIFF
--- a/apps/remix-ide/src/app/components/status-bar.tsx
+++ b/apps/remix-ide/src/app/components/status-bar.tsx
@@ -26,14 +26,13 @@ export class StatusBar extends Plugin<any, CustomRemixApi> implements StatusBarI
   currentWorkspaceName: string = ''
   isGitRepo: boolean = false
   isAiActive: boolean = false
-  constructor(filePanel: FilePanelType, veritcalIcons: VerticalIcons) {
+  constructor(filePanel: FilePanelType, verticalIcons: VerticalIcons) {
     super(statusBarProfile)
     this.filePanelPlugin = filePanel
-    this.verticalIcons = veritcalIcons
+    this.verticalIcons = verticalIcons
     this.events = new EventEmitter()
     this.htmlElement = document.createElement('div')
     this.htmlElement.setAttribute('id', 'status-bar')
-    this.filePanelPlugin
   }
 
   async isWorkspaceAGitRepo() {

--- a/apps/remix-ide/src/app/components/vertical-icons.tsx
+++ b/apps/remix-ide/src/app/components/vertical-icons.tsx
@@ -31,7 +31,7 @@ export class VerticalIcons extends Plugin {
   renderComponent() {
     const fixedOrder = ['filePanel', 'search', 'solidity', 'udapp', 'debugger', 'solidityStaticAnalysis', 'solidityUnitTesting', 'pluginManager']
 
-    const divived = Object.values(this.icons)
+    const divided = Object.values(this.icons)
       .map((value) => {
         return {
           ...value,
@@ -42,7 +42,7 @@ export class VerticalIcons extends Plugin {
         return a.timestamp - b.timestamp
       })
 
-    const required = divived
+    const required = divided
       .filter((value) => value.isRequired)
       .sort((a, b) => {
         return fixedOrder.indexOf(a.profile.name) - fixedOrder.indexOf(b.profile.name)
@@ -50,7 +50,7 @@ export class VerticalIcons extends Plugin {
 
     const sorted: IconRecord[] = [
       ...required,
-      ...divived.filter((value) => {
+      ...divided.filter((value) => {
         return !value.isRequired
       })
     ]
@@ -102,7 +102,7 @@ export class VerticalIcons extends Plugin {
       profile: profile,
       active: false,
       pinned: false,
-      canbeDeactivated: await this.call('manager', 'canDeactivate', this.profile, profile),
+      canBeDeactivated: await this.call('manager', 'canDeactivate', this.profile, profile),
       timestamp: Date.now()
     }
     this.renderComponent()


### PR DESCRIPTION
- Correcting the parameter name in the `StatusBar` constructor (`veritcalIcons` ➔ `verticalIcons`)
- Renaming the `divived` variable to `divided` in `VerticalIcons` for clarity
- Updating the property `canbeDeactivated` to `canBeDeactivated` to follow camelCase conventions

These adjustments enhance maintainability and prevent potential confusion during development.

