### PR TITLE
fix(quick-dapp-v2): fix VM initialization deadlock and AI update missing files

### DIFF
--- a/apps/remix-ide/src/app/plugins/ai-dapp-generator.ts
+++ b/apps/remix-ide/src/app/plugins/ai-dapp-generator.ts
@@ -353,10 +353,40 @@ export class AIDappGenerator extends Plugin {
         throw new Error("AI failed to return valid file structure.");
       }
 
-      // Merge: start with current files, overwrite only the ones LLM returned
-      const mergedPages: Record<string, string> = { ...currentFiles };
+      // Normalize all paths: strip leading '/' to match parsePages output
+      const normalizeKey = (k: string) => k.startsWith('/') ? k.substring(1) : k;
+
+      const normalizedCurrent: Record<string, string> = {};
+      for (const [file, content] of Object.entries(currentFiles)) {
+        normalizedCurrent[normalizeKey(file)] = content as string;
+      }
+
+      // Merge: current (normalized) + patched (already normalized by parsePages)
+      const mergedPages: Record<string, string> = { ...normalizedCurrent };
       for (const [file, content] of Object.entries(patchedPages)) {
-        mergedPages[file] = content;
+        mergedPages[normalizeKey(file)] = content;
+      }
+
+      // Detect missing imports: files referenced via import but not in mergedPages
+      const missingImports = findMissingImports(mergedPages);
+      if (missingImports.length > 0) {
+        try {
+          const retryMessages = [
+            ...messages,
+            { role: 'assistant', content: htmlContent },
+            {
+              role: 'user',
+              content: `The following files are imported in the code but were not included in your response:\n${missingImports.map(f => `- ${f}`).join('\n')}\n\nPlease generate ONLY these missing files using the START_TITLE format. Do not regenerate files that were already provided.`
+            }
+          ];
+          const additionalContent = await this.callLLMAPI(retryMessages, systemPrompt, false, true);
+          const additionalPages = parsePages(additionalContent);
+          for (const [file, content] of Object.entries(additionalPages)) {
+            mergedPages[normalizeKey(file)] = content;
+          }
+        } catch (retryErr: any) {
+          console.warn('[AI-DAPP] Retry for missing imports failed:', retryErr.message);
+        }
       }
 
       this.pendingResults.set(slug, { address, content: mergedPages, isUpdate: true })
@@ -631,6 +661,47 @@ const cleanFileContent = (content: string, filename: string): string => {
   }
 
   return cleaned.trim()
