### PR TITLE
chore(license): update year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Remix labs
+   Copyright 2026 Remix labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updates the copyright year from 2025 to 2026.

Keeping license files current for the new year.