### PR TITLE
replace outdated references

### DIFF
--- a/apps/remix-ide/src/app/plugins/code-format/index.ts
+++ b/apps/remix-ide/src/app/plugins/code-format/index.ts
@@ -6,7 +6,7 @@ import loc from 'prettier-plugin-solidity/src/loc.js';
 import { parse } from './parser'
 
 // https://prettier.io/docs/en/plugins.html#languages
-// https://github.com/ikatyang/linguist-languages/blob/master/data/Solidity.json
+// https://github.com/ikatyang/linguist-languages/blob/master/data/Solidity.js
 const languages = [
   {
     linguistLanguageId: 237469032,

--- a/apps/vyper/src/app/utils/compiler.tsx
+++ b/apps/vyper/src/app/utils/compiler.tsx
@@ -142,7 +142,7 @@ export function toStandardOutput(fileName: string, compilationResult: any): any 
         // If the language used has no contract names, this field should equal to an empty string
         [contractName]: {
           // The Ethereum Contract ABI. If empty, it is represented as an empty array.
-          // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
+          // See https://docs.soliditylang.org/en/latest/abi-spec.html
           abi: compiledAbi,
           contractName: contractName,
           evm: {

--- a/libs/remix-debug/src/code/opcodes.ts
+++ b/libs/remix-debug/src/code/opcodes.ts
@@ -3,7 +3,7 @@ export default function (op, full) {
   const codes = {
     // 0x0 range - arithmetic ops
     // name, baseCost, off stack, on stack, dynamic, async
-    // @todo can be improved on basis of this: https://github.com/ethereumjs/ethereumjs-vm/blob/master/lib/evm/opcodes.ts
+    // @todo can be improved on basis of this: https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/evm/src/opcodes/codes.ts
 
     0x00: ['STOP', 0, 0, 0, false],
     0x01: ['ADD', 3, 2, 1, false],


### PR DESCRIPTION
`https://github.com/ikatyang/linguist-languages/blob/master/data/Solidity.json` - dead link
`https://github.com/ikatyang/linguist-languages/blob/master/data/Solidity.js `- new link 

`https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI` - dead link
`https://docs.soliditylang.org/en/latest/abi-spec.html` - new link

`https://github.com/ethereumjs/ethereumjs-vm/blob/master/lib/evm/opcodes.ts` - old link
`https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/evm/src/opcodes/codes.ts` - new link

Hey, if you have any comments or suggestions, I’d be glad to hear them. 
