### PR TITLE
fix etherscan api key warning

### DIFF
--- a/apps/contract-verification/src/app/ContractVerificationPluginClient.ts
+++ b/apps/contract-verification/src/app/ContractVerificationPluginClient.ts
@@ -132,7 +132,7 @@ export class ContractVerificationPluginClient extends PluginClient {
         if (validConfiguration(chainSettings, verifier)) {
           if (verifier === 'Etherscan' && !etherscanApiKey) {
             this.call('terminal', 'log', { type: 'warn', value: 'Etherscan verification skipped: API key not provided for auto-verification.' })
-            this.call('terminal', 'log', { type: 'warn', value: 'Go to the Settings panel input the key.' })
+            this.call('terminal', 'log', { type: 'warn', value: `Go to contract verification plugin's settings tab & input the API key.` })
             continue
           }
           verificationPromises.push(this._verifyWithProvider(verifier, submittedContract, compilerAbstract, chainId, chainSettings))


### PR DESCRIPTION
Clarify Etherscan auto verification when API key is missing