### PR TITLE
chore(ci): bump actions/setup-node to v4 & add-pr-comment to v2

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.0.0
       - run: yarn install

--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -17,7 +17,7 @@ jobs:
       - run: pwd
       - run: yarn run build:production
       - run: echo "action_state=$('./apps/remix-ide/ci/publishIpfs' ${{ secrets.IPFS_PROJET_ID }} ${{ secrets.IPFS_PROJECT_SECRET }})" >> $GITHUB_ENV
-      - uses: mshick/add-pr-comment@v1
+      - uses: mshick/add-pr-comment@v2
         with:
           message: |
             ipfs://${{ env.action_state }}

--- a/.github/workflows/run-sut.yml
+++ b/.github/workflows/run-sut.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Environment Setup
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.0.0
       - name: Run SUT Action

--- a/libs/remix-ws-templates/src/script-templates/run-js-test-action/run-js-test.yml
+++ b/libs/remix-ws-templates/src/script-templates/run-js-test-action/run-js-test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Environment Setup
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20.0.0
     - name: Run Mocha Chai Unit Test Action

--- a/libs/remix-ws-templates/src/script-templates/solidity-test-action/run-solidity-unittesting.yml
+++ b/libs/remix-ws-templates/src/script-templates/solidity-test-action/run-solidity-unittesting.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Environment Setup
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20.0.0
     - name: Run SUT Action


### PR DESCRIPTION
* **actions/setup-node**: v3 → **v4** (latest v4.4.0); gains Node 22 support, built-in corepack, faster cache restore. [contentReference](https://github.com/actions/setup-node/releases/tag/v4.4.0)
* **mshick/add-pr-comment**: v1 → **v2** (current v2.x); fixes fork-PR token limits via proxy & adds richer templating. [contentReference](https://github.com/mshick/add-pr-comment/releases/tag/v2)
