### PR TITLE
[QA Fix] Pin Permissions button to bottom of Plugin Manager

### DIFF
--- a/libs/remix-ui/plugin-manager/src/lib/components/rootView.tsx
+++ b/libs/remix-ui/plugin-manager/src/lib/components/rootView.tsx
@@ -109,7 +109,9 @@ function RootView({ pluginComponent, children, filterByRemix, setFilterByRemix, 
             </div>
           </div>
         </header>
-        {children}
+        <div className="plugin-content">
+          {children}
+        </div>
         <PermisssionsSettings />
       </div>
       <LocalPluginForm closeModal={closeModal} visible={visible} pluginManager={pluginComponent} />

--- a/libs/remix-ui/plugin-manager/src/lib/remix-ui-plugin-manager.css
+++ b/libs/remix-ui/plugin-manager/src/lib/remix-ui-plugin-manager.css
@@ -54,12 +54,13 @@
 }
 
 .remixui_permissions {
+  flex-shrink: 0;
   position: sticky;
   bottom: 0;
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  padding: 5px 20px;
+  padding: 10px 20px 20px 20px;
 }
 .remixui_permissions button {
   padding: 2px 5px;
@@ -92,8 +93,14 @@
   font-size: 1rem;
 }
 #pluginManager {
-  overflow-y: scroll;
+  display: flex;
+  flex-direction: column;
   height: 100%;
+  overflow: hidden;
+}
+#pluginManager .plugin-content {
+  flex: 1;
+  overflow-y: auto;
 }
 .search-bar-container {
   position: relative;


### PR DESCRIPTION
This PR addresses a QA-reported issue in the Plugin Manager:
- Adjusted layout so that only the plugin list is scrollable, while the Permissions button remains pinned at the bottom.

Tested locally, ready for review.