### PR TITLE
fix deleting workspace

### DIFF
--- a/libs/remix-ui/top-bar/src/lib/remix-ui-topbar.tsx
+++ b/libs/remix-ui/top-bar/src/lib/remix-ui-topbar.tsx
@@ -205,6 +205,7 @@ export function RemixUiTopbar() {
         switchWorkspace(NO_WORKSPACE)
       }
     }
+    updateMenuItems()
   }, [global.fs.browser.workspaces, global.fs.browser.workspaces.length])
 
   useEffect(() => {
@@ -285,6 +286,7 @@ export function RemixUiTopbar() {
   const onFinishDeleteWorkspace = async (workspaceName?: string) => {
     try {
       await deleteWorkspace(workspaceName)
+      await updateMenuItems()
     } catch (e) {
       global.modal(
         intl.formatMessage({ id: 'filePanel.workspace.delete' }),


### PR DESCRIPTION
fixes #6445 

Delete workspace modal already shows workspace name to be deleted on modal. This PR is removing the deleted workspace immediately from dropdown list. 