### PR TITLE
Fix using matomo api

### DIFF
--- a/apps/remix-ide-e2e/src/tests/matomo.test.ts
+++ b/apps/remix-ide-e2e/src/tests/matomo.test.ts
@@ -76,7 +76,7 @@ module.exports = {
             browser.execute(function () {
                 localStorage.removeItem('config-v0.8:.remix.config')
                 localStorage.setItem('showMatomo', 'true')
-                localStorage.removeItem('matomo-perf-analytics-consent')
+                localStorage.removeItem('matomo-analytics-consent')
             }, [])
                 .refreshPage()
                 .perform(done())
@@ -137,7 +137,7 @@ module.exports = {
             browser.execute(function () {
                 const oldTimestamp = new Date()
                 oldTimestamp.setMonth(oldTimestamp.getMonth() - 7)
-                localStorage.setItem('matomo-perf-analytics-consent', oldTimestamp.getTime().toString())
+                localStorage.setItem('matomo-analytics-consent', oldTimestamp.getTime().toString())
             }, [])
                 .refreshPage()
                 .perform(done())
@@ -149,7 +149,7 @@ module.exports = {
             })
             .execute(function () {
 
-                const timestamp = window.localStorage.getItem('matomo-perf-analytics-consent');
+                const timestamp = window.localStorage.getItem('matomo-analytics-consent');
                 if (timestamp) {
 
                     const consentDate = new Date(Number(timestamp));
@@ -179,7 +179,7 @@ module.exports = {
             browser.execute(function () {
                 const recentTimestamp = new Date()
                 recentTimestamp.setMonth(recentTimestamp.getMonth() - 1)
-                localStorage.setItem('matomo-perf-analytics-consent', recentTimestamp.getTime().toString())
+                localStorage.setItem('matomo-analytics-consent', recentTimestamp.getTime().toString())
             }, [])
                 .refreshPage()
                 .perform(done())
@@ -187,7 +187,7 @@ module.exports = {
             // check if timestamp is younger than 6 months
             .execute(function () {
 
-                const timestamp = window.localStorage.getItem('matomo-perf-analytics-consent');
+                const timestamp = window.localStorage.getItem('matomo-analytics-consent');
                 if (timestamp) {
 
                     const consentDate = new Date(Number(timestamp));
@@ -221,7 +221,7 @@ module.exports = {
             browser.execute(function () {
                 localStorage.removeItem('config-v0.8:.remix.config')
                 localStorage.setItem('showMatomo', 'true')
-                localStorage.removeItem('matomo-perf-analytics-consent')
+                localStorage.removeItem('matomo-analytics-consent')
             }, [])
                 .refreshPage()
                 .perform(done())
@@ -237,7 +237,7 @@ module.exports = {
             .pause(2000)
             .execute(function () {
 
-                const timestamp = window.localStorage.getItem('matomo-perf-analytics-consent');
+                const timestamp = window.localStorage.getItem('matomo-analytics-consent');
                 if (timestamp) {
 
                     const consentDate = new Date(Number(timestamp));
@@ -263,7 +263,7 @@ module.exports = {
             browser.execute(function () {
                 const oldTimestamp = new Date()
                 oldTimestamp.setMonth(oldTimestamp.getMonth() - 7)
-                localStorage.setItem('matomo-perf-analytics-consent', oldTimestamp.getTime().toString())
+                localStorage.setItem('matomo-analytics-consent', oldTimestamp.getTime().toString())
             }, [])
                 .refreshPage()
                 .perform(done())
@@ -281,7 +281,7 @@ module.exports = {
             browser.execute(function () {
                 const recentTimestamp = new Date()
                 recentTimestamp.setMonth(recentTimestamp.getMonth() - 1)
-                localStorage.setItem('matomo-perf-analytics-consent', recentTimestamp.getTime().toString())
+                localStorage.setItem('matomo-analytics-consent', recentTimestamp.getTime().toString())
             }, [])
                 .refreshPage()
                 .perform(done())
@@ -300,7 +300,7 @@ module.exports = {
                 localStorage.removeItem('config-v0.8:.remix.config')
                 const recentTimestamp = new Date()
                 recentTimestamp.setMonth(recentTimestamp.getMonth() - 1)
-                localStorage.setItem('matomo-perf-analytics-consent', recentTimestamp.getTime().toString())
+                localStorage.setItem('matomo-analytics-consent', recentTimestamp.getTime().toString())
             }, [])
                 .refreshPage()
                 .perform(done())
@@ -315,7 +315,7 @@ module.exports = {
                 localStorage.removeItem('config-v0.8:.remix.config')
                 const oldTimestamp = new Date()
                 oldTimestamp.setMonth(oldTimestamp.getMonth() - 7)
-                localStorage.setItem('matomo-perf-analytics-consent', oldTimestamp.getTime().toString())
+                localStorage.setItem('matomo-analytics-consent', oldTimestamp.getTime().toString())
             }, [])
                 .refreshPage()
                 .perform(done())

--- a/apps/remix-ide/src/app.ts
+++ b/apps/remix-ide/src/app.ts
@@ -226,7 +226,7 @@ class AppComponent {
 
     const electronTracking = (window as any).electronAPI ? await (window as any).electronAPI.canTrackMatomo() : false
 
-    const lastMatomoCheck = window.localStorage.getItem('matomo-perf-analytics-consent')
+    const lastMatomoCheck = window.localStorage.getItem('matomo-analytics-consent')
     const sixMonthsAgo = new Date();
     sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6);
 

--- a/apps/remix-ide/src/app/tabs/settings-tab.tsx
+++ b/apps/remix-ide/src/app/tabs/settings-tab.tsx
@@ -129,14 +129,14 @@ export default class SettingsTab extends ViewPlugin {
   updateMatomoPerfAnalyticsChoice(isChecked) {
     this.config.set('settings/matomo-perf-analytics', isChecked)
     // set timestamp to local storage to track when the user has given consent
-    localStorage.setItem('matomo-perf-analytics-consent', Date.now().toString())
+    localStorage.setItem('matomo-analytics-consent', Date.now().toString())
     this.useMatomoPerfAnalytics = isChecked
     if (!isChecked) {
       // revoke tracking consent for performance data
-      _paq.push(['forgetMatomoPerfConsentGiven'])
+      _paq.push(['disableCookies'])
     } else {
       // user has given consent to process their performance data
-      _paq.push(['setMatomoPerfConsentGiven'])
+      _paq.push(['setCookieConsentGiven'])
     }
     this.dispatch({
       ...this

--- a/apps/remix-ide/src/assets/js/loader.js
+++ b/apps/remix-ide/src/assets/js/loader.js
@@ -18,25 +18,8 @@ function trackDomain(domainToTrack) {
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   _paq.push(['enableHeartBeatTimer']);
-  const remixConfig = window.localStorage.getItem('config-v0.8:.remix.config');
-  if (!remixConfig || (remixConfig && !remixConfig.includes('settings/matomo-analytics'))) {
-    // require user tracking consent before processing data
-    _paq.push(['requireConsent']);
-  } else {
-    try {
-      const config = JSON.parse(remixConfig);
-      if (config['settings/matomo-analytics'] === true) {
-        // user has given consent to process their data
-        _paq.push(['setConsentGiven']);
-      } else {
-        // user has not given consent to process their data
-        _paq.push(['requireConsent']);
-      }
-    } catch (e) {
-      console.error('Error parsing remix config:', e);
-      _paq.push(['requireConsent']);
-    }
-  }
+  _paq.push(['setConsentGiven']);
+  _paq.push(['requireCookieConsent']);
   _paq.push(['trackEvent', 'loader', 'load']);
   (function () {
     var u = "https://ethereumfoundation.matomo.cloud/";

--- a/libs/remix-ui/app/src/lib/remix-app/components/modals/managePreferences.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/components/modals/managePreferences.tsx
@@ -117,13 +117,6 @@ const ManagePreferencesDialog = (props) => {
     _paq.push(['setConsentGiven']) // default consent to process their anonymous data
     settings.updateMatomoAnalyticsChoice(true) // Always true for matomo Anonymous analytics
     settings.updateMatomoPerfAnalyticsChoice(switcherState.current.matPerfSwitch) // Enable/Disable Matomo Performance analytics
-    if (switcherState.current.matPerfSwitch) {
-      // user has given consent to process their performance data
-      _paq.push(['setMatomoPerfConsentGiven'])
-    } else {
-      // revoke tracking consent for performance data
-      _paq.push(['forgetMatomoPerfConsentGiven'])
-    }
     settings.updateCopilotChoice(switcherState.current.remixAISwitch) // Enable/Disable RemixAI copilot
     setVisible(false)
     props.savePreferencesFn()

--- a/libs/remix-ui/app/src/lib/remix-app/components/modals/matomo.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/components/modals/matomo.tsx
@@ -66,8 +66,6 @@ const MatomoDialog = (props: MatomoDialogProps) => {
   }, [visible])
 
   const handleAcceptAllClick = async () => {
-    _paq.push(['setConsentGiven']) // default consent to process their anonymous data
-    _paq.push(['setMatomoPerfConsentGiven']) // user has given consent to process their performance data
     settings.updateMatomoAnalyticsChoice(true) // Enable Matomo Anonymous analytics
     settings.updateMatomoPerfAnalyticsChoice(true) // Enable Matomo Performance analytics
     settings.updateCopilotChoice(true) // Enable RemixAI copilot

--- a/libs/remix-ui/settings/src/lib/settingsAction.ts
+++ b/libs/remix-ui/settings/src/lib/settingsAction.ts
@@ -41,14 +41,15 @@ export const copilotTemperature = (config, checked, dispatch) => {
 
 export const useMatomoPerfAnalytics = (config, checked, dispatch) => {
   config.set('settings/matomo-perf-analytics', checked)
-  localStorage.setItem('matomo-perf-analytics-consent', Date.now().toString())
+  localStorage.setItem('matomo-analytics-consent', Date.now().toString())
   dispatch({ type: 'useMatomoPerfAnalytics', payload: { isChecked: checked, textClass: checked ? textDark : textSecondary } })
   if (checked) {
     // user has given consent to process their performance data
-    _paq.push(['setMatomoPerfConsentGiven'])
+    _paq.push(['setCookieConsentGiven'])
+
   } else {
     // revoke tracking consent for performance data
-    _paq.push(['forgetMatomoPerfConsentGiven'])
+    _paq.push(['disableCookies'])
   }
 }
 


### PR DESCRIPTION
- better to keep using `matomo-analytics-consent` for storing the last time matomo was accepted/rejected.
- forgetMatomoPerfConsentGiven and setMatomoPerfConsentGiven are not in the matomo api, it is either disableCookies/setCookieConsentGiven .
- by default cookies are disabled.
- fix some redundancy in calling the matomo api.