### PR TITLE
Implement priority sorting logic for LearnEth tutorials

### DIFF
--- a/apps/learneth/src/pages/Home/index.tsx
+++ b/apps/learneth/src/pages/Home/index.tsx
@@ -103,7 +103,7 @@ function HomePage(): JSX.Element {
           levelText,
           name: entity.name || '',
           subtitle: tags.join(', '),
-          preview: mdToPlain(entity.description?.content || '', 280),
+          preview: mdToPlain(entity.metadata?.data?.summary || '', 280),
           stepsLen: entity.steps?.length,
           duration: entity.metadata?.data?.duration,
           tags,


### PR DESCRIPTION
fixes #6501

This PR implements the new sorting logic for LearnEth tutorials as requested and sets the filter panel to be open by default.

**Key Changes**
* **New Sorting Logic (`Home/index.tsx`):**
    1.  By `Level` (asc)
    2.  By `priority` (asc, lower numbers first)
    3.  By `name` (alphabetical)
    * Items without a `priority` are sorted last, alphabetically by name.
* **Filter Panel Default State (`Home/index.tsx`):**
    * Changed the default state of `showFilters` to `true`.
* **Mock Data for Testing (`workshop.ts`):**
    * Since the remote `.yml` files are not yet updated with the `priority` field, I have added mock data in `workshop.ts` to allow for immediate testing.
    * The original `loadRepo` function is commented out, and a temporary `loadRepo` is used to inject this mock data.
    * Once the real `.yml` files are updated and deployed, `workshop.ts` can be easily reverted (uncomment original function, delete mock data).

@ryestew Please review the new sorting logic and the default filter state. 