### PR TITLE
 refactor: fix comment typos

### DIFF
--- a/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
+++ b/apps/remix-ide-e2e/src/tests/transactionExecution.test.ts
@@ -317,9 +317,9 @@ module.exports = {
     - check the block number has been set to the current mainnet block number.
     - check blocknumber is advancing
     - fork and check blocknumber is advancing the forked state. The name is 'Mainnet fork 1'
-    - fork again and check blocknumber is advancing the forked state. The nmae is 'Mainnet fork 2'
+    - fork again and check blocknumber is advancing the forked state. The name is 'Mainnet fork 2'
     - switch back to Mainnet fork 1 and check we have the right number of blocks.
-    - transact agin using Mainnet fork 1
+    - transact again using Mainnet fork 1
     */
     let addressRef
     let currentBlockNumber: number
@@ -707,7 +707,7 @@ contract C {
         }
 
         contract MyResolver {
-            // Same address for Mainet, Ropsten, Rinkerby, Gorli and other networks;
+            // Same address for Mainnet, Ropsten, Rinkerby, Gorli and other networks;
             ENS ens = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
 
             function resolve() public view returns(address) {

--- a/libs/remix-debug/src/solidity-decoder/internalCallTree.ts
+++ b/libs/remix-debug/src/solidity-decoder/internalCallTree.ts
@@ -340,7 +340,7 @@ async function buildTree (tree, step, scopeId, isCreation, functionDefinition?, 
         const newScopeId = scopeId === '' ? subScope.toString() : scopeId + '.' + subScope
         tree.scopeStarts[step] = newScopeId
         tree.scopes[newScopeId] = { firstStep: step, locals: {}, isCreation, gasCost: 0 }
-        // for the ctor we we are at the start of its trace, we have to replay this step in order to catch all the locals:
+        // for the ctor we are at the start of its trace, we have to replay this step in order to catch all the locals:
         const nextStep = constructorExecutionStarts ? step : step + 1
         if (constructorExecutionStarts) {
           tree.constructorsStartExecution[tree.pendingConstructorId] = tree.pendingConstructorExecutionAt

--- a/libs/remix-simulator/src/vm-context.ts
+++ b/libs/remix-simulator/src/vm-context.ts
@@ -402,7 +402,7 @@ export class VMContext {
   */
   latestBlockNumber: string
   /*
-    This is the number of block that VMContext is instanciated with.
+    This is the number of block that VMContext is instantiated with.
     The final amount of blocks will be `latestBlockNumber` and the value either `blockNumber` or `baseBlockNumber` + `blockNumber`
   */
   private blockNumber: number | 'latest'

--- a/libs/remix-ui/plugin-manager/src/lib/custom-hooks/useLocalStorage.ts
+++ b/libs/remix-ui/plugin-manager/src/lib/custom-hooks/useLocalStorage.ts
@@ -6,7 +6,7 @@ function useLocalStorage<T> (key: string, initialValue: T): [T, SetValue<T>] {
   // Get from local storage then
   // parse stored json or return initialValue
   const readValue = (): T => {
-    // Prevent build error "window is undefined" but keep keep working
+    // Prevent build error "window is undefined" but keep working
     if (typeof window === 'undefined') {
       return initialValue
     }


### PR DESCRIPTION
**apps/remix-ide-e2e/src/tests/transactionExecution.test.ts**
`nmae`   -- typo 
`name`   -- fix typo
`agin`.    -- typo 
`again`   -- fix typo
`Mainet` -- typo 
`Mainnet`-- fix typo

**libs/remix-debug/src/solidity-decoder/internalCallTree.ts**
`we we` -- duplicate
`we` -- fix duplicate

**libs/remix-simulator/src/vm-context.ts**
`instanciated` -- duplicate
`instantiated` -- fix duplicate

**libs/remix-ui/plugin-manager/src/lib/custom-hooks/useLocalStorage.ts**
`keep keep` -- duplicate
`keep` -- fix duplicate

