### PR TITLE
Verification plugin: Use Etherscan API v2

### DIFF
--- a/apps/contract-verification/src/app/Verifiers/AbstractVerifier.ts
+++ b/apps/contract-verification/src/app/Verifiers/AbstractVerifier.ts
@@ -4,8 +4,8 @@ import type { LookupResponse, SubmittedContract, VerificationResponse } from '..
 // Optional function definitions
 export interface AbstractVerifier {
   verifyProxy?(submittedContract: SubmittedContract): Promise<VerificationResponse>
-  checkVerificationStatus?(receiptId: string): Promise<VerificationResponse>
-  checkProxyVerificationStatus?(receiptId: string): Promise<VerificationResponse>
+  checkVerificationStatus?(receiptId: string, chainId: string): Promise<VerificationResponse>
+  checkProxyVerificationStatus?(receiptId: string, chainId: string): Promise<VerificationResponse>
 }
 
 export abstract class AbstractVerifier {

--- a/apps/contract-verification/src/app/Verifiers/EtherscanVerifier.ts
+++ b/apps/contract-verification/src/app/Verifiers/EtherscanVerifier.ts
@@ -47,7 +47,6 @@ export class EtherscanVerifier extends AbstractVerifier {
     // TODO: Handle version Vyper contracts. This relies on Solidity metadata.
     const metadata = JSON.parse(compilerAbstract.data.contracts[submittedContract.filePath][submittedContract.contractName].metadata)
     const formData = new FormData()
-    formData.append('chainId', submittedContract.chainId)
     formData.append('codeformat', 'solidity-standard-json-input')
     formData.append('sourceCode', compilerAbstract.input.toString())
     formData.append('contractaddress', submittedContract.address)
@@ -56,6 +55,7 @@ export class EtherscanVerifier extends AbstractVerifier {
     formData.append('constructorArguements', submittedContract.abiEncodedConstructorArgs?.replace('0x', '') ?? '')
 
     const url = new URL(this.apiUrl + '/api')
+    url.searchParams.append('chainid', submittedContract.chainId)
     url.searchParams.append('module', 'contract')
     url.searchParams.append('action', 'verifysourcecode')
     if (this.apiKey) {
@@ -98,6 +98,7 @@ export class EtherscanVerifier extends AbstractVerifier {
     formData.append('expectedimplementation', submittedContract.address)
 
     const url = new URL(this.apiUrl + '/api')
+    url.searchParams.append('chainid', submittedContract.chainId)
     url.searchParams.append('module', 'contract')
     url.searchParams.append('action', 'verifyproxycontract')
     if (this.apiKey) {
@@ -129,8 +130,9 @@ export class EtherscanVerifier extends AbstractVerifier {
     return { status: 'pending', receiptId: verificationResponse.result }
   }
 
-  async checkVerificationStatus(receiptId: string): Promise<VerificationResponse> {
+  async checkVerificationStatus(receiptId: string, chainId: string): Promise<VerificationResponse> {
     const url = new URL(this.apiUrl + '/api')
+    url.searchParams.append('chainid', chainId)
     url.searchParams.append('module', 'contract')
     url.searchParams.append('action', 'checkverifystatus')
     url.searchParams.append('guid', receiptId)
@@ -173,8 +175,9 @@ export class EtherscanVerifier extends AbstractVerifier {
     return { status: 'unknown', receiptId }
   }
 
-  async checkProxyVerificationStatus(receiptId: string): Promise<VerificationResponse> {
+  async checkProxyVerificationStatus(receiptId: string, chainId: string): Promise<VerificationResponse> {
     const url = new URL(this.apiUrl + '/api')
+    url.searchParams.append('chainid', chainId)
     url.searchParams.append('module', 'contract')
     url.searchParams.append('action', 'checkproxyverification')
     url.searchParams.append('guid', receiptId)
@@ -216,6 +219,7 @@ export class EtherscanVerifier extends AbstractVerifier {
 
   async lookup(contractAddress: string, chainId: string): Promise<LookupResponse> {
     const url = new URL(this.apiUrl + '/api')
+    url.searchParams.append('chainid', chainId)
     url.searchParams.append('module', 'contract')
     url.searchParams.append('action', 'getsourcecode')
     url.searchParams.append('address', contractAddress)

--- a/apps/contract-verification/src/app/app.tsx
+++ b/apps/contract-verification/src/app/app.tsx
@@ -123,9 +123,9 @@ const App = () => {
             try {
               let response: VerificationResponse
               if (receipt.isProxyReceipt) {
-                response = await verifier.checkProxyVerificationStatus(receiptId)
+                response = await verifier.checkProxyVerificationStatus(receiptId, contract.chainId)
               } else {
-                response = await verifier.checkVerificationStatus(receiptId)
+                response = await verifier.checkVerificationStatus(receiptId, contract.chainId)
               }
               const { status, message, lookupUrl } = response
               receipt.status = status

--- a/apps/contract-verification/src/app/utils/default-apis.json
+++ b/apps/contract-verification/src/app/utils/default-apis.json
@@ -4,144 +4,110 @@
     "explorerUrl": "https://repo.sourcify.dev"
   },
   "Etherscan": {
+    "apiUrl": "https://api.etherscan.io/v2",
     "1": {
-      "apiUrl": "https://api.etherscan.io",
       "explorerUrl": "https://etherscan.io"
     },
     "56": {
-      "apiUrl": "https://api.bscscan.com",
       "explorerUrl": "https://bscscan.com"
     },
     "137": {
-      "apiUrl": "https://api.polygonscan.com",
       "explorerUrl": "https://polygonscan.com"
     },
     "250": {
-      "apiUrl": "https://api.ftmscan.com",
       "explorerUrl": "https://ftmscan.com"
     },
     "42161": {
-      "apiUrl": "https://api.arbiscan.io",
       "explorerUrl": "https://arbiscan.io"
     },
     "43114": {
-      "apiUrl": "https://api.snowtrace.io",
       "explorerUrl": "https://snowtrace.io"
     },
     "1285": {
-      "apiUrl": "https://api-moonriver.moonscan.io",
       "explorerUrl": "https://moonscan.io"
     },
     "1284": {
-      "apiUrl": "https://api-moonbeam.moonscan.io",
       "explorerUrl": "https://moonscan.io"
     },
     "25": {
-      "apiUrl": "https://api.cronoscan.com",
       "explorerUrl": "https://cronoscan.com"
     },
     "199": {
-      "apiUrl": "https://api.bttcscan.com",
       "explorerUrl": "https://bttcscan.com"
     },
     "10": {
-      "apiUrl": "https://api-optimistic.etherscan.io",
       "explorerUrl": "https://optimistic.etherscan.io"
     },
     "42220": {
-      "apiUrl": "https://api.celoscan.io",
       "explorerUrl": "https://celoscan.io"
     },
     "288": {
-      "apiUrl": "https://api.bobascan.com",
       "explorerUrl": "https://bobascan.com"
     },
     "100": {
-      "apiUrl": "https://api.gnosisscan.io",
       "explorerUrl": "https://gnosisscan.io"
     },
     "1101": {
-      "apiUrl": "https://api-zkevm.polygonscan.com",
       "explorerUrl": "https://zkevm.polygonscan.com"
     },
     "59144": {
-      "apiUrl": "https://api.lineascan.build",
       "explorerUrl": "https://lineascan.build"
     },
     "8453": {
-      "apiUrl": "https://api.basescan.org",
       "explorerUrl": "https://basescan.org"
     },
     "534352": {
-      "apiUrl": "https://api.scrollscan.com",
       "explorerUrl": "https://scrollscan.com"
     },
     "17000": {
-      "apiUrl": "https://api-holesky.etherscan.io",
       "explorerUrl": "https://holesky.etherscan.io"
     },
     "11155111": {
-      "apiUrl": "https://api-sepolia.etherscan.io",
       "explorerUrl": "https://sepolia.etherscan.io"
     },
     "97": {
-      "apiUrl": "https://api-testnet.bscscan.com",
       "explorerUrl": "https://bscscan.com"
     },
     "80001": {
-      "apiUrl": "https://api-testnet.polygonscan.com",
       "explorerUrl": "https://polygonscan.com"
     },
     "4002": {
-      "apiUrl": "https://api-testnet.ftmscan.com",
       "explorerUrl": "https://ftmscan.com"
     },
     "421611": {
-      "apiUrl": "https://api-testnet.arbiscan.io",
       "explorerUrl": "https://arbiscan.io"
     },
     "42170": {
-      "apiUrl": "https://api-nova.arbiscan.io",
       "explorerUrl": "https://nova.arbiscan.io"
     },
     "43113": {
-      "apiUrl": "https://api-testnet.snowtrace.io",
       "explorerUrl": "https://snowtrace.io"
     },
     "1287": {
-      "apiUrl": "https://api-moonbase.moonscan.io",
       "explorerUrl": "https://moonscan.io"
     },
     "338": {
-      "apiUrl": "https://api-testnet.cronoscan.com",
       "explorerUrl": "https://cronoscan.com"
     },
     "1028": {
-      "apiUrl": "https://api-testnet.bttcscan.com",
       "explorerUrl": "https://bttcscan.com"
     },
     "44787": {
-      "apiUrl": "https://api-alfajores.celoscan.io",
       "explorerUrl": "https://alfajores.celoscan.io"
     },
     "2888": {
-      "apiUrl": "https://api-testnet.bobascan.com",
       "explorerUrl": "https://bobascan.com"
     },
     "84532": {
-      "apiUrl": "https://api-sepolia.basescan.org",
       "explorerUrl": "https://sepolia.basescan.org"
     },
     "1442": {
-      "apiUrl": "https://api-testnet-zkevm.polygonscan.com",
       "explorerUrl": "https://zkevm.polygonscan.com"
     },
     "59140": {
-      "apiUrl": "https://api-testnet.lineascan.build",
       "explorerUrl": "https://lineascan.build"
     },
     "534351": {
-      "apiUrl": "https://api-sepolia.scrollscan.com",
       "explorerUrl": "https://sepolia.scrollscan.com"
     }
   },

--- a/apps/contract-verification/src/app/utils/default-settings.ts
+++ b/apps/contract-verification/src/app/utils/default-settings.ts
@@ -13,12 +13,15 @@ export function mergeChainSettingsWithDefaults(chainId: string, userSettings: Co
     let defaultsForVerifier: VerifierSettings
     if (verifierId === 'Sourcify') {
       defaultsForVerifier = DEFAULT_APIS['Sourcify']
+    } else if (verifierId === 'Etherscan') {
+      const apiUrl = DEFAULT_APIS['Etherscan'].apiUrl
+      const explorerUrl = DEFAULT_APIS['Etherscan'][chainId]?.explorerUrl
+      defaultsForVerifier = { apiUrl, explorerUrl }
     } else if (verifierId === 'Routescan') {
       const routescanDefaults = DEFAULT_APIS['Routescan']
 
       if (!routescanDefaults[chainId]) {
         defaultsForVerifier = {}
-
       } else {
         const explorerUrl = routescanDefaults[chainId]?.type === 'mainnet' ? routescanDefaults.mainnetExplorerUrl : routescanDefaults.testnetExplorerUrl
         const apiUrl = routescanDefaults.apiUrl.replace('${CHAIN_TYPE}', routescanDefaults[chainId]?.type).replace('${CHAIN_ID}', chainId)


### PR DESCRIPTION
Etherscan is disabling their v1 API by May 31. This upgrades the verification plugin code to use API v2.