### PR TITLE
Add Aztec Compiler plugin to Remix Project

### DIFF
--- a/apps/aztec-compiler/.eslintrc
+++ b/apps/aztec-compiler/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.eslintrc.json",
+}

--- a/apps/aztec-compiler/project.json
+++ b/apps/aztec-compiler/project.json
@@ -1,0 +1,67 @@
+{
+    "name": "aztec-compiler",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "apps/aztec-compiler/src",
+    "projectType": "application",
+    "implicitDependencies": [],
+    "targets": {
+      "build": {
+        "executor": "@nrwl/webpack:webpack",
+        "outputs": ["{options.outputPath}"],
+        "defaultConfiguration": "development",
+        "options": {
+          "compiler": "babel",
+          "outputPath": "dist/apps/aztec-compiler",
+          "index": "apps/aztec-compiler/src/index.html",
+          "baseHref": "./",
+          "main": "apps/aztec-compiler/src/main.tsx",
+          "polyfills": "apps/aztec-compiler/src/polyfills.ts",
+          "tsConfig": "apps/aztec-compiler/tsconfig.app.json",
+          "assets": ["apps/aztec-compiler/src/profile.json"],
+          "styles": ["apps/aztec-compiler/src/css/app.css"],
+          "scripts": [],
+          "webpackConfig": "apps/aztec-compiler/webpack.config.js"          
+        },
+        "configurations": {
+          "development": {
+          },
+          "production": {
+            "fileReplacements": [
+              {
+                "replace": "apps/aztec-compiler/src/environments/environment.ts",
+                "with": "apps/aztec-compiler/src/environments/environment.prod.ts"
+              }
+            ]
+          }
+        }
+      },
+      "lint": {
+        "executor": "@nrwl/linter:eslint",
+        "outputs": ["{options.outputFile}"],
+        "options": {
+          "lintFilePatterns": ["apps/aztec-compiler/**/*.ts"],
+          "eslintConfig": "apps/aztec-compiler/.eslintrc"
+        }
+      },
+      "serve": {
+        "executor": "@nrwl/webpack:dev-server",
+        "defaultConfiguration": "development",
+        "options": {
+          "buildTarget": "aztec-compiler:build",
+          "hmr": true,
+          "baseHref": "/"
+        },
+        "configurations": {
+          "development": {
+            "buildTarget": "aztec-compiler:build:development",
+            "port": 2023
+          },
+          "production": {
+            "buildTarget": "aztec-compiler:build:production"
+          }
+        }
+      }
+    },
+    "tags": []
+  }
+  

--- a/apps/aztec-compiler/src/app/app.tsx
+++ b/apps/aztec-compiler/src/app/app.tsx
@@ -1,0 +1,27 @@
+import { useReducer } from 'react'
+import { IntlProvider } from 'react-intl'
+import { RenderIf } from '@remix-ui/helper'
+import { Compile } from './components/Compile'
+import { pluginReducer, initialState } from './reducers/state'
+import { AztecPluginClient } from './services/aztecPluginClient'
+import { PluginContext } from './contexts/pluginContext'
+
+const plugin = new AztecPluginClient()
+
+function App() {
+  const [state, dispatch] = useReducer(pluginReducer, initialState)
+
+  return (
+    <div className="aztec_plugin_app">
+      <RenderIf condition={true}>
+        <IntlProvider locale="en" messages={{}}>
+          <PluginContext.Provider value={{ plugin, dispatch, state }}>
+            <Compile />
+          </PluginContext.Provider>
+        </IntlProvider>
+      </RenderIf>
+    </div>
+  )
+}
+
+export default App

