### PR TITLE
Fix broken link to Ethereum Contract ABI specification

### DIFF
--- a/apps/vyper/src/app/utils/compiler.tsx
+++ b/apps/vyper/src/app/utils/compiler.tsx
@@ -141,7 +141,7 @@ export function toStandardOutput(fileName: string, compilationResult: any): any 
         // If the language used has no contract names, this field should equal to an empty string
         [contractName]: {
           // The Ethereum Contract ABI. If empty, it is represented as an empty array.
-          // See https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
+          // See https://docs.soliditylang.org/en/latest/abi-spec.html
           abi: compiledAbi,
           contractName: contractName,
           evm: {


### PR DESCRIPTION
Replaced the outdated link to the Ethereum Contract ABI specification (previously pointing to the old GitHub wiki) with the current official Solidity documentation link: https://docs.soliditylang.org/en/latest/abi-spec.html. This ensures that users and developers are directed to the most up-to-date and authoritative resource for ABI details.