### PR TITLE
Fix: Remove deprecated partialVisbile typo property

### DIFF
--- a/libs/remix-ui/home-tab/src/lib/components/types/carouselTypes.ts
+++ b/libs/remix-ui/home-tab/src/lib/components/types/carouselTypes.ts
@@ -49,7 +49,6 @@ export interface CarouselProps {
   // partialVisible has to be used in conjunction with the responsive props, details are in documentation.
   // it shows the next set of items partially, different from centerMode as it shows both.
   partialVisible?: boolean;
-  partialVisbile?: boolean; // old typo - deprecated (will be remove in 3.0)
   customTransition?: string;
   transitionDuration?: number;
   // if you are using customTransition, make sure to put the duration here.


### PR DESCRIPTION
Removes the deprecated `partialVisbile` property (typo) from `CarouselProps` interface. This property was marked for removal and the correct `partialVisible` property is already available and in use.