--- a/apps/aztec-compiler/src/app/components/Compile.tsx
+++ b/apps/aztec-compiler/src/app/components/Compile.tsx
@@ -1,0 +1,326 @@
+import { useState, useEffect, useRef, useContext } from 'react'
+import { Collapse, Button, Card, Form, Alert, Spinner, InputGroup, OverlayTrigger, Tooltip } from 'react-bootstrap'
+import JSZip from 'jszip'
+import axios from 'axios'
+import { PluginContext } from '../contexts/pluginContext'
+import { ImportExampleSelector } from './compile/ImportExampleSelector'
+import { TargetProjectSelector } from './compile/TargetProjectSelector'
+import { CompileStatusPanel } from './compile/CompileStatusPanel'
+import { FileUtil } from '../utils/fileutils'
+
+const BASE_URL = process.env.AZTEC_PLUGIN_API_BASE_URL
+const WS_URL = process.env.AZTEC_PLUGIN_WS_URL
+
+export const Compile = () => {
+  const [openCompile, setOpenCompile] = useState(false)
+  const [projectList, setProjectList] = useState<string[]>([])
+  const [targetProject, setTargetProject] = useState<string>('')
+  const [compileError, setCompileError] = useState<string | null>(null)
+  const [compileLogs, setCompileLogs] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const [queuePosition, setQueuePosition] = useState<number | null>(null)
+  const [examples, setExamples] = useState<string[]>([])
+  const [exampleToImport, setExampleToImport] = useState<string>('')
+  const wsRef = useRef<WebSocket | null>(null)
+  const requestIdRef = useRef<string>('')
+  const { plugin: client } = useContext(PluginContext)
+
+  useEffect(() => {
+    const fetchExamples = async () => {
+      try {
+        const res = await axios.get(`${BASE_URL}/examples`)
+        setExamples(res.data.examples)
+      } catch (err) {
+        console.error('Failed to fetch examples', err)
+      }
+    }
+    fetchExamples()
+  }, [])
+
+  useEffect(() => {
+    getList()
+    return () => {
+      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+        wsRef.current.close()
+      }
+    }
+  }, [])
+
+  const generateUniqueId = () => {
+    const timestamp = new Date().toISOString().replace(/[-:.]/g, '')
+    const rand = Math.random().toString(36).substring(2, 8)
+    return `req_${timestamp}_${rand}`
+  }
+
+  const getList = async () => {
+    const projects = await getProjectHaveTomlFile('browser/aztec')
+    setProjectList(projects)
+    setTargetProject(projects[0] || '')
+  }
+
+  const setTarget = (e: { target: { value: string } }) => {
+    setTargetProject(e.target.value)
+  }
+
+  const getProjectHaveTomlFile = async (path: string): Promise<string[]> => {
+    if (!client) return []
+    const projects: string[] = []
+    const findTomlFileRecursively = async (currentPath: string): Promise<void> => {
+      const list = await client.call('fileManager', 'readdir', currentPath);
+      const hasTomlFile = Object.keys(list).some((item) => item.endsWith('Nargo.toml'))
+      if (hasTomlFile) {
+        projects.push(currentPath.replace('browser/', ''))
+      }
+      for (const [key, value] of Object.entries(list)) {
+        if ((value as any).isDirectory) {
+          const additionalPath = key.split('/').pop()
+          await findTomlFileRecursively(currentPath + '/' + additionalPath)
+        }
+      }
+    }
+    await findTomlFileRecursively(path)
+    return projects
+  }
+
+  const getAllProjectFiles = async (projectPath: string) => {
+    const files = await FileUtil.allFilesForBrowser(client, projectPath)
+    return files.filter((file) => !file.path.startsWith(`${projectPath}/target`))
+  }
+
+  const generateZip = async (files: any[], projectPath: string) => {
+    const zip = new JSZip()
+    await Promise.all(
+      files.map(async (file) => {
+        if (!file.isDirectory) {
+          const content = await client.call('fileManager', 'readFile', file.path);
+          const relativePath = file.path.replace('browser/', '')
+          const zipPath = relativePath.replace(`${projectPath}/`, '')
+          zip.file(zipPath, content)
+        }
+      })
+    )
+    return zip.generateAsync({ type: 'blob' })
+  }
+
+  const handleCompile = async () => {
+    if (!targetProject) {
+      await client.call('terminal', 'log', {
+        type: 'error',
+        value: 'No target project selected!'
+      })
+      setCompileError('No target project selected!')
+      return
+    }
+
+    setLoading(true)
+    setCompileError(null)
+    setCompileLogs([])
+    requestIdRef.current = generateUniqueId()
+
+    const ws = new WebSocket(`${WS_URL}`)
+    wsRef.current = ws
+
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => {
+        ws.send(JSON.stringify({ requestId: requestIdRef.current }))
+        resolve()
+      }
+      ws.onerror = (error) => {
+        console.error('[Frontend] WebSocket connection error:', error)
+        reject(new Error('WebSocket connection failed'))
+      }
+    })
+
+    ws.onmessage = async (event) => {
+      try {
+        const parsed = JSON.parse(event.data)
+        if (parsed.logMsg) {
+          setCompileLogs((prev) => [...prev, parsed.logMsg])
+          await client.call('terminal', 'log', {
+            type: 'info',
+            value: parsed.logMsg
+          })
+        }
+      } catch (e) {
+        console.warn('[Frontend] Invalid WebSocket message:', event.data)
+      }
+    }
+
+    ws.onerror = () => {
+      setCompileError('WebSocket connection failed.')
+      setLoading(false)
+    }
+
+    try {
+      const projFiles = await getAllProjectFiles(targetProject)
+      const zipBlob = await generateZip(projFiles, targetProject)
+
+      const formData = new FormData()
+      formData.append('file', zipBlob, `${targetProject}.zip`)
+      formData.append('projectPath', targetProject)
+
+      const response = await axios.post(
+        `${BASE_URL}/compile?requestId=${requestIdRef.current}`,
+        formData
+      )
+
+      if (!response.data || !response.data.url) {
+        throw new Error('S3 URL not returned from backend')
+      }
+
+      const zipResponse = await axios.get(response.data.url, { responseType: 'arraybuffer' })
+      const compiledZip = await JSZip.loadAsync(zipResponse.data)
+
+      await Promise.all(
+        Object.entries(compiledZip.files).map(async ([path, file]) => {
+          if (!file.dir) {
+            const content = await file.async('string')
+            const remixPath = `browser/${targetProject}/${path}`
+            await client.call('fileManager', 'writeFile', remixPath, content)
+          }
+        })
+      )
+
+      await client.call('terminal', 'log', {
+        type: 'info',
+        value: '✅ Compilation completed!'
+      })
+    } catch (error: any) {
+      setCompileError(`Compilation failed: ${error.message}`)
+      await client.call('terminal', 'log', {
+        type: 'error',
+        value: `❌ Compilation failed: ${error.message}`
+      })
+    } finally {
+      setLoading(false)
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.close()
+      }
+    }
+  }
+
+  const checkQueueStatus = async () => {
+    try {
+      const res = await axios.get(`${BASE_URL}/queue/status`, {
+        params: { requestId: requestIdRef.current },
+      })
+      setQueuePosition(res.data.position)
+    } catch (err) {
+      console.warn('Failed to check queue status', err)
+    }
+  }
+
+  const importExample = async (exampleName: string) => {
+    if (!client) return
+    const targetPath = `browser/aztec/${exampleName}`
+
+    try {
+      const existing = await client.call('fileManager', 'readdir', targetPath)
+      if (Object.keys(existing).length > 0) {
+        await client.call('terminal', 'log', {
+          type: 'warn',
+          value: `⚠️ Project "${exampleName}" already exists. Import canceled.`
+        })
+        return
+      }
+    } catch (err) {}
+
+    try {
+      const res = await axios.get(`${BASE_URL}/examples/url`, {
+        params: { name: exampleName },
+      })
+
+      if (!res.data.url) throw new Error('No download URL received')
+
+      const zipRes = await axios.get(res.data.url, { responseType: 'arraybuffer' })
+      const zip = await JSZip.loadAsync(zipRes.data)
+      const rootFolder = Object.keys(zip.files)[0]?.split('/')[0]
+
+      await Promise.all(
+        Object.entries(zip.files).map(async ([zipPath, file]) => {
+          if (!file.dir && zipPath.startsWith(`${rootFolder}/`)) {
+            const relativePath = zipPath.replace(`${rootFolder}/`, '')
+            const remixPath = `${targetPath}/${relativePath}`
+            const content = await file.async('string')
+            await client.call('fileManager', 'writeFile', remixPath, content)
+          }
+        })
+      )
+
+      await client.call('terminal', 'log', {
+        type: 'info',
+        value: `✅ Example "${exampleName}" imported.`
+      })
+      
+      setTargetProject(`aztec/${exampleName}`)
+      await getList()
+    } catch (err: any) {
+      console.error(`Failed to import example ${exampleName}`, err)
+      await client.call('terminal', 'log', {
+        type: 'error',
+        value: `❌ Failed to import ${exampleName}: ${err.message}`
+      })
+    }
+  }
+
+  return (
+    <Card className="mb-3">
+      <Card.Header
+        onClick={() => setOpenCompile(!openCompile)}
+        aria-controls="compile-collapse"
+        aria-expanded={openCompile}
+        className="d-flex align-items-center justify-content-between"
+        style={{ cursor: 'pointer' }}
+      >
+        <div className="d-flex align-items-center">Compile Aztec Project</div>
+      </Card.Header>
+      <Collapse in={openCompile}>
+        <div id="compile-collapse" style={{ transition: 'height 0.3s ease-in-out', overflow: 'hidden' }}>
+          <Card.Body>
+            <Form>
+              <ImportExampleSelector
+                examples={examples}
+                exampleToImport={exampleToImport}
+                setExampleToImport={setExampleToImport}
+                importExample={importExample}
+              />
+              <TargetProjectSelector
+                projectList={projectList}
+                targetProject={targetProject}
+                setTarget={setTarget}
+                onReload={getList}
+              />
+              <Button
+                variant="primary"
+                className="w-100 mt-3"
+                disabled={!targetProject || loading}
+                onClick={handleCompile}
+              >
+                {loading ? (
+                  <>
+                    <Spinner animation="border" size="sm" /> Compiling...
+                  </>
+                ) : (
+                  'Compile'
+                )}
+              </Button>
+              <CompileStatusPanel
+                loading={loading}
+                queuePosition={queuePosition}
+                checkQueueStatus={checkQueueStatus}
+              />
+              {compileError && (
+                <Alert variant="danger" className="mt-2" style={{
+                  fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
+                  fontSize: '12px',
+                }}>
+                  {compileError}
+                </Alert>
+              )}
+            </Form>
+          </Card.Body>
+        </div>
+      </Collapse>
+    </Card>
+  )
+}