+}
+
+/**
+ * Scan all JS/JSX/TS/TSX files for relative imports and find ones that
+ * point to files not present in the file set.
+ */
+const findMissingImports = (pages: Record<string, string>): string[] => {
+  const allFiles = new Set(Object.keys(pages).map(f =>
+    f.startsWith('/') ? f : '/' + f
+  ));
+  const missing: string[] = [];
+
+  for (const [filename, content] of Object.entries(pages)) {
+    if (!filename.match(/\.(js|jsx|ts|tsx)$/)) continue;
+
+    // Match: import ... from './path' or require('./path')
+    const importRegex = /(?:import\s+[\s\S]*?\s+from\s+['"]|require\s*\(\s*['"])(\.\.?\/[^'"]+)['"]/g;
+    let match;
+    while ((match = importRegex.exec(content)) !== null) {
+      const importPath = match[1];
+      const fileDir = '/' + filename.replace(/\\/g, '/').replace(/[^/]+$/, '');
+      const resolved = resolveRelativePath(fileDir, importPath);
+
+      // Try with common extensions
+      const candidates = [resolved, resolved + '.jsx', resolved + '.js', resolved + '.tsx', resolved + '.ts'];
+      if (!candidates.some(c => allFiles.has(c))) {
+        missing.push(resolved);
+      }
+    }
+  }
+  return [...new Set(missing)];
+}
+
+/** Resolve a relative path against a directory */
+const resolveRelativePath = (base: string, relative: string): string => {
+  const parts = base.split('/').filter(Boolean);
+  for (const part of relative.split('/')) {
+    if (part === '..') parts.pop();
+    else if (part !== '.') parts.push(part);
+  }
+  return '/' + parts.join('/');
 }
 
 // Helper function to ensure HTML has complete structure

--- a/apps/remix-ide/src/app/plugins/prompt-blocks.ts
+++ b/apps/remix-ide/src/app/plugins/prompt-blocks.ts
@@ -576,11 +576,11 @@ ${descText}
 ${currentFiles}
 
 **RULES:**
-1. Return ONLY the files that need changes using START_TITLE format. Do NOT return files that are unmodified.
+1. Return ALL modified files AND all NEW files using START_TITLE format. Do NOT return files that are completely unmodified.
 2. Do NOT provide explanations — only code blocks.
-3. You are allowed to create NEW files if the request requires new features.
+3. **CRITICAL:** If you add an import for a new file (e.g. \`import Foo from './components/Foo.jsx'\`), you MUST also generate that file in your response. Missing files will crash the app.
 4. If \`App.jsx\` is getting too large, refactor parts into \`src/components/\`.
-5. When returning a modified file, return the COMPLETE file content — not just the changed portion.
+5. When returning a file, return the COMPLETE file content — not just the changed portion.
 `
   },
 

--- a/apps/remix-ide/src/blockchain/blockchain.tsx
+++ b/apps/remix-ide/src/blockchain/blockchain.tsx
@@ -745,6 +745,9 @@ export class Blockchain extends Plugin {
       await this.getCurrentProvider().resetEnvironment()
     }
 
+    // Expose web3 for QuickDapp bridge (bypasses plugin queue)
+    ;(globalThis as any).__remixVM_web3 = this.web3()
+
     const logTransaction = async (txhash, origin) => {
       const network = await this.detectNetwork()
       const actionName = origin === 'plugin' ? 'sendTransaction-from-plugin' : 'sendTransaction-from-gui';

--- a/libs/remix-ui/quick-dapp-v2/src/lib/InBrowserVite.tsx
+++ b/libs/remix-ui/quick-dapp-v2/src/lib/InBrowserVite.tsx
@@ -299,7 +299,7 @@ export class InBrowserVite {
               return { contents: jsContent, loader: 'js' };
             }
           }
-          return { contents: `throw new Error('File not found: ${args.path}')`, loader: 'js' };
+          return { errors: [{ text: `CSS file not found: ${args.path}. Check that the file exists in your workspace.` }]};
         });
 
         // load local files
@@ -319,7 +319,7 @@ export class InBrowserVite {
             }
           }
 
-          return { contents: `throw new Error('File not found in virtual filesystem: ${args.path}')`, loader: 'js' };
+          return { errors: [{ text: `File not found: ${args.path}. This file is imported but does not exist in the workspace.` }]};
         });
 
       }

