### PR TITLE
fix: correct typos and errors in documentation files

### DIFF
--- a/OLLAMA_SETUP.md
+++ b/OLLAMA_SETUP.md
@@ -23,10 +23,10 @@ Ollama is a local AI model runner that allows you to run large language models o
 - **Fill-in-Middle (FIM) support**: Advanced code completion capabilities
 
 ## Model compatible with the Remix IDE
-The folowing is a list of model compatible with the Remix IDE (both desktop and web). The models have been tested to provide acceptable results on mid-tier consumer GPUs. As operating Ollama independently, the user should understand the model performance criteria and their hardware specifications.
+The following is a list of models compatible with the Remix IDE (both desktop and web). The models have been tested to provide acceptable results on mid-tier consumer GPUs. As operating Ollama independently, the user should understand the model performance criteria and their hardware specifications.
 
 - **codestral:latest**
-- **quen3-coder:latest**
+- **qwen3-coder:latest**
 - **gpt-oss:latest**
 - **deepseek-coder-v2:latest** Great for code completion
 

--- a/libs/remix-ai-core/README.md
+++ b/libs/remix-ai-core/README.md
@@ -1,7 +1,7 @@
 # remix-ai-core
 
-[![npm version](https://badge.fury.io/js/%40remix-project%2Fremixd.svg)](https://www.npmjs.com/package/@remix-project/remixd)
-[![npm](https://img.shields.io/npm/dt/@remix-project/remixd.svg?label=Total%20Downloads&logo=npm)](https://www.npmjs.com/package/@remix-project/remixd)
-[![npm](https://img.shields.io/npm/dw/@remix-project/remixd.svg?logo=npm)](https://www.npmjs.com/package/@remix-project/remixd)
+[![npm version](https://badge.fury.io/js/%40remix-project%2Fremix-ai-core.svg)](https://www.npmjs.com/package/@remix-project/remix-ai-core)
+[![npm](https://img.shields.io/npm/dt/@remix-project/remix-ai-core.svg?label=Total%20Downloads&logo=npm)](https://www.npmjs.com/package/@remix-project/remix-ai-core)
+[![npm](https://img.shields.io/npm/dw/@remix-project/remix-ai-core.svg?logo=npm)](https://www.npmjs.com/package/@remix-project/remix-ai-core)
 
 

--- a/libs/remix-core-plugin/README.md
+++ b/libs/remix-core-plugin/README.md
@@ -1,3 +1,3 @@
-# remix-core-plugin-core-plugin
+# remix-core-plugin
 
 This library was generated with [Nx](https://nx.dev).

--- a/libs/remix-debug/README.md
+++ b/libs/remix-debug/README.md
@@ -1,4 +1,4 @@
-## Remix Debug`
+## Remix Debug
 [![npm version](https://badge.fury.io/js/%40remix-project%2Fremix-debug.svg)](https://www.npmjs.com/package/@remix-project/remix-debug)
 [![npm](https://img.shields.io/npm/dt/@remix-project/remix-debug.svg?label=Total%20Downloads)](https://www.npmjs.com/package/@remix-project/remix-debug)
 [![npm](https://img.shields.io/npm/dw/@remix-project/remix-debug.svg)](https://www.npmjs.com/package/@remix-project/remix-debug)

--- a/team-best-practices.md
+++ b/team-best-practices.md
@@ -184,4 +184,4 @@ Before starting coding, we should ensure all devs / contributors are aware of:
 
 # Coding best practices
 
- - https://github.com/ethereum/remix-project/blob/master/CONTRIBUTING.md
+ - https://github.com/remix-project-org/remix-project/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
## Summary
- Fix extra backtick in `libs/remix-debug/README.md` heading
- Fix typo "folowing" to "following" and "quen3-coder" to "qwen3-coder" in `OLLAMA_SETUP.md`
- Fix duplicate "core-plugin" in `libs/remix-core-plugin/README.md` heading
- Fix incorrect npm badges in `libs/remix-ai-core/README.md` (was showing remixd badges instead of remix-ai-core)
- Fix outdated GitHub URL in `team-best-practices.md` (ethereum -> remix-project-org)

## Test plan
- [x] Verify all markdown renders correctly
- [x] Verify npm badge links point to correct packages
- [x] Verify GitHub URLs resolve correctly