--- a/apps/aztec-compiler/src/app/components/compile/CompileStatusPanel.tsx
+++ b/apps/aztec-compiler/src/app/components/compile/CompileStatusPanel.tsx
@@ -1,0 +1,35 @@
+import { Alert, Button } from 'react-bootstrap';
+
+export const CompileStatusPanel = ({
+  loading,
+  queuePosition,
+  checkQueueStatus,
+}: {
+  loading: boolean;
+  queuePosition: number | null;
+  checkQueueStatus: () => void;
+}) => {
+  if (!loading) return null;
+
+  return (
+    <div className="mt-3" style={{ marginTop: '10px' }}>
+      <div className="d-flex align-items-center justify-content-between">
+        <Button size="sm" variant="outline-primary" onClick={checkQueueStatus}>
+          Check Compile Order
+        </Button>
+      </div>
+      {queuePosition !== null && (
+        <Alert
+          variant="info"
+          className="mt-2"
+          style={{
+            fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
+            fontSize: '12px',
+          }}
+        >
+          You're currently <strong>#{queuePosition + 1}</strong> in the queue.<br />
+        </Alert>
+      )}
+    </div>
+  );
+};

--- a/apps/aztec-compiler/src/app/components/compile/CompileStatusPanel.tsx
+++ b/apps/aztec-compiler/src/app/components/compile/CompileStatusPanel.tsx
@@ -1,35 +1,18 @@
-import { Alert, Button } from 'react-bootstrap';
+import React from 'react'
+import { CustomTooltip } from '@remix-ui/helper'
 
