### PR TITLE
fix(contract-verification): fix Sourcify, Etherscan, and Routescan verification failures

### DIFF
--- a/apps/contract-verification/src/app/Verifiers/EtherscanVerifier.ts
+++ b/apps/contract-verification/src/app/Verifiers/EtherscanVerifier.ts
@@ -46,9 +46,14 @@ export class EtherscanVerifier extends AbstractVerifier {
   async verify(submittedContract: SubmittedContract, compilerAbstract: CompilerAbstract): Promise<VerificationResponse> {
     // TODO: Handle version Vyper contracts. This relies on Solidity metadata.
     const metadata = JSON.parse(compilerAbstract.data.contracts[submittedContract.filePath][submittedContract.contractName].metadata)
+
+    const sourceCode = typeof compilerAbstract.input === 'string'
+      ? compilerAbstract.input
+      : JSON.stringify(compilerAbstract.input)
+
     const formData = new FormData()
     formData.append('codeformat', 'solidity-standard-json-input')
-    formData.append('sourceCode', compilerAbstract.input.toString())
+    formData.append('sourceCode', sourceCode)
     formData.append('contractaddress', submittedContract.address)
     formData.append('contractname', submittedContract.filePath + ':' + submittedContract.contractName)
     formData.append('compilerversion', `v${metadata.compiler.version}`)
@@ -76,7 +81,7 @@ export class EtherscanVerifier extends AbstractVerifier {
     const verificationResponse: EtherscanRpcResponse = await response.json()
     const lookupUrl = this.getContractCodeUrl(submittedContract.address, submittedContract.chainId)
 
-    if (verificationResponse.result.includes('already verified')) {
+    if (verificationResponse.result?.includes('already verified')) {
       return { status: 'already verified', receiptId: null, lookupUrl }
     }
 

--- a/apps/contract-verification/src/app/Verifiers/SourcifyVerifier.ts
+++ b/apps/contract-verification/src/app/Verifiers/SourcifyVerifier.ts
@@ -64,8 +64,13 @@ export class SourcifyVerifier extends AbstractVerifier {
     const metadata = JSON.parse(compilerAbstract.data.contracts[submittedContract.filePath][submittedContract.contractName].metadata)
     const compilerVersion = `v${metadata.compiler.version}`
     const contractIdentifier = `${submittedContract.filePath}:${submittedContract.contractName}`
-    // The CompilerAbstract.input property seems to be wrongly typed
-    const stdJsonInput = JSON.parse(compilerAbstract.input as unknown as string)
+
+    let stdJsonInput: any
+    if (typeof compilerAbstract.input === 'string') {
+      stdJsonInput = JSON.parse(compilerAbstract.input)
+    } else {
+      stdJsonInput = compilerAbstract.input
+    }
 
     const body: SourcifyVerificationRequest = {
       stdJsonInput,

--- a/libs/remix-ui/run-tab-deploy/src/lib/actions/index.ts
+++ b/libs/remix-ui/run-tab-deploy/src/lib/actions/index.ts
@@ -222,31 +222,13 @@ async function createInstance(selectedContract: ContractData, args, deployMode: 
     try {
       const status = await plugin.call('blockchain', 'detectNetwork')
       const currentChainId = parseInt(status.id)
-      const response = await fetch('https://chainid.network/chains.json')
-
-      if (!response.ok) throw new Error('Could not fetch chains list from chainid.network.')
-      const allChains = await response.json()
-      const currentChain = allChains.find(chain => chain.chainId === currentChainId)
-
-      if (!currentChain) {
-        console.error('Could not find chain data for Chain ID: ', currentChainId)
-        // const errorMsg = `Could not find chain data for Chain ID: ${currentChainId}. Verification cannot proceed.`
-        // const errorLog = logBuilder(errorMsg)
-        // terminalLogger(plugin, errorLog)
-        return
-      }
-
-      const etherscanApiKey = await plugin.call('config', 'getAppParameter', 'etherscan-access-token')
 
       const verificationData = {
         chainId: currentChainId.toString(),
-        currentChain: currentChain,
         address: result.address,
         contractName: selectedContract.name,
         filePath: selectedContract.contract.file,
-        compilationResult: await plugin.call('compilerArtefacts', 'getCompilerAbstract', selectedContract.contract.file),
-        constructorArgs: args,
-        etherscanApiKey: etherscanApiKey
+        args: args
       }
 
       setTimeout(async () => {


### PR DESCRIPTION
After 532d9d73 normalized CompilerAbstract.input from string to parsed object, verifiers broke because they assumed input was still a raw JSON string.

- SourcifyVerifier: replace JSON.parse(input) with type-safe check
- EtherscanVerifier: replace input.toString() with JSON.stringify(input)
- EtherscanVerifier: add optional chaining on result?.includes() (fixes Routescan null crash)
- Remove redundant chain/compilation data from deploy verification payload