### PR TITLE
patch verification

### DIFF
--- a/apps/contract-verification/src/app/ContractVerificationPluginClient.ts
+++ b/apps/contract-verification/src/app/ContractVerificationPluginClient.ts
@@ -9,6 +9,7 @@ import { CompilerAbstract } from '@remix-project/remix-solidity'
 
 export class ContractVerificationPluginClient extends PluginClient {
   public internalEvents: EventManager
+  private _isActivated: boolean = false
 
   constructor() {
     super()
@@ -19,7 +20,12 @@ export class ContractVerificationPluginClient extends PluginClient {
   }
 
   onActivation(): void {
+    this._isActivated = true
     this.internalEvents.emit('verification_activated')
+  }
+
+  isActivated(): boolean {
+    return this._isActivated
   }
 
   async lookupAndSave(verifierId: string, chainId: string, contractAddress: string): Promise<LookupResponse> {

--- a/apps/contract-verification/src/app/app.tsx
+++ b/apps/contract-verification/src/app/app.tsx
@@ -41,7 +41,7 @@ const App = () => {
   const timer = useRef(null)
 
   useEffect(() => {
-    plugin.internalEvents.on('verification_activated', () => {
+    const initializePlugin = () => {
       // @ts-ignore
       plugin.call('locale', 'currentLocale').then((locale: any) => {
         setLocale(locale)
@@ -51,6 +51,7 @@ const App = () => {
       plugin.on('locale', 'localeChanged', (locale: any) => {
         setLocale(locale)
       })
+      
       // Fetch compiler artefacts initially
       plugin.call('compilerArtefacts' as any, 'getAllCompilerAbstracts').then((obj: any) => {
         setCompilationOutput(obj)
@@ -60,7 +61,17 @@ const App = () => {
       plugin.on('compilerArtefacts' as any, 'compilationSaved', (compilerAbstracts: { [key: string]: CompilerAbstract }) => {
         setCompilationOutput((prev) => ({ ...(prev || {}), ...compilerAbstracts }))
       })
-    })
+    }
+
+    // Check if plugin is already activated
+    if (plugin.isActivated()) {
+      initializePlugin()
+    } else {
+      // Listen for activation event if not yet activated
+      plugin.internalEvents.once('verification_activated', () => {
+        initializePlugin()
+      })
+    }
 
     // Fetch chains.json and update state
     fetch('https://chainid.network/chains.json')


### PR DESCRIPTION
fix race conditions 

this has to with this button reacting to compilation events

<img width="719" height="191" alt="Screenshot 2025-10-27 at 08 56 59" src="https://github.com/user-attachments/assets/808d33cf-0f97-487b-9fbd-b5f8c1401da4" />

in Desktop it would not happen because the listeners were only set when the plugin emits activation events but this event got lost if the react App component wasn't rendered yet. so having the app check if the plugin is already activated fixes that. 

So test by looking at the button reacting to compilation. 