-export const CompileStatusPanel = ({
-  loading,
-  queuePosition,
-  checkQueueStatus,
-}: {
-  loading: boolean;
-  queuePosition: number | null;
-  checkQueueStatus: () => void;
-}) => {
-  if (!loading) return null;
-
+export const CompileStatusPanel = ({ loading, queuePosition, checkQueueStatus }) => {
+  if (!loading) return null
   return (
-    <div className="mt-3" style={{ marginTop: '10px' }}>
-      <div className="d-flex align-items-center justify-content-between">
-        <Button size="sm" variant="outline-primary" onClick={checkQueueStatus}>
-          Check Compile Order
-        </Button>
-      </div>
+    <div className="mt-3">
+      <button className="btn btn-outline-primary btn-sm" onClick={checkQueueStatus}>
+        Check Compile Order
+      </button>
       {queuePosition !== null && (
-        <Alert
-          variant="info"
-          className="mt-2"
-          style={{
-            fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
-            fontSize: '12px',
-          }}
-        >
-          You're currently <strong>#{queuePosition + 1}</strong> in the queue.<br />
-        </Alert>
+        <div className="remixui_alert remixui_alert-info mt-2" style={{ fontFamily: 'Menlo, Monaco, Consolas', fontSize: '12px' }}>
+          You're currently <strong>#{queuePosition + 1}</strong> in the queue.
+        </div>
       )}
     </div>
-  );
-};
+  )
+}

--- a/apps/aztec-compiler/src/app/components/compile/ImportExampleSelector.tsx
+++ b/apps/aztec-compiler/src/app/components/compile/ImportExampleSelector.tsx
@@ -1,44 +1,25 @@
-import { Form, InputGroup, Button } from 'react-bootstrap';
+import React from 'react'
+import { CustomTooltip } from '@remix-ui/helper'
 
-export const ImportExampleSelector = ({
-  examples,
-  exampleToImport,
-  setExampleToImport,
-  importExample,
-}: {
-  examples: string[];
-  exampleToImport: string;
-  setExampleToImport: (v: string) => void;
-  importExample: (v: string) => void;
-}) => {
-  return (
-    <Form.Group>
-      <Form.Text className="text-muted">
-        <small>IMPORT EXAMPLE PROJECT</small>
-      </Form.Text>
-      <InputGroup className="mt-2">
-        <Form.Control
-          className="custom-select"
-          as="select"
-          value={exampleToImport}
-          onChange={(e) => setExampleToImport(e.target.value)}
-        >
-          <option value="">-- Select Example --</option>
-          {examples.map((exampleName) => (
-            <option key={exampleName} value={exampleName}>
-              {exampleName}
-            </option>
-          ))}
-        </Form.Control>
-      </InputGroup>
-      <Button
-        className="w-100 mt-2"
-        variant="secondary"
-        disabled={!exampleToImport}
-        onClick={() => importExample(exampleToImport)}
+export const ImportExampleSelector = ({ examples, exampleToImport, setExampleToImport, importExample }) => (
+  <div className="mb-3">
+    <div className="text-muted"><small className="text-white">IMPORT EXAMPLE PROJECT</small></div>
+    <CustomTooltip tooltipText="Download template code">
+      <select
+        className="custom-select mt-2"
+        value={exampleToImport}
+        onChange={(e) => setExampleToImport(e.target.value)}
       >
-        Import Selected Example
-      </Button>
-    </Form.Group>
-  );
-};
+        <option value="">-- Select Example --</option>
+        {examples.map((ex) => <option key={ex} value={ex}>{ex}</option>)}
+      </select>
+    </CustomTooltip>
+    <button
+      className="btn btn-secondary btn-block mt-2"
+      disabled={!exampleToImport}
+      onClick={() => importExample(exampleToImport)}
+    >
+      Import Selected Example
+    </button>
+  </div>
+)

--- a/apps/aztec-compiler/src/app/components/compile/ImportExampleSelector.tsx
+++ b/apps/aztec-compiler/src/app/components/compile/ImportExampleSelector.tsx
@@ -1,0 +1,44 @@
+import { Form, InputGroup, Button } from 'react-bootstrap';
+
+export const ImportExampleSelector = ({
+  examples,
+  exampleToImport,
+  setExampleToImport,
+  importExample,
+}: {
+  examples: string[];
+  exampleToImport: string;
+  setExampleToImport: (v: string) => void;
+  importExample: (v: string) => void;
+}) => {
+  return (
+    <Form.Group>
+      <Form.Text className="text-muted">
+        <small>IMPORT EXAMPLE PROJECT</small>
+      </Form.Text>
+      <InputGroup className="mt-2">
+        <Form.Control
+          className="custom-select"
+          as="select"
+          value={exampleToImport}
+          onChange={(e) => setExampleToImport(e.target.value)}
+        >
+          <option value="">-- Select Example --</option>
+          {examples.map((exampleName) => (
+            <option key={exampleName} value={exampleName}>
+              {exampleName}
+            </option>
+          ))}
+        </Form.Control>
+      </InputGroup>
+      <Button
+        className="w-100 mt-2"
+        variant="secondary"
+        disabled={!exampleToImport}
+        onClick={() => importExample(exampleToImport)}
+      >
+        Import Selected Example
+      </Button>
+    </Form.Group>
+  );
+};

