### PR TITLE
Fix duplicate yarn command in Chrome driver installation script

### DIFF
--- a/apps/remix-ide-e2e/install-webdriver.sh
+++ b/apps/remix-ide-e2e/install-webdriver.sh
@@ -39,4 +39,4 @@ fi
 
 
 yarn init -y --cwd "$directory" || exit 1
-yarn add -D chromedriver@135.0.4 geckodriver --cwd  "$directory" ||  yarn add -D chromedriver@135.0.4 geckodriver --cwd  "$directory" || yarn add -D chromedriver geckodriver --cwd  "$directory" || exit 1
+yarn add -D chromedriver@135.0.4 geckodriver --cwd  "$directory" || yarn add -D chromedriver geckodriver --cwd  "$directory" || exit 1


### PR DESCRIPTION
Description:
This PR fixes an issue in the Chrome driver installation script where the same yarn command was duplicated:

```bash
# Before
yarn add -D chromedriver@135.0.4 geckodriver --cwd "$directory" || yarn add -D chromedriver@135.0.4 geckodriver --cwd "$directory" || yarn add -D chromedriver geckodriver --cwd "$directory" || exit 1

# After
yarn add -D chromedriver@135.0.4 geckodriver --cwd "$directory" || yarn add -D chromedriver geckodriver --cwd "$directory" || exit 1
```

The duplicate command was redundant as it was attempting the exact same operation twice, which would not improve the chances of success. This change simplifies the script while maintaining the same fallback logic.