### PR TITLE
Fix loading contracts from url

### DIFF
--- a/libs/remix-core-plugin/src/lib/compiler-fetch-and-compile.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-fetch-and-compile.ts
@@ -176,6 +176,21 @@ export class FetchAndCompile extends Plugin {
       }
     }
     const { config, compilationTargets, version } = data
+    /*
+    * If the remappings are defined in the config, we need to update them to point to the targetPath
+    * it's beeing disabled for the moment.
+    */
+    /*if (config && config.settings && config.settings.remappings) {
+      console.log(config.settings.remappings)
+      config.settings.remappings = config.settings.remappings.map((remapping) => {
+        let [virtual, path] = remapping.split('=')
+        if (virtual.includes(':')) {
+          let [scope, path] = virtual.split(':')
+          virtual = `${targetPath}/${scope}:${path}`
+        }
+        return `${virtual}=${targetPath}/${path}`
+      })
+    }*/
 
     try {
       setTimeout(_ => this.emit('compiling', config.settings), 0)

--- a/libs/remix-core-plugin/src/lib/compiler-metadata.ts
+++ b/libs/remix-core-plugin/src/lib/compiler-metadata.ts
@@ -22,11 +22,11 @@ export class CompilerMetadata extends Plugin {
   }
 
   _JSONFileName (path, contractName) {
-    return this.joinPath(path, this.innerPath, contractName + '.json')
+    return this.joinPath(this.innerPath, contractName + '.json')
   }
 
   _MetadataFileName (path, contractName) {
-    return this.joinPath(path, this.innerPath, contractName + '_metadata.json')
+    return this.joinPath(this.innerPath, contractName + '_metadata.json')
   }
 
   onActivation () {
@@ -53,7 +53,7 @@ export class CompilerMetadata extends Plugin {
   // Access each file in build-info, check the input sources
   // If they are all same as in current compiled file and sources includes the path of compiled file, remove old build file
   async removeStoredBuildInfo (currentInput, path, filePath) {
-    const buildDir = this.joinPath(path, this.innerPath, 'build-info/')
+    const buildDir = this.joinPath(this.innerPath, 'build-info/')
     if (await this.call('fileManager', 'exists', buildDir)) {
       const allBuildFiles = await this.call('fileManager', 'fileList', buildDir)
       const currentInputFileNames = Object.keys(currentInput.sources)
@@ -79,7 +79,7 @@ export class CompilerMetadata extends Plugin {
       input
     })
     const id = createHash('md5').update(Buffer.from(json)).digest().toString('hex')
-    const buildFilename = this.joinPath(path, this.innerPath, 'build-info/' + id + '.json')
+    const buildFilename = this.joinPath(this.innerPath, 'build-info/' + id + '.json')
     // If there are no file in buildInfoNames,it means compilation is running first time after loading Remix
     if (!this.buildInfoNames[filePath]) {
       // Check the existing build-info and delete all the previous build files for compiled file

--- a/libs/remix-ui/workspace/src/lib/actions/index.tsx
+++ b/libs/remix-ui/workspace/src/lib/actions/index.tsx
@@ -29,6 +29,7 @@ export type UrlParametersType = {
   opendir: string,
   blockscout: string,
   ghfolder: string
+  endpoint: string
 }
 
 const basicWorkspaceInit = async (workspaces: { name: string; isGitRepo: boolean; }[], workspaceProvider) => {
@@ -136,39 +137,25 @@ export const initWorkspace = (filePanelPlugin) => async (reducerDispatch: React.
         try {
           let etherscanKey = await plugin.call('config', 'getAppParameter', 'etherscan-access-token')
           if (!etherscanKey) etherscanKey = '2HKUX5ZVASZIKWJM8MIQVCRUVZ6JAWT531'
-          const networks = [
-            { id: 1, name: 'mainnet' },
-            { id: 11155111, name: 'sepolia' }
-          ]
-          let found = false
           const workspaceName = 'code-sample'
           let filePath
           const foundOnNetworks = []
-          for (const network of networks) {
-            const target = `/${network.name}/${contractAddress}`
-            try {
-              data = await fetchContractFromEtherscan(plugin, network, contractAddress, target, false, etherscanKey)
-            } catch (error) {
-              if ((error.message.startsWith('contract not verified on Etherscan') || error.message.startsWith('unable to retrieve contract data')) && network.id !== 5)
-                continue
-              else {
-                if (!found) await basicWorkspaceInit(workspaces, workspaceProvider)
-                break
-              }
-            }
-            found = true
-            foundOnNetworks.push(network.name)
-            if (await workspaceExists(workspaceName)) workspaceProvider.setWorkspace(workspaceName)
-            else await createWorkspaceTemplate(workspaceName, 'code-template')
-            plugin.setWorkspace({ name: workspaceName, isLocalhost: false })
-            dispatch(setCurrentWorkspace({ name: workspaceName, isGitRepo: false }))
-            count = count + (Object.keys(data.compilationTargets)).length
-            for (filePath in data.compilationTargets)
-              await workspaceProvider.set(filePath, data.compilationTargets[filePath]['content'])
+          const endpoint = params.endpoint || 'api.etherscan.io'
+          try {
+            data = await fetchContractFromEtherscan(plugin, endpoint, contractAddress, '', false, etherscanKey)
+          } catch (error) {
+            await basicWorkspaceInit(workspaces, workspaceProvider)
+          }
+          if (await workspaceExists(workspaceName)) workspaceProvider.setWorkspace(workspaceName)
+          else await createWorkspaceTemplate(workspaceName, 'code-template')
+          plugin.setWorkspace({ name: workspaceName, isLocalhost: false })
+          dispatch(setCurrentWorkspace({ name: workspaceName, isGitRepo: false }))
+          count = count + (Object.keys(data.compilationTargets)).length
+          for (filePath in data.compilationTargets)
+            await workspaceProvider.set(filePath, data.compilationTargets[filePath]['content'])
 
-            if (data.config) {
-              await workspaceProvider.set('compiler_config.json', JSON.stringify(data.config, null, '\t'))
-            }
+          if (data.config) {
+            await workspaceProvider.set('compiler_config.json', JSON.stringify(data.config, null, '\t'))
           }
 
           plugin.on('filePanel', 'workspaceInitializationCompleted', async () => {


### PR DESCRIPTION
fix https://github.com/ethereum/remix-project/issues/6041

- always save artifact in the root folder.
- fix remappings when compiling a contract from the `.debug` folder.
- pass the endpoint URL to the  etherscan resolver.