### PR TITLE
[fix]: correct "Occurence" to "Occurrence" in NightwatchCustomCommands interface

### DIFF
--- a/apps/remixdesktop/test/types/index.d.ts
+++ b/apps/remixdesktop/test/types/index.d.ts
@@ -24,7 +24,7 @@ declare module 'nightwatch' {
     journalLastChildIncludes(val: string): NightwatchBrowser
     executeScriptInTerminal(script: string): NightwatchBrowser
     clearEditableContent(cssSelector: string): NightwatchBrowser
-    journalChildIncludes(val: string, opts = {shouldHaveOnlyOneOccurence: boolean}): NightwatchBrowser
+    journalChildIncludes(val: string, opts = {shouldHaveOnlyOneOccurrence: boolean}): NightwatchBrowser
     debugTransaction(index: number): NightwatchBrowser
     checkElementStyle(cssSelector: string, styleProperty: string, expectedResult: string): NightwatchBrowser
     openFile(name: string): NightwatchBrowser


### PR DESCRIPTION
correct name is [shouldHaveOnlyOneOccurrence](https://github.com/search?q=repo%3Aethereum%2Fremix-project%20shouldHaveOnlyOneOccurrence&type=code)