### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/apps/remix-dapp/src/components/DappTop/index.tsx
+++ b/apps/remix-dapp/src/components/DappTop/index.tsx
@@ -42,7 +42,7 @@ const DappTop: React.FC = () => {
               className="fab fa-twitter btn"
               onClick={() => {
                 window.open(
-                  `https://twitter.com/intent/tweet?url=${shareUrl}&text=${shareTitle}`,
+                  `https://x.com/intent/tweet?url=${shareUrl}&text=${shareTitle}`,
                   '',
                   Object.keys(windowConfig)
                     .map((key) => `${key}=${windowConfig[key]}`)


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com to https://x.com to reflect the platform's rebranding.