--- a/apps/aztec-compiler/src/app/components/compile/TargetProjectSelector.tsx
+++ b/apps/aztec-compiler/src/app/components/compile/TargetProjectSelector.tsx
@@ -1,0 +1,49 @@
+import { Form, InputGroup, OverlayTrigger, Tooltip } from 'react-bootstrap';
+
+export const TargetProjectSelector = ({
+  projectList,
+  targetProject,
+  setTarget,
+  onReload,
+}: {
+  projectList: string[];
+  targetProject: string;
+  setTarget: (e: React.ChangeEvent<any>) => void;
+  onReload: () => void;
+}) => {
+  return (
+    <Form.Group className="mt-3" style={{ marginTop: '10px' }}>
+      <Form.Text className="text-muted">
+        <small>TARGET PROJECT </small>
+        <OverlayTrigger placement="top" overlay={<Tooltip id={''}>Reload</Tooltip>}>
+          <span style={{ cursor: 'pointer' }} onClick={onReload}>
+          </span>
+        </OverlayTrigger>
+      </Form.Text>
+      <InputGroup className="mt-2">
+        <OverlayTrigger
+          placement="top"
+          overlay={
+            <Tooltip id={''}>
+              The project must be located under the `aztec` folder in the root directory.
+            </Tooltip>
+          }
+        >
+          <Form.Control
+            className="custom-select"
+            as="select"
+            value={targetProject}
+            onChange={setTarget}
+          >
+            <option value="">-- Select Project --</option>
+            {projectList.map((projectName, idx) => (
+              <option key={idx} value={projectName}>
+                {projectName}
+              </option>
+            ))}
+          </Form.Control>
+        </OverlayTrigger>
+      </InputGroup>
+    </Form.Group>
+  );
+};

