### PR TITLE
docs: fix typos and grammar in workspace template READMEs

### DIFF
--- a/libs/remix-ws-templates/src/templates/hashchecker/README.md
+++ b/libs/remix-ws-templates/src/templates/hashchecker/README.md
@@ -7,7 +7,7 @@ The workspace comprises two main directories:
 
 ### circuits: Contains sample Hash Checker contracts. These can be compiled to generate a witness using 'Circom ZKP Compiler' plugin.
 
-### scripts: Provides a sample script designed for a trusted setup using snarkjs. This script also aids in generating Solidity code, which is essential for on-chain deployment. There are 2 scripts options to choose from, Groth16 and Plonk.
+### scripts: Provides a sample script designed for a trusted setup using snarkjs. This script also aids in generating Solidity code, which is essential for on-chain deployment. There are 2 script options to choose from: Groth16 and Plonk.
 
 ### first steps:
 

--- a/libs/remix-ws-templates/src/templates/rln/README.md
+++ b/libs/remix-ws-templates/src/templates/rln/README.md
@@ -9,13 +9,13 @@ To learn more about RLN and how it works - check out [documentation](https://rat
 
 The workspace comprises two main directories:
 
-### circuits: Contains sample semaphore contracts. These can be compiled to generate a witness using 'Circom ZKP Compiler' plugin.
+### circuits: Contains sample RLN circuits. These can be compiled to generate a witness using 'Circom ZKP Compiler' plugin.
 
 ### scripts: Provides a sample script designed for a trusted setup using snarkjs. This script also aids in generating Solidity code, which is essential for on-chain deployment.
 
 ### first steps:
 
-#### 1) compile the semaphore circuit using the remix circom compiler. This will generate artifacts.
+#### 1) compile the RLN circuit using the remix circom compiler. This will generate artifacts.
 
 #### 2) execute the file `run_setup.ts`:
 
@@ -29,8 +29,8 @@ This generates a verification key (`./zk/build/verification_key.json`) and artif
 
 This script:
 
-- creates a list of identity commitments and add it to a `IncrementalMerkleTree`. The tree is used to generate a merkle proof that a specified identity is actually in the tree (see`tree.createProof(0)`).
+- creates a list of identity commitments and adds it to an `IncrementalMerkleTree`. The tree is used to generate a merkle proof that a specified identity is actually in the tree (see `tree.createProof(0)`).
 
-- generate a witness and a proof of execution with `messageId`equal to 0.
+- generates a witness and a proof of execution with `messageId` equal to 0.
 
-- generating 2 proofs (two different messages) with the same `messageId` reveal the two points of the polynomial necessary to deduce the `identitySecret` (using `shamirRecovery`).
+- generating 2 proofs (two different messages) with the same `messageId` reveals the two points of the polynomial necessary to deduce the `identitySecret` (using `shamirRecovery`).

--- a/libs/remix-ws-templates/src/templates/simpleEip7702/README.md
+++ b/libs/remix-ws-templates/src/templates/simpleEip7702/README.md
@@ -1,15 +1,15 @@
 # EIP 7702
 
-This Workspace Template present one of the updates shipped with the Pectra upgrade which occurred in May 2025.
+This Workspace Template presents one of the updates shipped with the Pectra upgrade which occurred in May 2025.
 
 ### Basics
 
 In the Ethereum blockchain there are two different types of accounts:
-- Externally Owned Account (EOA): which require a private key and could initiate transactions.
-- Smart Contract Account: which represents code deployed in the blockchain.
+- Externally Owned Account (EOA): which requires a private key and can initiate transactions.
+- Smart Contract Account: which represents code deployed on the blockchain.
 
-These two concepts are separated: e.g until now EOAs doesn't have code associated to them.
-But with the Pectra upgrade, EOA can now host code and can directly run code.
+These two concepts are separated: e.g. until now EOAs don't have code associated with them.
+But with the Pectra upgrade, EOAs can now host code and can directly run code.
 
 For more information please see [this page](https://eip7702.io)
 
@@ -17,11 +17,11 @@ For more information please see [this page](https://eip7702.io)
 
 This section explains how to run this project. We are going to assign a piece of code to an EOA:
 
-- Open and Comple the file `Example7702.sol`.
-- From the `Run and Deploy` module switch the `Remix VM (pectra)` provider.
-- Deploy the contract above (this will be deployed to the in-browser blockchain)
+- Open and Compile the file `Example7702.sol`.
+- From the `Deploy & Run` module switch to the `Remix VM (pectra)` provider.
+- Deploy the contract above (this will be deployed to the in-browser blockchain).
 - Copy the address of the contract to the clipboard.
-- Click on `Delegation Authorization`
+- Click on `Delegation Authorization`.
 - In the Modal dialog, paste the contract's address and validate.
 - Check in the terminal that the "Delegation" has been "activated".
 - Check the list of deployed contracts, you'll see a new instance that calls the current account. This account now also executes code!


### PR DESCRIPTION
## Summary
Fix various typos and grammatical errors in workspace template README files.

### simpleEip7702/README.md
- Fix "present" -> "presents"
- Fix "which require" -> "which requires"
- Fix "could initiate" -> "can initiate"
- Fix "deployed in" -> "deployed on"
- Fix "EOAs doesn't have" -> "EOAs don't have"
- Fix "associated to" -> "associated with"
- Fix "EOA can now" -> "EOAs can now"
- Fix "Comple" -> "Compile"
- Fix "Run and Deploy" -> "Deploy & Run" (to match actual UI)

### hashchecker/README.md
- Fix "2 scripts options" -> "2 script options"

### rln/README.md
- Fix "sample semaphore contracts" -> "sample RLN circuits" (correct terminology for RLN workspace)
- Fix "compile the semaphore circuit" -> "compile the RLN circuit"
- Add missing space before parenthesis
- Fix grammatical consistency in verb tenses

## Test plan
- [x] Verify all markdown renders correctly
- [x] Verify terminology matches the actual workspace content