--- a/libs/remix-ui/quick-dapp-v2/src/lib/components/EditHtmlTemplate/index.tsx
+++ b/libs/remix-ui/quick-dapp-v2/src/lib/components/EditHtmlTemplate/index.tsx
@@ -222,7 +222,7 @@ function EditHtmlTemplate(): JSX.Element {
   };
 
   const runBuild = async (showNotification: boolean = false) => {
-    console.log('[QuickDapp][runBuild] START', { slug: activeDapp?.slug, showNotification });
+
     if (!iframeRef.current || !activeDapp) return;
     if (isBuilding) return;
 
@@ -313,7 +313,6 @@ window.addEventListener('unhandledrejection', function(e) {
     const ext = `<script>
 (function() {
   if (parent.__remixVMBridge) {
-    console.log('[DApp] Using Remix VM Bridge');
     var _listeners = {};
     window.ethereum = {
       isMetaMask: false,
@@ -341,16 +340,10 @@ window.addEventListener('unhandledrejection', function(e) {
       },
       removeAllListeners: function() { _listeners = {}; return this; }
     };
-    // Set static defaults — ethers.js will call eth_chainId / eth_requestAccounts
-    // itself during connection, so async pre-fetching is unnecessary and
-    // causes timeout errors during workspace switches.
-    window.ethereum.chainId = '0x539'; // 1337 (standard local dev chain ID)
+    window.ethereum.chainId = '0x539';
     window.ethereum.selectedAddress = null;
   } else if (parent.window && parent.window.ethereum) {
-    console.log('[DApp] Using parent window.ethereum (MetaMask)');
     window.ethereum = parent.window.ethereum;
-  } else {
-    console.warn('[DApp] No provider available');
   }
 })();
 </script>`;
@@ -477,31 +470,43 @@ window.addEventListener('unhandledrejection', function(e) {
     return () => { mounted = false; };
   }, []);
 
-  useEffect(() => {
-    if (isBuilderReady && activeDapp && !isAiUpdating) {
-      setTimeout(() => {
-        runBuild(false);
-      }, 100);
-    }
-  }, [isBuilderReady, isAiUpdating, activeDapp?.slug]);
-
   const isVM = !!activeDapp?.contract?.chainId && activeDapp.contract.chainId.toString().startsWith('vm');
-
   const [isCurrentProviderVM, setIsCurrentProviderVM] = useState(false);
   const [vmContractStatus, setVmContractStatus] = useState<'checking' | 'deployed' | 'not-found'>('checking');
 
   useEffect(() => {
-    if (!plugin) return;
-    const checkVM = async () => {
-      try {
-        const provider = await plugin.call('blockchain', 'getProvider');
-        setIsCurrentProviderVM(!!provider && provider.startsWith('vm-'));
-      } catch (e) {
-        setIsCurrentProviderVM(false);
+    if (isBuilderReady && activeDapp && !isAiUpdating) {
+      // VM dapps: wait until VM Worker is ready before building.
+      if (isVM && !isCurrentProviderVM) {
+        return;
       }
+      setTimeout(() => runBuild(false), 100);
+    }
+  }, [isBuilderReady, isAiUpdating, activeDapp?.slug, isCurrentProviderVM]);
+
+  // Detect when blockchain VM is ready via contextChanged event (debounced).
+  // Uses plugin.on (passive event) instead of plugin.call (blocked by engine queue).
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!plugin || !isVM) return;
+
+    const onContextChanged = (context: string) => {
+      if (!context || !context.startsWith('vm')) return;
+
+      // Reset the debounce timer on every event
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        setIsCurrentProviderVM(true);
+      }, 1500);
     };
-    checkVM();
-  }, [plugin, activeDapp]);
+
+    plugin.on('blockchain', 'contextChanged', onContextChanged);
+
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      try { plugin.off('blockchain', 'contextChanged', onContextChanged); } catch (e) {}
+    };
+  }, [plugin, isVM]);
 
   useEffect(() => {
     if (!isVM || !isCurrentProviderVM || !plugin || !activeDapp?.contract?.address) {
@@ -511,83 +516,72 @@ window.addEventListener('unhandledrejection', function(e) {
 
     let cancelled = false;
 
-    const checkWithRetry = async () => {
-      const MAX_RETRIES = 5;
-      const RETRY_DELAY_MS = 3000;
-
-      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const checkContract = async () => {
+      try {
+        const web3 = (window as any).__remixVM_web3;
+        if (!web3) {
+          setVmContractStatus('deployed');
+          return;
+        }
+        const result = await web3.send('eth_getCode', [activeDapp.contract.address, 'latest']);
         if (cancelled) return;
-        if (attempt > 0) {
-          await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
-          if (cancelled) return;
+        if (result && result !== '0x' && result !== '0x0' && result.length > 2) {
+          setVmContractStatus('deployed');
+        } else {
+          setVmContractStatus('not-found');
         }
+      } catch (e) {
+        if (cancelled) return;
 
-        try {
-          const code = await plugin.call('blockchain', 'sendRpc', 'eth_getCode', [
-            activeDapp.contract.address, 'latest'
-          ]);
-          console.log(`[QuickDapp] getCode attempt ${attempt + 1}/${MAX_RETRIES}:`, code?.substring(0, 20));
-          if (code && code !== '0x' && code !== '0x0' && code.length > 2) {
-            setVmContractStatus('deployed');
-            return;
-          }
-        } catch (e) {
-          console.warn(`[QuickDapp] getCode attempt ${attempt + 1} failed:`, e);
-        }
-      }
-
-      if (!cancelled) {
-        setVmContractStatus('not-found');
+        setVmContractStatus('deployed');
       }
     };
 
-    checkWithRetry();
+    checkContract();
     return () => { cancelled = true; };
   }, [isVM, isCurrentProviderVM, plugin, activeDapp?.contract?.address]);
 
+  // Bridge setup: provides window.__remixVMBridge for DApp iframe to call VM directly.
   useEffect(() => {
     let isMounted = true;
 
-    if (!isVM || !isCurrentProviderVM || !plugin) {
+    if (!isVM || !plugin) {
       delete (window as any).__remixVMBridge;
       return;
     }
 
     const bridge = {
       request: async ({ method, params }: { method: string; params?: any[] }) => {
+        if (method === 'wallet_switchEthereumChain' || method === 'wallet_addEthereumChain') {
+          return null;
+        }
+        // Direct VM access: bypasses plugin queue (which gets permanently blocked)
+        const web3 = (window as any).__remixVM_web3;
+        if (!web3) {
+          // VM not ready yet
+          throw new Error('VM not ready');
+        }
         try {
-          if (method === 'wallet_switchEthereumChain' || method === 'wallet_addEthereumChain') {
-            return null;
-          }
-
-          const result = await plugin.call('blockchain', 'sendRpc', method, params || []);
-
+          const result = await web3.send(method, params || []);
           if (!isMounted) return;
-
           if (method === 'eth_sendTransaction') {
-            try {
-              await plugin.call('blockchain', 'dumpState');
-            } catch (e) {
-              console.warn('[VM-Bridge] dumpState after TX failed:', e);
-            }
+            // dumpState is non-critical, fire-and-forget
+            plugin.call('blockchain', 'dumpState').catch(() => {});
           }
-
           return result;
         } catch (error: any) {
           if (!isMounted) return;
-          console.error(`[VM-Bridge] ${method} failed:`, error);
+          console.error(`[QD] bridge:${method} ERROR:`, error);
           throw error;
         }
       }
     };
 
     (window as any).__remixVMBridge = bridge;
-    console.log('[VM-Bridge] Remix VM bridge activated');
 
     return () => {
       isMounted = false;
       delete (window as any).__remixVMBridge;
-      console.log('[VM-Bridge] Remix VM bridge deactivated');
     };
   }, [isVM, isCurrentProviderVM, plugin]);
 
@@ -697,6 +691,10 @@ window.addEventListener('unhandledrejection', function(e) {
                         <div className="mt-1 text-danger">
                           <i className="fas fa-ban me-1"></i>
                           IPFS deployment will not work — Remix VM is local to this browser only.
+                        </div>
+                        <div className="mt-1 text-warning">
+                          <i className="fas fa-info-circle me-1"></i>
+                          VM data is not permanently stored. Clearing browser data or switching workspaces may reset the VM state.
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
- [x] VM DApp connects to MetaMask instead of Remix VM on initial load
> "I created a dapp in remix vm but I see a MetaMask account being connected. When refreshing the preview it worked fine."

- [x] AI update creates blank preview when generating new components
> "After prompting 'add a new section to check balance': blank page, no error. BalanceCheck.jsx is not in the file system."