--- a/apps/aztec-compiler/src/app/components/compile/TargetProjectSelector.tsx
+++ b/apps/aztec-compiler/src/app/components/compile/TargetProjectSelector.tsx
@@ -1,49 +1,26 @@
-import { Form, InputGroup, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import React from 'react'
+import { CustomTooltip } from '@remix-ui/helper'
 
-export const TargetProjectSelector = ({
-  projectList,
-  targetProject,
-  setTarget,
-  onReload,
-}: {
-  projectList: string[];
-  targetProject: string;
-  setTarget: (e: React.ChangeEvent<any>) => void;
-  onReload: () => void;
-}) => {
-  return (
-    <Form.Group className="mt-3" style={{ marginTop: '10px' }}>
-      <Form.Text className="text-muted">
-        <small>TARGET PROJECT </small>
-        <OverlayTrigger placement="top" overlay={<Tooltip id={''}>Reload</Tooltip>}>
-          <span style={{ cursor: 'pointer' }} onClick={onReload}>
-          </span>
-        </OverlayTrigger>
-      </Form.Text>
-      <InputGroup className="mt-2">
-        <OverlayTrigger
-          placement="top"
-          overlay={
-            <Tooltip id={''}>
-              The project must be located under the `aztec` folder in the root directory.
-            </Tooltip>
-          }
-        >
-          <Form.Control
-            className="custom-select"
-            as="select"
-            value={targetProject}
-            onChange={setTarget}
-          >
-            <option value="">-- Select Project --</option>
-            {projectList.map((projectName, idx) => (
-              <option key={idx} value={projectName}>
-                {projectName}
-              </option>
-            ))}
-          </Form.Control>
-        </OverlayTrigger>
-      </InputGroup>
-    </Form.Group>
-  );
-};
+export const TargetProjectSelector = ({ projectList, targetProject, setTarget, onReload }) => (
+  <div className="mb-3">
+    <div className="d-flex align-items-center text-muted text-white">
+      <small className="text-white">TARGET PROJECT</small>
+      <i
+        className="fas fa-sync ml-2"
+        title="Reload"
+        style={{ cursor: 'pointer' }}
+        onClick={onReload}
+      />
+    </div>
+    <CustomTooltip tooltipText="Target project must be under root/aztec directory/">
+      <select
+        className="custom-select mt-2"
+        value={targetProject}
+        onChange={setTarget}
+      >
+        <option value="">-- Select Project --</option>
+        {projectList.map((proj, idx) => <option key={idx} value={proj}>{proj}</option>)}
+      </select>
+    </CustomTooltip>
+  </div>
+)

--- a/apps/aztec-compiler/src/app/contexts/pluginContext.ts
+++ b/apps/aztec-compiler/src/app/contexts/pluginContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react'
+import { PluginClient } from '@remixproject/plugin'
+
+export const PluginContext = createContext<{
+  plugin: PluginClient
+  dispatch: React.Dispatch<any>
+  state: any
+}>(null as any)

--- a/apps/aztec-compiler/src/app/reducers/state.ts
+++ b/apps/aztec-compiler/src/app/reducers/state.ts
@@ -1,0 +1,8 @@
+export const initialState = {}
+
+export const pluginReducer = (state: any, action: any) => {
+  switch (action.type) {
+    default:
+      return state
+  }
+}

--- a/apps/aztec-compiler/src/app/services/aztecPluginClient.ts
+++ b/apps/aztec-compiler/src/app/services/aztecPluginClient.ts
@@ -1,0 +1,40 @@
+import { PluginClient } from '@remixproject/plugin'
+import { createClient } from '@remixproject/plugin-webview'
+import EventManager from 'events'
+
+export class AztecPluginClient extends PluginClient {
+  public internalEvents: EventManager
+
+  constructor() {
+    super()
+    this.methods = ['init', 'compile']
+    createClient(this)
+    this.internalEvents = new EventManager()
+    this.onload()
+  }
+
+  init(): void {
+    console.log('[aztec-plugin] Initialized!')
+  }
+
+  onActivation(): void {
+    this.internalEvents.emit('aztec_activated')
+  }
+
+  async compile(): Promise<void> {
+    try {
+      this.internalEvents.emit('aztec_compiling_start')
+      this.emit('statusChanged', { key: 'loading', title: 'Compiling Aztec project...', type: 'info' })
+
+      // 👇 실제 컴파일 요청은 기존에 하던 WebSocket+S3 방식과 연동 가능
+      // 예를 들어 backend API 호출하거나 websocket 열거나
+
+      this.internalEvents.emit('aztec_compiling_done')
+      this.emit('statusChanged', { key: 'success', title: 'Compile complete.', type: 'success' })
+    } catch (e: any) {
+      this.emit('statusChanged', { key: 'error', title: e.message, type: 'error' })
+      this.internalEvents.emit('aztec_compiling_errored', e)
+      console.error('[aztec-plugin] compile error:', e)
+    }
+  }
+}

--- a/apps/aztec-compiler/src/app/utils/fileutils.ts
+++ b/apps/aztec-compiler/src/app/utils/fileutils.ts
@@ -1,0 +1,56 @@
+export interface FileInfo {
+  path: string;
+  isDirectory: boolean;
+}
+
+export class FileUtil {
+  
+  static async allFilesForBrowser(client: any, dirName: string): Promise<FileInfo[]> {
+    try {
+      let result: FileInfo[] = [];
+      const files = await client?.fileManager.readdir('browser/' + dirName);
+      for (const [key, val] of Object.entries(files)) {
+        const file_ = {
+          path: key,
+          isDirectory: (val as any).isDirectory,
+        };
+        if (file_.isDirectory) {
+          const subDirFiles = (await FileUtil.allFilesForBrowser(client, file_.path)) || [];
+
+          result = [...result, file_, ...subDirFiles];
+        } else {
+          result.push(file_);
+        }
+      }
+      return result;
+    } catch (e) {
+      console.error(e);
+      return [];
+    }
+  }
+
+  static extractFilename(path: string): string {
+    const lastIndex = path.lastIndexOf('/');
+    if (lastIndex === -1) {
+      return path;
+    }
+
+    return path.slice(lastIndex + 1);
+  }
+
+  static extractFilenameWithoutExtension(path: string): string {
+    const filename = FileUtil.extractFilename(path);
+    return filename.slice(0, filename.lastIndexOf('.'));
+  }
+
+  static async contents(fileManager: any, compileTarget: string, projFiles: FileInfo[]) {
+    return await Promise.all(
+      projFiles.map(async (u) => {
+        if (u.isDirectory) {
+          return '';
+        }
+        return await fileManager.readFile('browser/' + compileTarget + '/' + u.path);
+      }),
+    );
+  }
+}

--- a/apps/aztec-compiler/src/css/app.css
+++ b/apps/aztec-compiler/src/css/app.css
@@ -1,0 +1,101 @@
+body {
+    font-size          : .8rem;
+}
+.noir_section {
+    padding: 12px 24px 16px;
+}
+.noir_label {
+    margin-bottom: 2px;
+    font-size: 11px;
+    line-height: 12px;
+    text-transform: uppercase;
+}
+.noir_warnings_box {
+    display: flex;
+    align-items: center;
+}
+.noir_warnings_box label {
+    margin: 0;
+}
+.noir_config_section:hover {
+    cursor: pointer;
+}
+.noir_config_section {
+    font-size: 1rem;
+}
+.noir_config {
+    display: flex;
+    align-items: center;
+}
+.noir_config label {
+    margin: 0;
+}
+.noir_inner_label {
+    margin-bottom: 2px;
+    font-size: 11px;
+    line-height: 12px;
+    text-transform: uppercase;
+}
+.circuit_errors_box {
+    word-break: break-word;
+}
+.circuit_feedback.success,
+.circuit_feedback.error,
+.circuit_feedback.warning {
+  white-space: pre-line;
+  word-wrap: break-word;
+  cursor: pointer;
+  position: relative;
+  margin: 0.5em 0 1em 0;
+  border-radius: 5px;
+  line-height: 20px;
+  padding: 8px 15px;
+}
+
+.circuit_feedback.success pre,
+.circuit_feedback.error pre,
+.circuit_feedback.warning pre {
+  white-space: pre-line;
+  overflow-y: hidden;
+  background-color: transparent;
+  margin: 0;
+  font-size: 12px;
+  border: 0 none;
+  padding: 0;
+  border-radius: 0;
+}
+
+.circuit_feedback.success .close,
+.circuit_feedback.error .close,
+.circuit_feedback.warning .close {
+  visibility: hidden;
+  white-space: pre-line;
+  font-weight: bold;
+  position: absolute;
+  color: hsl(0, 0%, 0%); /* black in style-guide.js */
+  top: 0;
+  right: 0;
+  padding: 0.5em;
+}
+
+.circuit_feedback.success a,
+.circuit_feedback.error a,
+.circuit_feedback.warning a {
+  bottom: 0;
+  right: 0;
+}
+.custom-dropdown-items {
+    padding: 0.25rem 0.25rem;
+    border-radius: .25rem;
+    background: var(--custom-select);
+}
+.custom-dropdown-items a {
+    border-radius: .25rem;
+    text-transform: none;
+    text-decoration: none;
+    font-weight: normal;
+    font-size: 0.875rem;
+    padding: 0.25rem 0.25rem;
+    width: auto;
+    color: var(--text);
+}

--- a/apps/aztec-compiler/src/css/app.css
+++ b/apps/aztec-compiler/src/css/app.css
@@ -99,3 +99,17 @@ body {
     width: auto;
     color: var(--text);
 }
+
+.compiler-version {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: #6c757d;
+    padding: 0 1rem 0.5rem 1rem;
+}
+  
+.compiler-version-value {
+    color: #ffffff;
+    font-weight: 500;
+}

--- a/apps/aztec-compiler/src/index.html
+++ b/apps/aztec-compiler/src/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Aztec - Compiler</title>
+    <base href="./" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <!-- <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous"/> -->
+    <!-- <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous"> -->
+    <link rel="stylesheet" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf"
+		crossorigin="anonymous" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css">
+  </head>
+  <body>
+    <script>
+      var global = window
+    </script>
+    <div id="root"></div>
+    <script src="https://kit.fontawesome.com/41dd021e94.js" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/apps/aztec-compiler/src/main.tsx
+++ b/apps/aztec-compiler/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './app/app'
+
+const container = document.getElementById('root')
+
+if (container) {
+  createRoot(container).render(<App />)
+}

--- a/apps/aztec-compiler/src/polyfills.ts
+++ b/apps/aztec-compiler/src/polyfills.ts
@@ -1,0 +1,7 @@
+/**
+ * Polyfill stable language features. These imports will be optimized by `@babel/preset-env`.
+ *
+ * See: https://github.com/zloirock/core-js#babel
+ */
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';

--- a/apps/aztec-compiler/src/profile.json
+++ b/apps/aztec-compiler/src/profile.json
@@ -1,0 +1,17 @@
+{
+  "name": "aztec-compiler",
+  "kind": "provider",
+  "displayName": "Aztec Compiler",
+  "events": [],
+  "version": "2.0.0",
+  "methods": [],
+  "canActivate": [],
+  "url": "",
+  "description": "Enables support for aztec contract compilation",
+  "icon": "assets/img/noir-icon12.webp",
+  "location": "sidePanel",
+  "documentation": "",
+  "repo": "https://github.com/ethereum/remix-project/tree/master/apps/aztec-compiler",
+  "maintainedBy": "Remix",
+  "authorContact": ""
+}

--- a/apps/aztec-compiler/tsconfig.app.json
+++ b/apps/aztec-compiler/tsconfig.app.json
@@ -1,0 +1,24 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+      "outDir": "../../dist/out-tsc",
+      "types": ["node"]
+    },
+    "files": [
+      "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+      "../../node_modules/@nrwl/react/typings/image.d.ts"
+    ],
+    "exclude": [
+      "jest.config.ts",
+      "**/*.spec.ts",
+      "**/*.test.ts",
+      "**/*.spec.tsx",
+      "**/*.test.tsx",
+      "**/*.spec.js",
+      "**/*.test.js",
+      "**/*.spec.jsx",
+      "**/*.test.jsx"
+    ],
+    "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+  }
+  

