### PR TITLE
Update github actions versions due to deprecation

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 20.0.0

--- a/.github/workflows/run-sut.yml
+++ b/.github/workflows/run-sut.yml
@@ -8,7 +8,7 @@ jobs:
     name: A job to run solidity unit tests on github actions CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Environment Setup
         uses: actions/setup-node@v3
         with:

--- a/libs/remix-ws-templates/src/script-templates/run-js-test-action/run-js-test.yml
+++ b/libs/remix-ws-templates/src/script-templates/run-js-test-action/run-js-test.yml
@@ -7,7 +7,7 @@ jobs:
     name: A job to run mocha and chai tests for solidity on github actions CI
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Environment Setup
       uses: actions/setup-node@v3
       with:

--- a/libs/remix-ws-templates/src/script-templates/slither-action/run-slither-action.yml
+++ b/libs/remix-ws-templates/src/script-templates/slither-action/run-slither-action.yml
@@ -5,7 +5,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: npm install
     - uses: crytic/slither-action@v0.2.0
       with:

--- a/libs/remix-ws-templates/src/script-templates/solidity-test-action/run-solidity-unittesting.yml
+++ b/libs/remix-ws-templates/src/script-templates/solidity-test-action/run-solidity-unittesting.yml
@@ -7,7 +7,7 @@ jobs:
     name: A job to run solidity unit tests on github actions CI
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Environment Setup
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
Artifact Actions v3 will be deprecated by January 30, 2025. GitHub has started temporarily failing workflows that haven't been updated ahead of this deadline. This PR updates the action versions accordingly, following the [official migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).