### PR TITLE
fix: store invite token in Registry before URL cleanup

### DIFF
--- a/apps/remix-ide/src/app.ts
+++ b/apps/remix-ide/src/app.ts
@@ -214,6 +214,32 @@ class AppComponent {
     this.queryParams = new QueryParams()
     this.params = this.queryParams.get()
     this.desktopClientMode = this.params && this.params.activate && this.params.activate.split(',').includes('desktopClient')
+
+    // Capture invite token from URL params or hash early, before any plugin strips it
+    const urlParams = new URLSearchParams(window.location.search)
+    let inviteToken = urlParams.get('invite') || urlParams.get('invite_token') || null
+    if (!inviteToken) {
+      const hashMatch = window.location.hash.match(/[#&]invite=([A-Za-z0-9_-]+)/)
+      if (hashMatch) inviteToken = hashMatch[1]
+    }
+    if (inviteToken) {
+      Registry.getInstance().put({ api: inviteToken, name: 'inviteToken' })
+
+      // Clean invite params from URL now that they're stored in the Registry
+      urlParams.delete('invite')
+      urlParams.delete('invite_token')
+      const newSearch = urlParams.toString()
+
+      // Remove invite=TOKEN from hash, then ensure remaining hash is well-formed
+      let cleanHash = window.location.hash
+        .replace(/([#&])invite=[A-Za-z0-9_-]+&?/, '$1') // remove invite param
+        .replace(/[#&]$/, '')                             // trim trailing # or &
+      if (cleanHash && !cleanHash.startsWith('#')) cleanHash = '#' + cleanHash
+
+      const newUrl = window.location.pathname + (newSearch ? `?${newSearch}` : '') + cleanHash
+      window.history.replaceState(null, '', newUrl)
+    }
+
     this._components = {} as Components
     // setup storage
     const configStorage = new Storage('config-v0.8:')

--- a/apps/remix-ide/src/app.ts
+++ b/apps/remix-ide/src/app.ts
@@ -233,7 +233,7 @@ class AppComponent {
       // Remove invite=TOKEN from hash, then ensure remaining hash is well-formed
       let cleanHash = window.location.hash
         .replace(/([#&])invite=[A-Za-z0-9_-]+&?/, '$1') // remove invite param
-        .replace(/[#&]$/, '')                             // trim trailing # or &
+        .replace(/[#&]$/, '') // trim trailing # or &
       if (cleanHash && !cleanHash.startsWith('#')) cleanHash = '#' + cleanHash
 
       const newUrl = window.location.pathname + (newSearch ? `?${newSearch}` : '') + cleanHash

--- a/apps/remix-ide/src/app/plugins/invitation-manager-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/invitation-manager-plugin.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { InviteOverlay, InviteState } from '@remix-ui/invites'
 import { PluginViewWrapper } from '@remix-ui/helper'
 import { InviteValidateResponse, InviteRedeemResponse } from '@remix-api'
+import { Registry } from '@remix-project/remix-lib'
 import * as packageJson from '../../../../../package.json'
 
 const profile = {
@@ -274,21 +275,21 @@ export class InvitationManagerPlugin extends Plugin {
    * Supports: ?invite=TOKEN, ?invite_token=TOKEN, and #invite=TOKEN
    */
   private async checkUrlForInvite(): Promise<void> {
-    // Check query params first (?invite= or ?invite_token=)
-    const params = new URLSearchParams(window.location.search)
-    const queryToken = params.get('invite') || params.get('invite_token')
+    // Read invite token from Registry (set early by app.ts) so it survives URL
+    // param cleanup.  Fall back to reading from the URL directly.
+    let queryToken: string | null = null
+    try {
+      const entry = Registry.getInstance().get('inviteToken')
+      console.log('[InvitationManager] Invite token from Registry on URL check:', entry)
+      if (entry && entry.api) queryToken = entry.api as string
+    } catch {}
+    if (!queryToken) {
+      const params = new URLSearchParams(window.location.search)
+      queryToken = params.get('invite') || params.get('invite_token')
+    }
 
     if (queryToken) {
-      this.log('[InvitationManager] Found invite token in query params:', queryToken)
 
-      // Clean URL — remove invite params from query string
-      params.delete('invite')
-      params.delete('invite_token')
-      const newSearch = params.toString()
-      const newUrl = window.location.pathname + (newSearch ? `?${newSearch}` : '') + window.location.hash
-      window.history.replaceState(null, '', newUrl)
-
-      // Show the invite modal
       await this.showInvite(queryToken)
       return
     }

--- a/apps/remix-ide/src/app/plugins/invitation-manager-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/invitation-manager-plugin.tsx
@@ -280,7 +280,7 @@ export class InvitationManagerPlugin extends Plugin {
     let queryToken: string | null = null
     try {
       const entry = Registry.getInstance().get('inviteToken')
-      console.log('[InvitationManager] Invite token from Registry on URL check:', entry)
+      this.log('[InvitationManager] Invite token from Registry on URL check:', entry)
       if (entry && entry.api) queryToken = entry.api as string
     } catch {}
     if (!queryToken) {

--- a/libs/remix-ui/home-tab/src/lib/components/homeTabRecentWorkspaces.tsx
+++ b/libs/remix-ui/home-tab/src/lib/components/homeTabRecentWorkspaces.tsx
@@ -100,7 +100,7 @@ function HomeTabRecentWorkspaces({ plugin }: HomeTabFileProps) {
     }
     setLoadingWorkspace(null)
   }
-
+  // This needs to be refactored to be compatible with cloud workspaces
   return null
 
   return (

--- a/libs/remix-ui/home-tab/src/lib/components/homeTabRecentWorkspaces.tsx
+++ b/libs/remix-ui/home-tab/src/lib/components/homeTabRecentWorkspaces.tsx
@@ -101,6 +101,8 @@ function HomeTabRecentWorkspaces({ plugin }: HomeTabFileProps) {
     setLoadingWorkspace(null)
   }
 
+  return null
+
   return (
     <div className="justify-content-start d-flex flex-column my-5" id="hTFileSection">
       <div className="d-flex flex-column mb-5 remixui_recentworkspace">

--- a/libs/remix-ui/invites/src/lib/beta-join-modal.tsx
+++ b/libs/remix-ui/invites/src/lib/beta-join-modal.tsx
@@ -518,7 +518,7 @@ const BetaJoinModal: React.FC<BetaJoinModalProps> = ({
                     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                       <path d="M2 8l5 5L14 3" />
                     </svg>
-                    Join the Beta
+                    Start Using Remix Beta
                   </>
                 )}
               </button>

--- a/libs/remix-ui/login/src/lib/modals/login-modal.tsx
+++ b/libs/remix-ui/login/src/lib/modals/login-modal.tsx
@@ -3,6 +3,7 @@ import { AuthProvider, InviteValidateResponse, AccessPolicyResponse, ACCESS_POLI
 import { useAuth } from '../../../../app/src/lib/remix-app/context/auth-context'
 import { AppContext } from '../../../../app/src/lib/remix-app/context/context'
 import { endpointUrls } from '@remix-endpoints-helper'
+import { Registry } from '@remix-project/remix-lib'
 import './login-modal.css'
 
 interface LoginModalProps {
@@ -52,10 +53,16 @@ export const LoginModal: React.FC<LoginModalProps> = ({ onClose, plugin }) => {
   })
   const [accessPolicyLoading, setAccessPolicyLoading] = useState(true)
 
-  // Invite token handling
+  // Invite token handling – read from Registry (set early by app.ts) so the
+  // token is available even after other plugins strip it from the URL.
   const [inviteToken, setInviteToken] = useState<string | undefined>(() => {
+    try {
+      const entry = Registry.getInstance().get('inviteToken')
+      if (entry && entry.api) return entry.api as string
+
+    } catch {}
+    // Fallback: read directly from URL
     const params = new URLSearchParams(window.location.search)
-    // Support both ?invite=TOKEN and ?invite_token=TOKEN
     return params.get('invite') || params.get('invite_token') || undefined
   })
   const [inviteValidation, setInviteValidation] = useState<InviteValidateResponse | null>(null)
@@ -856,33 +863,6 @@ export const LoginModal: React.FC<LoginModalProps> = ({ onClose, plugin }) => {
                       </div>
                       <span className="text-muted fs-small-medium">Validating invite code...</span>
                     </div>
-                  )}
-
-                  {inviteToken && inviteValidation && !inviteValidating && (
-                    inviteValidation.valid ? (
-                      <div className="alert alert-success py-2 px-3 fs-small-medium mb-3" role="alert">
-                        <i className="fas fa-gift me-2"></i>
-                        <strong>{inviteValidation.name || 'Invite'}</strong>
-                        {inviteValidation.description && (
-                          <span className="d-block mt-1">{inviteValidation.description}</span>
-                        )}
-                        {inviteValidation.actions && inviteValidation.actions.length > 0 && (
-                          <ul className="list-unstyled mb-0 mt-1">
-                            {inviteValidation.actions.map((action, i) => (
-                              <li key={i} className="fs-small">
-                                <i className="fas fa-check me-1 text-success"></i>
-                                {action.description}
-                              </li>
-                            ))}
-                          </ul>
-                        )}
-                      </div>
-                    ) : (
-                      <div className="alert alert-warning py-2 px-3 fs-small-medium mb-3" role="alert">
-                        <i className="fas fa-exclamation-triangle me-2"></i>
-                        {inviteValidation.error || 'This invite link is invalid or expired.'}
-                      </div>
-                    )
                   )}
 
                   {/* Invite code input for invite_only mode */}

--- a/libs/remix-ui/workspace/src/lib/actions/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/workspace.ts
@@ -874,7 +874,7 @@ export const deleteWorkspace = async (workspaceName: string, cb?: (err: Error, r
             _creatingDefaultCloudWorkspace = true
             try {
               plugin.call('notification', 'toast', 'Creating default cloud workspace…')
-              await _createWorkspaceInternal('cloud workspace', 'remixDefault')
+              await _createWorkspaceInternal(cloudStore.isCloudMode ? 'cloud workspace' : 'default_workspace', 'remixDefault')
             } finally {
               _creatingDefaultCloudWorkspace = false
             }
@@ -964,7 +964,7 @@ export const switchToWorkspace = async (name: string) => {
       if (cloudStore.isCloudMode) _creatingDefaultCloudWorkspace = true
       try {
         plugin.call('notification', 'toast', `No workspace found! Creating default workspace ....`)
-        await _createWorkspaceInternal('cloud workspace', 'remixDefault')
+        await _createWorkspaceInternal(cloudStore.isCloudMode ? 'cloud workspace' : 'default_workspace', 'remixDefault')
       } finally {
         if (cloudStore.isCloudMode) _creatingDefaultCloudWorkspace = false
       }

--- a/libs/remix-ui/workspace/src/lib/cloud/cloud-migration-dialog.tsx
+++ b/libs/remix-ui/workspace/src/lib/cloud/cloud-migration-dialog.tsx
@@ -606,6 +606,7 @@ export const CloudMigrationDialog: React.FC<CloudMigrationDialogProps> = ({
     case 'loading':
       return 'Loading…'
     case 'select':
+      if (items.length === 0) return 'Close'
       return selectedCount > 0
         ? `Migrate ${selectedCount} workspace${selectedCount !== 1 ? 's' : ''}`
         : 'Migrate'
@@ -622,6 +623,7 @@ export const CloudMigrationDialog: React.FC<CloudMigrationDialogProps> = ({
   }
 
   const getOkFn = () => {
+    if (phase === 'select' && items.length === 0) return handleHide
     if (phase === 'select' && selectedCount > 0) return startMigration
     if (phase === 'done') return handleHide
     return undefined
@@ -642,7 +644,7 @@ export const CloudMigrationDialog: React.FC<CloudMigrationDialogProps> = ({
       okLabel={getOkLabel()}
       okFn={getOkFn()}
       okBtnClass={phase === 'done' ? 'btn-success' : (phase === 'migrating' ? 'btn-secondary disabled' : 'btn-primary')}
-      cancelLabel={phase === 'migrating' ? undefined : (phase === 'done' ? undefined : 'Skip')}
+      cancelLabel={phase === 'migrating' || phase === 'done' || (phase === 'select' && items.length === 0) ? undefined : 'Skip'}
       cancelFn={phase === 'migrating' ? undefined : handleHide}
       showCancelIcon={phase !== 'migrating'}
       modalParentClass="modal-dialog-centered"

--- a/libs/remix-ui/workspace/src/lib/cloud/cloud-migration-dialog.tsx
+++ b/libs/remix-ui/workspace/src/lib/cloud/cloud-migration-dialog.tsx
@@ -17,6 +17,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { ModalDialog } from '@remix-ui/modal-dialog'
 import {
   discoverLocalWorkspaces,
@@ -626,7 +627,7 @@ export const CloudMigrationDialog: React.FC<CloudMigrationDialogProps> = ({
     return undefined
   }
 
-  return (
+  return createPortal(
     <ModalDialog
       id="cloud-migration-dialog"
       title={
@@ -646,8 +647,9 @@ export const CloudMigrationDialog: React.FC<CloudMigrationDialogProps> = ({
       showCancelIcon={phase !== 'migrating'}
       modalParentClass="modal-dialog-centered"
       donotHideOnOkClick={phase === 'select' || phase === 'migrating'}
-      preventBlur={phase === 'migrating'}
-    />
+      preventBlur={true}
+    />,
+    document.body
   )
 }
 


### PR DESCRIPTION
The invite token wasn't properly passed on to the login modal for use when logging in with email. 
Removed 'recent workspaces' because we need to refactor that with cloud on/off states. 

also fixes migration of workspaces dialog not showing up

fixes https://github.com/remix-project-org/remix-project/issues/7053