--- a/apps/aztec-compiler/tsconfig.json
+++ b/apps/aztec-compiler/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/apps/aztec-compiler/webpack.config.js
+++ b/apps/aztec-compiler/webpack.config.js
@@ -1,0 +1,103 @@
+const { composePlugins, withNx } = require('@nrwl/webpack')
+const webpack = require('webpack')
+const TerserPlugin = require("terser-webpack-plugin")
+const CssMinimizerPlugin = require("css-minimizer-webpack-plugin")
+const path = require('path')
+
+// Nx plugins for webpack.
+module.exports = composePlugins(withNx(), (config) => {
+  
+  // add fallback for node modules
+  config.resolve.fallback = {
+    ...config.resolve.fallback,
+    "crypto": require.resolve("crypto-browserify"),
+    "stream": require.resolve("stream-browserify"),
+    "path": require.resolve("path-browserify"),
+    "http": require.resolve("stream-http"),
+    "https": require.resolve("https-browserify"),
+    "constants": require.resolve("constants-browserify"),
+    "os": false, //require.resolve("os-browserify/browser"),
+    "timers": false, // require.resolve("timers-browserify"),
+    "zlib": require.resolve("browserify-zlib"),
+    "fs": false,
+    "module": false,
+    "tls": false,
+    "net": false,
+    "readline": false,
+    "child_process": false,
+    "buffer": require.resolve("buffer/"),
+    "vm": require.resolve('vm-browserify'),
+  }
+
+
+  // add externals
+  config.externals = {
+    ...config.externals,
+    solc: 'solc',
+  }
+
+  // add public path
+  config.output.publicPath = './'
+
+  // add copy & provide plugin
+  config.plugins.push(
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+      url: ['url', 'URL'],
+      process: 'process/browser',
+    })
+  )
+
+  // set the define plugin to load the WALLET_CONNECT_PROJECT_ID
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      WALLET_CONNECT_PROJECT_ID: JSON.stringify(process.env.WALLET_CONNECT_PROJECT_ID),
+    })
+  )
+
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      'fetch': `((...args) => {
+        if (args[0].origin === 'https://github.com') {
+          return fetch('https://api.allorigins.win/raw?url=' + args[0])
+        }
+        return fetch(...args)
+      })`,
+    })
+  )
+
+  // source-map loader
+  config.module.rules.push({
+    test: /\.js$/,
+    use: ["source-map-loader"],
+    enforce: "pre"
+  })
+
+  config.ignoreWarnings = [/Failed to parse source map/] // ignore source-map-loader warnings
+
+
+  // set minimizer
+  config.optimization.minimizer = [
+    new TerserPlugin({
+      parallel: true,
+      terserOptions: {
+        ecma: 2015,
+        compress: false,
+        mangle: false,
+        format: {
+          comments: false,
+        },
+      },
+      extractComments: false,
+    }),
+    new CssMinimizerPlugin(),
+  ];
+
+  config.watchOptions = {
+    ignored: /node_modules/
+  }
+
+  config.experiments.syncWebAssembly = true
+
+  return config;
+});

