### PR TITLE
feat(quick-dapp-v2): log actual token usage via Matomo and suppress toast spam during generation

### DIFF
--- a/apps/remix-ide/src/app/files/fileManager.ts
+++ b/apps/remix-ide/src/app/files/fileManager.ts
@@ -629,7 +629,7 @@ export default class FileManager extends Plugin {
     if (this.currentRequest) {
       const canCall = await this.askUserPermission(`writeFile`, `modifying ${path} ...`)
       const required = this.appManager.isRequired(this.currentRequest.from)
-      if (canCall && !required) {
+      if (canCall && !required && !options?.silent) {
         // inform the user about modification after permission is granted and even if permission was saved before
         this.call('notification', 'toast', fileChangedToastMsg(this.currentRequest.from, path))
       }

--- a/apps/remix-ide/src/app/plugins/ai-dapp-generator.ts
+++ b/apps/remix-ide/src/app/plugins/ai-dapp-generator.ts
@@ -126,7 +126,7 @@ export class AIDappGenerator extends Plugin {
       // const FIGMA_BACKEND_URL = "http://localhost:4000/figma/generate";
       const FIGMA_BACKEND_URL = "https://quickdapp-figma.api.remix.live/generate";
 
-      const htmlContent = await this.callFigmaAPI(FIGMA_BACKEND_URL, {
+      const { content: htmlContent, meta: figmaMeta } = await this.callFigmaAPI(FIGMA_BACKEND_URL, {
         figmaToken: options.figmaToken,
         figmaUrl: options.figmaUrl,
         userPrompt: options.description,
@@ -162,6 +162,38 @@ export class AIDappGenerator extends Plugin {
       } catch (_) {}
 
       trackMatomoEvent(this, { category: 'quick-dapp-v2', action: 'generate_figma', name: 'success', isClick: false });
+
+      if (figmaMeta?.usage) {
+        const usage = figmaMeta.usage;
+        let userId: string | undefined;
+        if (typeof window !== 'undefined' && window.localStorage) {
+          try {
+            const user = JSON.parse(window.localStorage.getItem('remix_user') || '');
+            userId = user.sub || user.id;
+          } catch (_) {}
+        }
+        if (!userId && typeof window !== 'undefined' && window.sessionStorage) {
+          userId = window.sessionStorage.getItem('remix_random_session_id') || undefined;
+        }
+
+        const eventLog = [
+          `provider:fireworks-figma`,
+          `prompt_tokens:${usage.prompt_tokens || 0}`,
+          `completion_tokens:${usage.completion_tokens || 0}`,
+          `total_tokens:${usage.total_tokens || 0}`,
+          `usage_source:${usage.source || 'unknown'}`,
+          `userId:${userId}`
+        ].filter(Boolean).join('|');
+
+        trackMatomoEvent(this, {
+          category: 'quick-dapp-v2',
+          action: 'ai_usage',
+          name: 'token_usage',
+          value: `|${eventLog}`,
+          isClick: false
+        });
+      }
+
       try {
         await this.call('notification', 'toast', 'Figma Design Imported Successfully!');
       } catch (_) {}
@@ -180,7 +212,7 @@ export class AIDappGenerator extends Plugin {
     }
   }
 
-  private async callFigmaAPI(url: string, payload: any): Promise<string> {
+  private async callFigmaAPI(url: string, payload: any): Promise<{ content: string; meta?: any }> {
     try {
       const response = await fetch(url, {
         method: "POST",
@@ -194,7 +226,7 @@ export class AIDappGenerator extends Plugin {
       }
 
       const json = await response.json();
-      return json.content;
+      return { content: json.content, meta: json.meta };
 
     } catch (error) {
       console.error('[AI-DAPP] Figma API Call Failed:', error);
@@ -512,8 +544,20 @@ export class AIDappGenerator extends Plugin {
       }
 
       const json = await response.json();
-      const promptTokens = Math.ceil((messages.length + systemPrompt.length) * 1.3)
-      const completionTokens = Math.ceil((json?.content.length) * 1.3 || 0);
+
+      const usage = json.meta?.usage;
+      const promptTokens = usage?.prompt_tokens ?? Math.ceil(systemPrompt.length / 4);
+      const completionTokens = usage?.completion_tokens ?? Math.ceil((json?.content?.length || 0) / 4);
+      const totalTokens = usage?.total_tokens ?? (promptTokens + completionTokens);
+      const usageSource = usage?.source || 'estimated';
+
+      console.log('[AI-DAPP] ┌─ TOKEN USAGE ─────────────────');
+      console.log('[AI-DAPP] │ Backend meta:', JSON.stringify(json.meta, null, 2));
+      console.log(`[AI-DAPP] │ Source: ${usageSource}`);
+      console.log(`[AI-DAPP] │ Prompt tokens: ${promptTokens}`);
+      console.log(`[AI-DAPP] │ Completion tokens: ${completionTokens}`);
+      console.log(`[AI-DAPP] │ Total tokens: ${totalTokens}`);
+      console.log('[AI-DAPP] └──────────────────────────────');
 
       let userId: string | undefined;
       if (typeof window !== 'undefined' && window.sessionStorage) {
@@ -539,16 +583,17 @@ export class AIDappGenerator extends Plugin {
 
       const eventLog = [
         `provider:fireworks-custom-llm`,
-        `promptTokens:${promptTokens}`,
-        `completionTokens:${completionTokens}`,
-        `totalTokens:${promptTokens + completionTokens}`,
-        `model:${json.meta?.model}` || 'unknown',
+        `prompt_tokens:${promptTokens}`,
+        `completion_tokens:${completionTokens}`,
+        `total_tokens:${totalTokens}`,
+        `model:${json.meta?.model || 'unknown'}`,
+        `usage_source:${usageSource}`,
         `userId:${userId}`
       ].filter(Boolean).join('|')
 
       trackMatomoEvent(this, {
         category: 'quick-dapp-v2',
-        action: 'generate',
+        action: 'ai_usage',
         name: 'token_usage',
         value: `|${eventLog}`,
         isClick: false

--- a/libs/remix-api/src/lib/plugins/matomo/events/tools-events.ts
+++ b/libs/remix-api/src/lib/plugins/matomo/events/tools-events.ts
@@ -292,5 +292,6 @@ export interface QuickDappV2Event extends MatomoEventBase {
     | 'deploy_ipfs'
     | 'register_ens'
     | 'base_app_setup_complete'
+    | 'ai_usage'
     | 'error';
 }

--- a/libs/remix-ui/quick-dapp-v2/src/lib/utils/DappManager.ts
+++ b/libs/remix-ui/quick-dapp-v2/src/lib/utils/DappManager.ts
@@ -374,10 +374,11 @@ export class DappManager {
         try { await this.plugin.call('fileManager', 'mkdir', '.states'); } catch (_) {}
         for (const folder of foldersToWrite) {
           try { await this.plugin.call('fileManager', 'mkdir', `.states/${folder}`); } catch (_) {}
-          await this.plugin.call(
+          await (this.plugin as any).call(
             'fileManager', 'writeFile',
             `.states/${folder}/state.json`,
-            vmStateSnapshot
+            vmStateSnapshot,
+            { silent: true }
           );
         }
       } catch (e) {
@@ -403,10 +404,11 @@ export class DappManager {
       try { await this.plugin.call('fileManager', 'mkdir', '.deploys/pinned-contracts'); } catch (_) {}
       try { await this.plugin.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${pinnedChainId}`); } catch (_) {}
 
-      await this.plugin.call(
+      await (this.plugin as any).call(
         'fileManager', 'writeFile',
         pinnedPath,
-        JSON.stringify(pinnedContractData, null, 2)
+        JSON.stringify(pinnedContractData, null, 2),
+        { silent: true }
       );
       console.log('[DappManager] Contract pinned in dapp workspace:', pinnedPath);
 
@@ -461,7 +463,7 @@ export class DappManager {
           }
         };
 
-        await this.plugin.call('fileManager', 'writeFile', '.well-known/farcaster.json', JSON.stringify(manifestContent, null, 2));
+        await (this.plugin as any).call('fileManager', 'writeFile', '.well-known/farcaster.json', JSON.stringify(manifestContent, null, 2), { silent: true });
       } catch (e) {
         console.error('[DappManager] Failed to create .well-known folder or file', e);
       }
@@ -502,11 +504,12 @@ export class DappManager {
 
       const savePath = `.deploys/pinned-contracts/${chainId}/${address}.json`;
 
-      await this.plugin.call(
+      await (this.plugin as any).call(
         'fileManager',
         'writeFile',
         savePath,
-        JSON.stringify(objToSave, null, 2)
+        JSON.stringify(objToSave, null, 2),
+        { silent: true }
       );
 
       const dappMappingPath = `.deploys/dapp-mappings/${address}_${dappWorkspace}.json`;
@@ -517,11 +520,12 @@ export class DappManager {
         chainId,
         createdAt: Date.now()
       };
-      await this.plugin.call(
+      await (this.plugin as any).call(
         'fileManager',
         'writeFile',
         dappMappingPath,
-        JSON.stringify(dappMapping, null, 2)
+        JSON.stringify(dappMapping, null, 2),
+        { silent: true }
       );
     } catch (e) {
       console.warn('[DappManager] Failed to auto-pin instance:', e);
@@ -539,7 +543,7 @@ export class DappManager {
     config.updatedAt = Date.now();
     const sanitized = this.sanitizeConfig(config);
     const content = JSON.stringify(sanitized, null, 2);
-    await this.plugin.call('fileManager', 'writeFile', CONFIG_FILENAME, content);
+    await (this.plugin as any).call('fileManager', 'writeFile', CONFIG_FILENAME, content, { silent: true });
 
     if (currentWorkspace.name !== workspaceName) {
       await this.switchToWorkspace(currentWorkspace.name);
@@ -584,7 +588,7 @@ export class DappManager {
       }
 
       try {
-        await this.plugin.call('fileManager', 'writeFile', fullPath, content);
+        await (this.plugin as any).call('fileManager', 'writeFile', fullPath, content, { silent: true });
       } catch (e) {
         console.error(`[DEBUG-MANAGER] ❌ Failed to write ${fullPath}:`, e);
       }
@@ -736,7 +740,7 @@ export class DappManager {
 
       const sanitizedConfig = this.sanitizeConfig(newConfig);
 
-      await this.plugin.call('fileManager', 'writeFile', CONFIG_FILENAME, JSON.stringify(sanitizedConfig, null, 2));
+      await (this.plugin as any).call('fileManager', 'writeFile', CONFIG_FILENAME, JSON.stringify(sanitizedConfig, null, 2), { silent: true });
 
       if (currentWorkspace.name !== workspaceName) {
         await this.switchToWorkspace(currentWorkspace.name);


### PR DESCRIPTION
- Log usage for both LLM and Figma generation paths
- Add `silent` option to fileManager.writeFile to skip toast notifications