### PR TITLE
fix(quick-dapp-v2): resolve infinite spinner bug and improve sign-in UX

### DIFF
--- a/apps/remix-ide/src/app/plugins/ai-dapp-generator.ts
+++ b/apps/remix-ide/src/app/plugins/ai-dapp-generator.ts
@@ -5,7 +5,7 @@ const profile = {
   name: 'ai-dapp-generator',
   displayName: 'AI DApp Generator',
   description: 'AI-powered DApp frontend generator',
-  methods: ['generateDapp', 'updateDapp', 'resetDapp', 'getContext', 'getLastGeneratedDapp'],
+  methods: ['generateDapp', 'updateDapp', 'resetDapp', 'getContext', 'getLastGeneratedDapp', 'consumePendingResult', 'getAllPendingSlugs'],
   events: ['dappGenerated', 'dappUpdated', 'generationProgress'],
   version: '1.0.0'
 }
@@ -35,25 +35,60 @@ interface Pages {
 
 export class AIDappGenerator extends Plugin {
   private contexts: Map<string, DappGenerationContext> = new Map()
+  // Buffer for generation results — survives plugin reactivation cycles
+  private pendingResults: Map<string, { address: string, content: Pages, isUpdate: boolean }> = new Map()
 
   constructor() {
     super(profile)
+  }
+
+  async onActivation() {
+    // no-op
+  }
+
+  onDeactivation() {
+    // no-op (pendingResults intentionally preserved)
+  }
+
+  /**
+   * Consume a pending result for a given slug.
+   * Called by quick-dapp-v2 UI on initApp to recover missed events.
+   */
+  async consumePendingResult(slug: string): Promise<{ address: string, content: Pages, isUpdate: boolean } | null> {
+    const result = this.pendingResults.get(slug)
+    if (result) {
+      this.pendingResults.delete(slug)
+      return result
+    }
+    return null
+  }
+
+  /**
+   * Get all slugs that have pending results (for discovery).
+   */
+  async getAllPendingSlugs(): Promise<string[]> {
+    return Array.from(this.pendingResults.keys())
   }
 
   /**
    * Generate a new DApp or update an existing one
    */
   async generateDapp(options: GenerateDappOptions & { slug: string }): Promise<void> {
-
     if (options.figmaUrl && options.figmaToken) {
       this.processFigmaGeneration(options).catch(err => {
-        console.error("[DEBUG-AI] Figma process crashed:", err);
-        this.call('terminal', 'log', { type: 'error', value: err.message });
+        console.error('[AI-DAPP] Figma process crashed:', err);
+        try {
+          this.call('terminal', 'log', { type: 'error', value: err.message });
+          this.emit('dappGenerationError', { address: options.address, slug: options.slug, error: err.message });
+        } catch (_) {}
       });
     } else {
       this.processGeneration(options).catch(err => {
-        console.error("[DEBUG-AI] Background process crashed:", err);
-        this.call('terminal', 'log', { type: 'error', value: err.message });
+        console.error('[AI-DAPP] processGeneration crashed:', err);
+        try {
+          this.call('terminal', 'log', { type: 'error', value: err.message });
+          this.emit('dappGenerationError', { address: options.address, slug: options.slug, error: err.message });
+        } catch (_) {}
       });
     }
 
@@ -113,23 +148,30 @@ export class AIDappGenerator extends Plugin {
       context.messages.push({ role: 'assistant', content: htmlContent });
       this.saveContext(options.address, context);
 
-      this.emit('dappGenerated', {
-        address: options.address,
-        slug: options.slug,
-        content: pages,
-        isUpdate: false
-      });
+      this.pendingResults.set(options.slug, { address: options.address, content: pages, isUpdate: false })
+      try {
+        this.emit('dappGenerated', {
+          address: options.address,
+          slug: options.slug,
+          content: pages,
+          isUpdate: false
+        });
+      } catch (_) {}
 
-      await this.call('notification', 'toast', 'Figma Design Imported Successfully!');
+      try {
+        await this.call('notification', 'toast', 'Figma Design Imported Successfully!');
+      } catch (_) {}
 
     } catch (error: any) {
-      console.error('[DEBUG-AI] Figma Generation Failed:', error);
-      this.call('terminal', 'log', { type: 'error', value: error.message });
-      this.emit('dappGenerationError', {
-        address: options.address,
-        slug: options.slug,
-        error: error.message
-      });
+      console.error('[AI-DAPP] Figma Generation Failed:', error);
+      try { this.call('terminal', 'log', { type: 'error', value: error.message }); } catch (_) {}
+      try {
+        this.emit('dappGenerationError', {
+          address: options.address,
+          slug: options.slug,
+          error: error.message
+        });
+      } catch (_) {}
     }
   }
 
@@ -156,12 +198,13 @@ export class AIDappGenerator extends Plugin {
   }
 
   private async processGeneration(options: GenerateDappOptions & { slug: string }) {
-
     try {
       const hasImage = !!options.image;
 
-      await this.call('notification', 'toast', 'Generating... (Logs in console)')
-      this.emit('generationProgress', { status: 'started', address: options.address })
+      this.call('notification', 'toast', 'Generating... (Logs in console)').catch(() => {})
+      try {
+        this.emit('generationProgress', { status: 'started', address: options.address })
+      } catch (_) {}
 
       const context = this.getOrCreateContext(options.address)
 
@@ -190,13 +233,7 @@ export class AIDappGenerator extends Plugin {
       let pages = parsePages(htmlContent);
 
       if (Object.keys(pages).length === 0) {
-        console.error('[DEBUG-AI] ❌ CRITICAL: parsePages returned empty object!');
-        console.error('[DEBUG-AI] Raw response length:', htmlContent?.length);
-        console.error('[DEBUG-AI] First 500 chars:', htmlContent?.substring(0, 500));
-        console.error('[DEBUG-AI] Contains START_TITLE?', htmlContent?.includes('START_TITLE'));
-        console.error('[DEBUG-AI] Contains <<<:', htmlContent?.includes('<<<'));
-        const debugMatches = htmlContent?.match(/<{3,}\s*START_TITLE\s+(.*?)\s+>{3,}/g);
-        console.error('[DEBUG-AI] Marker matches found:', debugMatches?.length || 0, debugMatches);
+        console.error('[AI-DAPP] parsePages returned empty object. Response length:', htmlContent?.length);
         throw new Error("AI generated empty content. Please try again.");
       }
 
@@ -210,24 +247,31 @@ export class AIDappGenerator extends Plugin {
       ]
       this.saveContext(options.address, context)
 
-      this.emit('dappGenerated', {
-        address: options.address,
-        slug: options.slug,
-        content: pages,
-        isUpdate: false
-      });
+      // Store result BEFORE emit — ensures recovery even if event is lost
+      this.pendingResults.set(options.slug, { address: options.address, content: pages, isUpdate: false })
+      try {
+        this.emit('dappGenerated', {
+          address: options.address,
+          slug: options.slug,
+          content: pages,
+          isUpdate: false
+        });
+      } catch (_) {}
 
-      await this.call('notification', 'toast', 'Generation Complete!');
+      try {
+        await this.call('notification', 'toast', 'Generation Complete!');
+      } catch (_) {}
 
     } catch (error: any) {
-      console.error('[DEBUG-AI] Generation Failed:', error);
-      this.call('terminal', 'log', { type: 'error', value: error.message });
-
-      this.emit('dappGenerationError', {
-        address: options.address,
-        slug: options.slug,
-        error: error.message
-      });
+      console.error('[AI-DAPP] Generation Failed:', error);
+      try { this.call('terminal', 'log', { type: 'error', value: error.message }); } catch (_) {}
+      try {
+        this.emit('dappGenerationError', {
+          address: options.address,
+          slug: options.slug,
+          error: error.message
+        });
+      } catch (_) {}
     }
   }
 
@@ -278,23 +322,27 @@ export class AIDappGenerator extends Plugin {
       context.messages.push({ role: 'assistant', content: htmlContent });
       this.saveContext(address, context);
 
-      this.emit('dappGenerated', {
-        address,
-        slug,
-        content: pages,
-        isUpdate: true
-      });
+      this.pendingResults.set(slug, { address, content: pages, isUpdate: true })
+      try {
+        this.emit('dappGenerated', {
+          address,
+          slug,
+          content: pages,
+          isUpdate: true
+        });
+      } catch (_) {}
 
     } catch (error: any) {
       context.messages.pop();
-      console.error('[DEBUG-AI] Update failed:', error);
-      this.call('terminal', 'log', { type: 'error', value: `Update failed: ${error.message}` });
-
-      this.emit('dappGenerationError', {
-        address,
-        slug,
-        error: error.message || "Unknown error during generation"
-      });
+      console.error('[AI-DAPP] Update failed:', error);
+      try { this.call('terminal', 'log', { type: 'error', value: `Update failed: ${error.message}` }); } catch (_) {}
+      try {
+        this.emit('dappGenerationError', {
+          address,
+          slug,
+          error: error.message || "Unknown error during generation"
+        });
+      } catch (_) {}
     }
   }
 
@@ -459,7 +507,7 @@ export class AIDappGenerator extends Plugin {
 
       return json.content;
 
-    } catch (error) {
+    } catch (error: any) {
       console.error('[AI-DAPP] API Call Failed:', error);
       throw error;
     }

--- a/apps/remix-ide/src/app/plugins/quick-dapp-v2.tsx
+++ b/apps/remix-ide/src/app/plugins/quick-dapp-v2.tsx
@@ -56,7 +56,7 @@ export class QuickDappV2 extends ViewPlugin {
   }
 
   onDeactivation() {
-    // Plugin deactivated
+    this.listenersRegistered = false
   }
 
   setDispatch(dispatch: React.Dispatch<any>) {

--- a/libs/remix-ui/quick-dapp-v2/src/lib/quick-dapp-v2.tsx
+++ b/libs/remix-ui/quick-dapp-v2/src/lib/quick-dapp-v2.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useReducer, useState, useMemo, useRef } from 'react';
+import { LoginModal } from '@remix-ui/login';
 import { IntlProvider } from 'react-intl';
 import CreateInstance from './components/CreateInstance';
 import EditHtmlTemplate from './components/EditHtmlTemplate';
@@ -33,6 +34,7 @@ export function RemixUiQuickDappV2({ plugin }: RemixUiQuickDappV2Props): JSX.Ele
   // Permission gating state
   const [hasAccess, setHasAccess] = useState<boolean | null>(null); // null = checking
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   // DappManager now receives the plugin from props instead of a singleton
   const dappManager = useMemo(() => new DappManager(plugin as any), [plugin]);
@@ -113,7 +115,6 @@ export function RemixUiQuickDappV2({ plugin }: RemixUiQuickDappV2Props): JSX.Ele
           : null;
 
         if (!token) {
-          plugin.call('notification', 'toast', 'Please sign in to use QuickDapp V2. This feature is available to beta testers.');
           return;
         }
 
@@ -202,6 +203,7 @@ export function RemixUiQuickDappV2({ plugin }: RemixUiQuickDappV2Props): JSX.Ele
       const workspaceName = data.slug;
 
       try {
+        plugin.call('ai-dapp-generator', 'consumePendingResult', workspaceName).catch(() => {})
         await dappManager.saveGeneratedFiles(workspaceName, data.content);
 
         if (data.isUpdate) {
@@ -324,6 +326,19 @@ export function RemixUiQuickDappV2({ plugin }: RemixUiQuickDappV2Props): JSX.Ele
           const elapsed = now - processingStartedAt;
 
           if (status === 'creating' || status === 'updating') {
+            // Try to recover buffered results from ai-dapp-generator
+            try {
+              const pendingResult = await plugin.call('ai-dapp-generator', 'consumePendingResult', dapp.slug)
+              if (pendingResult) {
+                await dappManager.saveGeneratedFiles(dapp.slug, pendingResult.content)
+                await dappManager.updateDappConfig(dapp.slug, { status: 'created', processingStartedAt: null })
+                plugin.call('notification', 'toast', `DApp recovered: files saved for '${dapp.name}'`)
+                continue
+              }
+            } catch (e) {
+              console.warn('[QuickDapp] Could not check pending results:', e)
+            }
+
             if (elapsed < FIVE_MINUTES) {
               dispatch({
                 type: 'SET_DAPP_PROCESSING',
@@ -432,9 +447,17 @@ export function RemixUiQuickDappV2({ plugin }: RemixUiQuickDappV2Props): JSX.Ele
               QuickDapp V2 is currently available to beta testers only. Please contact the Remix team to request access.
             </p>
           ) : (
-            <p className="text-muted" style={{ maxWidth: '400px' }}>
-              Please sign in to access QuickDapp V2. This feature is available to beta testers.
-            </p>
+            <>
+              <p className="text-muted" style={{ maxWidth: '400px' }}>
+                Please sign in to access QuickDapp V2. This feature is available to beta testers.
+              </p>
+              <button
+                className="btn btn-sm btn-primary mt-2"
+                onClick={() => setShowLoginModal(true)}
+              >
+                Sign In
+              </button>
+            </>
           )}
         </div>
       );
@@ -530,6 +553,7 @@ export function RemixUiQuickDappV2({ plugin }: RemixUiQuickDappV2Props): JSX.Ele
           {renderContent()}
         </div>
         <LoadingScreen />
+        {showLoginModal && <LoginModal onClose={() => setShowLoginModal(false)} plugin={plugin} />}
       </IntlProvider>
     </AppContext.Provider>
   );


### PR DESCRIPTION
- [X] [QuickDapp]  When I click on ‘Create a Dapp’ from RemixAI assistant, it shows: ‘Please sign in to access QuickDapp V2. This feature is available to beta testers.’ Here can be a link to show login modal

- [X] [QuickDapp] A Sepolia Dapp is stuck saying ‘AI creating’. Toaster has been shown "Generation Completed”