--- a/apps/aztec-compiler/webpack.config.js
+++ b/apps/aztec-compiler/webpack.config.js
@@ -99,5 +99,15 @@ module.exports = composePlugins(withNx(), (config) => {
 
   config.experiments.syncWebAssembly = true
 
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      'process.env.REACT_APP_AZTEC_PLUGIN_API_BASE_URL_DEV':  JSON.stringify(process.env.REACT_APP_AZTEC_PLUGIN_API_BASE_URL_DEV),
+      'process.env.REACT_APP_AZTEC_PLUGIN_API_BASE_URL_PROD': JSON.stringify(process.env.REACT_APP_AZTEC_PLUGIN_API_BASE_URL_PROD),
+      'process.env.REACT_APP_AZTEC_PLUGIN_WS_URL_DEV':       JSON.stringify(process.env.REACT_APP_AZTEC_PLUGIN_WS_URL_DEV),
+      'process.env.REACT_APP_AZTEC_PLUGIN_WS_URL_PROD':      JSON.stringify(process.env.REACT_APP_AZTEC_PLUGIN_WS_URL_PROD),
+    })
+  )
+  
   return config;
 });

--- a/apps/remix-ide/project.json
+++ b/apps/remix-ide/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/remix-ide/src",
   "projectType": "application",
-  "implicitDependencies": ["doc-gen", "doc-viewer", "contract-verification", "vyper", "solhint", "circuit-compiler", "learneth", "quick-dapp", "remix-dapp", "noir-compiler"],
+  "implicitDependencies": ["doc-gen", "doc-viewer", "contract-verification", "vyper", "solhint", "circuit-compiler", "learneth", "quick-dapp", "remix-dapp", "noir-compiler", "aztec-compiler"],
   "targets": {
     "build": {
       "executor": "@nrwl/webpack:webpack",

--- a/apps/remix-ide/src/app/plugins/matomo.ts
+++ b/apps/remix-ide/src/app/plugins/matomo.ts
@@ -11,7 +11,7 @@ const profile = {
   version: '1.0.0'
 }
 
-const allowedPlugins = ['LearnEth', 'etherscan', 'vyper', 'circuit-compiler', 'doc-gen', 'doc-viewer', 'solhint', 'walletconnect', 'scriptRunner', 'scriptRunnerBridge', 'dgit', 'contract-verification', 'noir-compiler']
+const allowedPlugins = ['LearnEth', 'etherscan', 'vyper', 'circuit-compiler', 'doc-gen', 'doc-viewer', 'solhint', 'walletconnect', 'scriptRunner', 'scriptRunnerBridge', 'dgit', 'contract-verification', 'noir-compiler', 'aztec-compiler']
 
 export class Matomo extends Plugin {
 

--- a/apps/remix-ide/src/remixAppManager.ts
+++ b/apps/remix-ide/src/remixAppManager.ts
@@ -97,7 +97,7 @@ let requiredModules = [
 // dependentModules shouldn't be manually activated (e.g hardhat is activated by remixd)
 const dependentModules = ['foundry', 'hardhat', 'truffle', 'slither']
 
-const loadLocalPlugins = ['doc-gen', 'doc-viewer', 'contract-verification', 'vyper', 'solhint', 'circuit-compiler', 'learneth', 'quick-dapp', 'noir-compiler']
+const loadLocalPlugins = ['doc-gen', 'doc-viewer', 'contract-verification', 'vyper', 'solhint', 'circuit-compiler', 'learneth', 'quick-dapp', 'noir-compiler', 'aztec-compiler']
 
 const partnerPlugins = ['cookbookdev']
 
@@ -153,7 +153,8 @@ export function isNative(name) {
     'contract-verification',
     'popupPanel',
     'LearnEth',
-    'noir-compiler'
+    'noir-compiler',
+    'aztec-compiler',
   ]
   return nativePlugins.includes(name) || requiredModules.includes(name) || isInjectedProvider(name) || isVM(name) || isScriptRunner(name)
 }


### PR DESCRIPTION
Adds the Aztec Compiler plugin to Remix, providing a styled UI for importing example projects, selecting targets under aztec/, and compiling via WebSocket with a spinner and modal dialogs for success or error. Environment-specific endpoints are configured via REACT_APP_… vars and Webpack.