### PR TITLE
Feat/beta invite flow

### DIFF
--- a/apps/remix-ide/src/app/plugins/auth-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/auth-plugin.tsx
@@ -15,7 +15,7 @@ const profile = {
 
 export class AuthPlugin extends Plugin {
   /** Set to true to enable verbose console.log output for debugging */
-  private static DEBUG = true
+  private static DEBUG = false
 
   private apiClient: ApiClient
   private ssoApi: SSOApiService
@@ -453,7 +453,7 @@ export class AuthPlugin extends Plugin {
   async getAppConfig(): Promise<AppConfig> {
     try {
       if (this.cachedAppConfig) {
-        console.log('[AuthPlugin] Returning cached app config', this.cachedAppConfig)
+        this.log('[AuthPlugin] Returning cached app config', this.cachedAppConfig)
         return this.cachedAppConfig
       }
 

--- a/apps/remix-ide/src/app/plugins/auth-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/auth-plugin.tsx
@@ -15,7 +15,7 @@ const profile = {
 
 export class AuthPlugin extends Plugin {
   /** Set to true to enable verbose console.log output for debugging */
-  private static DEBUG = false
+  private static DEBUG = true
 
   private apiClient: ApiClient
   private ssoApi: SSOApiService
@@ -453,6 +453,7 @@ export class AuthPlugin extends Plugin {
   async getAppConfig(): Promise<AppConfig> {
     try {
       if (this.cachedAppConfig) {
+        console.log('[AuthPlugin] Returning cached app config', this.cachedAppConfig)
         return this.cachedAppConfig
       }
 
@@ -502,8 +503,14 @@ export class AuthPlugin extends Plugin {
    */
   async getAppConfigValue<T extends string | number | boolean>(key: string, defaultValue: T): Promise<T> {
     const config = await this.getAppConfig()
-    const val = config[key]
-    return (val !== undefined ? val : defaultValue) as T
+    let val: any
+    if (Array.isArray(config)) {
+      const entry = (config as any[]).find((c) => c && c.key === key)
+      val = entry?.value
+    } else if (config && typeof config === 'object') {
+      val = (config as any)[key]
+    }
+    return (val !== undefined && val !== null ? val : defaultValue) as T
   }
 
   async login(provider: AuthProviderType): Promise<void> {

--- a/apps/remix-ide/src/app/plugins/auth-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/auth-plugin.tsx
@@ -909,15 +909,32 @@ export class AuthPlugin extends Plugin {
 
     // Update API clients with current token
     if (token) {
-      this.apiClient.setToken(token)
-      // Update other API services too
-      this.creditsApi.setToken(token)
-      this.permissionsApi.setToken(token)
-      this.billingApi.setToken(token)
-      this.inviteApi.setToken(token)
+      this.applyAuthTokenToApiClients(token)
+    } else {
+      // Keep in-memory clients in sync with storage so stale Bearer headers
+      // are never sent after logout or manual token removal.
+      this.clearAuthTokenFromApiClients()
     }
 
     return token
+  }
+
+  private applyAuthTokenToApiClients(token: string): void {
+    this.apiClient.setToken(token)
+    this.creditsApi.setToken(token)
+    this.permissionsApi.setToken(token)
+    this.billingApi.setToken(token)
+    this.inviteApi.setToken(token)
+  }
+
+  private clearAuthTokenFromApiClients(): void {
+    this.apiClient.setToken(null)
+    // Api service wrappers expose setToken(string). Empty string clears
+    // Authorization because ApiClient only sends Bearer when token is truthy.
+    this.creditsApi.setToken('')
+    this.permissionsApi.setToken('')
+    this.billingApi.setToken('')
+    this.inviteApi.setToken('')
   }
 
   /**
@@ -1229,6 +1246,7 @@ export class AuthPlugin extends Plugin {
     localStorage.removeItem('remix_access_token')
     localStorage.removeItem('remix_refresh_token')
     localStorage.removeItem('remix_user')
+    this.clearAuthTokenFromApiClients()
     this.clearRefreshTimer()
   }
 

--- a/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
@@ -11,7 +11,7 @@ declare global {
 
 /* ─── Constants ─── */
 
-const DEBUG = true
+const DEBUG = false
 const log = (...args: any[]) => { if (DEBUG) console.log('[BetaCornerWidget]', ...args) }
 
 const DISMISSED_KEY = 'remix_beta_corner_dismissed'

--- a/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
@@ -11,7 +11,7 @@ declare global {
 
 /* ─── Constants ─── */
 
-const DEBUG = false
+const DEBUG = true
 const log = (...args: any[]) => { if (DEBUG) console.log('[BetaCornerWidget]', ...args) }
 
 const DISMISSED_KEY = 'remix_beta_corner_dismissed'
@@ -27,7 +27,7 @@ const TOKEN_STORAGE_KEY = 'remix_anonymous_request_tokens'
  * MIN_SESSION_MS have elapsed (so it never flash-appears on first load).
  */
 const ACTIVITY_THRESHOLD = 6
-const MIN_SESSION_MS = 45_000 // 45 seconds minimum
+const MIN_SESSION_MS = 5_000 // 5 seconds minimum
 
 /* ─── Plugin profile ─── */
 
@@ -68,7 +68,7 @@ function hasExistingBetaToken(): boolean {
 /* ─── Plugin class ─── */
 
 export class BetaCornerWidgetPlugin extends Plugin {
-  dispatch: React.Dispatch<any> = () => {}
+  dispatch: React.Dispatch<any> = () => { }
 
   private score = 0
   private sessionStart = Date.now()
@@ -94,6 +94,12 @@ export class BetaCornerWidgetPlugin extends Plugin {
       this.renderComponent()
       return
     }
+
+    // If app config provides an auto_invite_token, route the user directly to
+    // the invitation flow instead of showing the corner widget.
+
+
+
 
     // Listen for dev-activity events via the plugin engine (proper namespaced listeners)
     this.on('fileManager', 'fileSaved', () => this.addScore(1))
@@ -161,7 +167,25 @@ export class BetaCornerWidgetPlugin extends Plugin {
     }
   }
 
-  private showWidget(): void {
+  private async showWidget(): Promise<void> {
+    const autoInviteToken = await this.call('auth' as any, 'getAppConfigValue', 'auto_invite_token', '')
+    console.log('Retrieved auto_invite_token from appConfig:', autoInviteToken)
+    if (autoInviteToken && typeof autoInviteToken === 'string' && autoInviteToken.trim() !== '') {
+      log('auto_invite_token found in appConfig, delegating to invitationManager')
+      this.shown = true
+      this.state = { ...this.state, closedThisSession: true }
+      this.renderComponent()
+      this.call('invitationManager' as any, 'showInvite', autoInviteToken, (action: 'later' | 'never') => {
+        if (action === 'never') {
+          this.dismissPermanent()
+          return
+        }
+        this.dismiss()
+      }).catch((err) => {
+        log('Failed to show invite via invitationManager', err)
+      })
+      return
+    }
     this.shown = true
     this.state = { ...this.state, visible: true }
     this.renderComponent()
@@ -184,7 +208,7 @@ export class BetaCornerWidgetPlugin extends Plugin {
   dismiss(): void {
     this.state = { ...this.state, animateOut: true }
     this.renderComponent()
-    this.call('matomo', 'trackEvent', 'cornerWidget', 'betaPromo', 'closedSession', undefined).catch(() => {})
+    this.call('matomo', 'trackEvent', 'cornerWidget', 'betaPromo', 'closedSession', undefined).catch(() => { })
     setTimeout(() => {
       this.state = { ...this.state, closedThisSession: true }
       this.renderComponent()
@@ -196,7 +220,7 @@ export class BetaCornerWidgetPlugin extends Plugin {
     this.state = { ...this.state, animateOut: true }
     this.renderComponent()
     localStorage.setItem(DISMISSED_KEY, 'true')
-    this.call('matomo', 'trackEvent', 'cornerWidget', 'betaPromo', 'dismissedPermanent', undefined).catch(() => {})
+    this.call('matomo', 'trackEvent', 'cornerWidget', 'betaPromo', 'dismissedPermanent', undefined).catch(() => { })
     setTimeout(() => {
       this.state = { ...this.state, dismissed: true }
       this.renderComponent()
@@ -206,7 +230,7 @@ export class BetaCornerWidgetPlugin extends Plugin {
   /** Called when the user clicks "Register now" */
   private handleRegisterClick(): void {
     this.call('membershipRequest', 'showRequestForm', 'beta')
-    this.call('matomo', 'trackEvent', 'cornerWidget', 'betaPromo', 'joinClicked', undefined).catch(() => {})
+    this.call('matomo', 'trackEvent', 'cornerWidget', 'betaPromo', 'joinClicked', undefined).catch(() => { })
   }
 
   /* ─── Rendering ─── */

--- a/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
@@ -90,7 +90,7 @@ export class BetaCornerWidgetPlugin extends Plugin {
 
   async onActivation(): Promise<void> {
     // Don't bother listening if already permanently dismissed or already beta
-    if (this.state.dismissed || hasExistingBetaToken()) {
+    if (this.state.dismissed || await this.hasBetaAccess()) {
       this.renderComponent()
       return
     }
@@ -111,16 +111,16 @@ export class BetaCornerWidgetPlugin extends Plugin {
     this.on('membershipRequest', 'requestApproved', () => this.autoDismiss())
 
     // Hide when a beta invite is redeemed through the invitation system
-    this.on('invitationManager' as any, 'inviteRedeemed', (data: any) => {
+    this.on('invitationManager' as any, 'inviteRedeemed', async () => {
       // Any successful invite redemption could grant beta — re-check token
-      if (hasExistingBetaToken()) {
+      if (await this.hasBetaAccess()) {
         this.autoDismiss()
       }
     })
 
     // Hide when auth state changes and the user now has beta access
-    this.on('auth' as any, 'authStateChanged', () => {
-      if (hasExistingBetaToken()) {
+    this.on('auth' as any, 'authStateChanged', async () => {
+      if (await this.hasBetaAccess()) {
         this.autoDismiss()
       }
     })
@@ -168,6 +168,12 @@ export class BetaCornerWidgetPlugin extends Plugin {
   }
 
   private async showWidget(): Promise<void> {
+    // Never show widget or invite modal when beta access is already present.
+    if (await this.hasBetaAccess()) {
+      this.autoDismiss()
+      return
+    }
+
     const autoInviteToken = await this.call('auth' as any, 'getAppConfigValue', 'auto_invite_token', '')
     console.log('Retrieved auto_invite_token from appConfig:', autoInviteToken)
     if (autoInviteToken && typeof autoInviteToken === 'string' && autoInviteToken.trim() !== '') {
@@ -189,6 +195,21 @@ export class BetaCornerWidgetPlugin extends Plugin {
     this.shown = true
     this.state = { ...this.state, visible: true }
     this.renderComponent()
+  }
+
+  private async hasBetaAccess(): Promise<boolean> {
+    if (hasExistingBetaToken()) return true
+
+    try {
+      const isAuthenticated = await this.call('auth' as any, 'isAuthenticated')
+      if (!isAuthenticated) return false
+
+      const permissions = await this.call('auth' as any, 'getAllPermissions')
+      const groups = permissions?.feature_groups || []
+      return groups.some((g: any) => g?.name === 'beta')
+    } catch {
+      return false
+    }
   }
 
   /** Auto-hide after the user submits a request or gets approved */

--- a/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
@@ -95,12 +95,6 @@ export class BetaCornerWidgetPlugin extends Plugin {
       return
     }
 
-    // If app config provides an auto_invite_token, route the user directly to
-    // the invitation flow instead of showing the corner widget.
-
-
-
-
     // Listen for dev-activity events via the plugin engine (proper namespaced listeners)
     this.on('fileManager', 'fileSaved', () => this.addScore(1))
     this.on('solidity', 'compilationFinished', () => this.addScore(3))

--- a/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
@@ -26,7 +26,7 @@ const TOKEN_STORAGE_KEY = 'remix_anonymous_request_tokens'
  * The widget surfaces once the score reaches ACTIVITY_THRESHOLD **and** at least
  * MIN_SESSION_MS have elapsed (so it never flash-appears on first load).
  */
-const ACTIVITY_THRESHOLD = 6
+const ACTIVITY_THRESHOLD = 10
 const MIN_SESSION_MS = 5_000 // 5 seconds minimum
 
 /* ─── Plugin profile ─── */

--- a/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/beta-corner-widget-plugin.tsx
@@ -89,6 +89,12 @@ export class BetaCornerWidgetPlugin extends Plugin {
   /* ─── Lifecycle ─── */
 
   async onActivation(): Promise<void> {
+    // Disable the plugin behavior in E2E runs to avoid invite-modal flakiness.
+    if (window.__IS_E2E_TEST__) {
+      this.renderComponent()
+      return
+    }
+
     // Don't bother listening if already permanently dismissed or already beta
     if (this.state.dismissed || await this.hasBetaAccess()) {
       this.renderComponent()
@@ -162,6 +168,8 @@ export class BetaCornerWidgetPlugin extends Plugin {
   }
 
   private async showWidget(): Promise<void> {
+    if (window.__IS_E2E_TEST__) return
+
     // Never show widget or invite modal when beta access is already present.
     if (await this.hasBetaAccess()) {
       this.autoDismiss()

--- a/apps/remix-ide/src/app/plugins/invitation-manager-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/invitation-manager-plugin.tsx
@@ -22,6 +22,8 @@ export class InvitationManagerPlugin extends Plugin {
   /** Set to true to enable verbose console.log output for debugging */
   private static DEBUG = false
 
+  private onShowInviteDismissAction: ((action: 'later' | 'never') => void) | null = null
+
   dispatch: React.Dispatch<any> = () => {}
   private state: InviteState = {
     show: false,
@@ -82,7 +84,9 @@ export class InvitationManagerPlugin extends Plugin {
    * Show the invite modal with a specific token
    * Can be called by any plugin: this.call('invitationManager', 'showInvite', 'TOKEN')
    */
-  async showInvite(token: string): Promise<void> {
+  async showInvite(token: string, onDismissAction?: (action: 'later' | 'never') => void): Promise<void> {
+    this.onShowInviteDismissAction = typeof onDismissAction === 'function' ? onDismissAction : null
+
     // Validate the token first
     const validation = await this.validateToken(token)
 
@@ -204,7 +208,7 @@ export class InvitationManagerPlugin extends Plugin {
   /**
    * Close the invite modal
    */
-  async close(): Promise<void> {
+  async close(reason: 'close' | 'later' | 'never' = 'close'): Promise<void> {
     this.state = {
       show: false,
       token: null,
@@ -220,6 +224,17 @@ export class InvitationManagerPlugin extends Plugin {
       await this.call('auth', 'clearPendingInviteToken')
     } catch (e) {
       // Ignore
+    }
+
+    if (this.onShowInviteDismissAction) {
+      const callback = this.onShowInviteDismissAction
+      this.onShowInviteDismissAction = null
+      const action: 'later' | 'never' = reason === 'never' ? 'never' : 'later'
+      try {
+        callback(action)
+      } catch (e) {
+        console.error('[InvitationManager] Invite dismiss callback failed:', e)
+      }
     }
 
     this.emit('inviteClosed')
@@ -351,7 +366,9 @@ export class InvitationManagerPlugin extends Plugin {
       <InviteOverlay
         state={dispatchState.state}
         onRedeem={(token) => this.redeemToken(token)}
-        onClose={() => this.close()}
+        onClose={() => this.close('close')}
+        onDoLater={this.onShowInviteDismissAction ? () => this.close('later') : undefined}
+        onDismissPermanent={this.onShowInviteDismissAction ? () => this.close('never') : undefined}
         onStartWalkthrough={(slug) => this.startWalkthrough(slug)}
         plugin={dispatchState.plugin}
       />

--- a/apps/remix-ide/src/app/plugins/membership-request-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/membership-request-plugin.tsx
@@ -81,6 +81,25 @@ export class MembershipRequestPlugin extends Plugin {
    * Called by other plugins: this.call('membershipRequest', 'showRequestForm', 'beta_program')
    */
   async showRequestForm(groupName?: string): Promise<void> {
+    if (groupName) {
+      try {
+        const [autoInviteToken, autoInviteGroup] = await Promise.all([
+          this.call('auth' as any, 'getAppConfigValue', 'auto_invite_token', ''),
+          this.call('auth' as any, 'getAppConfigValue', 'auto_invite_group', '')
+        ])
+
+        if (
+          typeof autoInviteToken === 'string' && autoInviteToken.trim() !== '' &&
+          typeof autoInviteGroup === 'string' && autoInviteGroup.trim() === groupName
+        ) {
+          await this.call('invitationManager' as any, 'showInvite', autoInviteToken.trim())
+          return
+        }
+      } catch {
+        // Fall back to the normal membership request flow if app config is unavailable.
+      }
+    }
+
     this.state = {
       ...this.state,
       show: true,

--- a/apps/remix-ide/src/app/plugins/nudge-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/nudge-plugin.tsx
@@ -105,10 +105,10 @@ export class NudgePlugin extends Plugin {
     // Auth state changes
     this.on('auth', 'authStateChanged', (state: { isAuthenticated: boolean }) => {
       if (state?.isAuthenticated) {
-        this.engine_.fire('user:logged_in')
+        this._setAuthState(true)
         this._checkBetaMembership()
       } else {
-        this.engine_.fire('user:not_logged_in')
+        this._setAuthState(false)
       }
     })
 
@@ -241,14 +241,26 @@ export class NudgePlugin extends Plugin {
     try {
       const isAuth = await this.call('auth' as any, 'isAuthenticated')
       if (isAuth) {
-        this.engine_.fire('user:logged_in')
+        this._setAuthState(true)
         this._checkBetaMembership()
       } else {
-        this.engine_.fire('user:not_logged_in')
+        this._setAuthState(false)
       }
     } catch {
       // Auth not ready yet — we'll catch it via the event listener
     }
+  }
+
+  private _setAuthState(isAuthenticated: boolean): void {
+    if (isAuthenticated) {
+      this.engine_.unfire('user:not_logged_in')
+      this.engine_.fire('user:logged_in')
+      return
+    }
+
+    this.engine_.unfire('user:logged_in')
+    this.engine_.unfire('user:logged_in_beta')
+    this.engine_.fire('user:not_logged_in')
   }
 
   private async _checkBetaMembership(): Promise<void> {

--- a/libs/remix-lib/src/state-machine/event-guard.ts
+++ b/libs/remix-lib/src/state-machine/event-guard.ts
@@ -155,6 +155,17 @@ export class EventGuard {
     return this.firedEvents.has(eventId)
   }
 
+  /**
+   * Remove a previously fired event from the context.
+   * Useful for mutually exclusive state flags (e.g. logged_in vs not_logged_in).
+   */
+  unfire(eventId: EventId): void {
+    if (!this.firedEvents.has(eventId)) return
+    this.firedEvents.delete(eventId)
+    this.orderedEvents = this.orderedEvents.filter(e => e !== eventId)
+    this.log(`🧹 unfire("${eventId}") — total fired: [${[...this.firedEvents].join(', ')}]`)
+  }
+
   /** Get a snapshot of all fired events */
   getFiredEvents(): string[] {
     return [...this.firedEvents]

--- a/libs/remix-lib/src/state-machine/nudge-engine.ts
+++ b/libs/remix-lib/src/state-machine/nudge-engine.ts
@@ -58,6 +58,11 @@ export class NudgeEngine {
     return this.guard.has(eventId)
   }
 
+  /** Remove a previously fired context event */
+  unfire(eventId: string): void {
+    this.guard.unfire(eventId)
+  }
+
   // ─── Rule management ─────────────────────────────────────────────
 
   /** Register a nudge rule. If a rule with the same id exists, it's replaced. */

--- a/libs/remix-ui/invites/src/lib/beta-join-modal.tsx
+++ b/libs/remix-ui/invites/src/lib/beta-join-modal.tsx
@@ -21,6 +21,10 @@ interface BetaJoinModalProps {
   error: string | null;
   /** Called when the user clicks "Join the Beta". */
   onRedeem: (token: string) => Promise<InviteRedeemResponse>;
+  /** Optional action to defer for this session only. */
+  onDoLater?: () => void;
+  /** Optional action to permanently dismiss related nudges. */
+  onDismissPermanent?: () => void;
   /** Plugin reference passed to LoginButton. */
   plugin?: any;
 }
@@ -276,7 +280,7 @@ function formatExpiry(expiresAt: string | null | undefined): string | null {
 // ─── Main component ──────────────────────────────────────────────
 
 const BetaJoinModal: React.FC<BetaJoinModalProps> = ({
-  open, onClose, token, validation, isAuthenticated, redeeming, error, onRedeem, plugin,
+  open, onClose, token, validation, isAuthenticated, redeeming, error, onRedeem, onDoLater, onDismissPermanent, plugin,
 }) => {
   const [ctaHovered, setCtaHovered] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
@@ -380,7 +384,7 @@ const BetaJoinModal: React.FC<BetaJoinModalProps> = ({
                 fontSize: 24, fontWeight: 500, color: c.tx, lineHeight: 1.25, marginBottom: 8,
               }}
             >
-              Help Us Build the{" "}
+              Join the{" "}
               <span
                 style={{
                   background: `linear-gradient(90deg, ${c.cy}, ${c.bl}, ${c.pu}, ${c.cy})`,
@@ -390,7 +394,7 @@ const BetaJoinModal: React.FC<BetaJoinModalProps> = ({
                   animation: "bjShimmer 4s linear infinite",
                 }}
               >
-                Future of Web3 Tooling
+                Remix Beta Program
               </span>
             </div>
             <div style={{ position: "relative", zIndex: 2, fontSize: 14, color: c.tm, lineHeight: 1.5 }}>
@@ -494,15 +498,21 @@ const BetaJoinModal: React.FC<BetaJoinModalProps> = ({
                 data-id="invite-join-beta-btn"
                 style={{
                   width: "100%", padding: 14, borderRadius: 12,
-                  background: c.cy, border: "none",
+                  background: "linear-gradient(135deg, #8af7df 0%, #45d4cb 26%, #68b2ff 58%, #b08dff 100%)",
+                  backgroundSize: "220% 220%",
+                  border: "1px solid rgba(255,255,255,0.24)",
                   fontFamily: "'DM Sans', sans-serif",
                   fontSize: 14, fontWeight: 500, color: c.bg,
                   cursor: redeeming ? "wait" : "pointer",
                   display: "flex", alignItems: "center", justifyContent: "center", gap: 8,
                   transition: "all 0.2s",
                   opacity: redeeming ? 0.7 : 1,
-                  filter: ctaHovered && !redeeming ? "brightness(1.1)" : "none",
+                  filter: ctaHovered && !redeeming ? "brightness(1.06) saturate(1.05)" : "none",
                   transform: ctaHovered && !redeeming ? "translateY(-1px)" : "none",
+                  boxShadow: ctaHovered && !redeeming
+                    ? "0 18px 36px rgba(69,212,203,0.28), 0 8px 18px rgba(104,178,255,0.22), inset 0 1px 0 rgba(255,255,255,0.35)"
+                    : "0 14px 28px rgba(69,212,203,0.22), 0 6px 14px rgba(176,141,255,0.18), inset 0 1px 0 rgba(255,255,255,0.28)",
+                  animation: redeeming ? "none" : "bjShimmer 5s linear infinite",
                 }}
               >
                 {redeeming ? (
@@ -518,7 +528,7 @@ const BetaJoinModal: React.FC<BetaJoinModalProps> = ({
                     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
                       <path d="M2 8l5 5L14 3" />
                     </svg>
-                    Start Using Remix Beta
+                    Start Using the Beta
                   </>
                 )}
               </button>
@@ -548,6 +558,51 @@ const BetaJoinModal: React.FC<BetaJoinModalProps> = ({
             <div style={{ textAlign: "center", fontSize: 11, color: c.td, marginTop: 10, lineHeight: 1.4 }}>
               Free to join. Free to leave anytime. Around a month of testing.
             </div>
+            {(onDoLater || onDismissPermanent) && (
+              <div style={{
+                marginTop: 12,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 8,
+                flexWrap: "wrap"
+              }}>
+                {onDoLater && (
+                  <button
+                    onClick={onDoLater}
+                    style={{
+                      padding: "8px 12px",
+                      borderRadius: 10,
+                      background: c.s1,
+                      border: "0.5px solid rgba(255,255,255,0.08)",
+                      fontFamily: "'DM Sans', sans-serif",
+                      fontSize: 12,
+                      color: c.tm,
+                      cursor: "pointer"
+                    }}
+                  >
+                    I will join later
+                  </button>
+                )}
+                {onDismissPermanent && (
+                  <button
+                    onClick={onDismissPermanent}
+                    style={{
+                      padding: "8px 12px",
+                      borderRadius: 10,
+                      background: c.s1,
+                      border: "0.5px solid rgba(255,255,255,0.08)",
+                      fontFamily: "'DM Sans', sans-serif",
+                      fontSize: 12,
+                      color: c.tm,
+                      cursor: "pointer"
+                    }}
+                  >
+                    Don&apos;t show again
+                  </button>
+                )}
+              </div>
+            )}
           </div>
 
           {/* ── Footer ── */}

--- a/libs/remix-ui/invites/src/lib/invite-overlay.tsx
+++ b/libs/remix-ui/invites/src/lib/invite-overlay.tsx
@@ -18,6 +18,8 @@ interface InviteOverlayProps {
   state: InviteState
   onRedeem: (token: string) => Promise<InviteRedeemResponse>
   onClose: () => void
+  onDoLater?: () => void
+  onDismissPermanent?: () => void
   onStartWalkthrough?: (slug: string) => void
   plugin?: any
 }
@@ -30,6 +32,8 @@ export const InviteOverlay: React.FC<InviteOverlayProps> = ({
   state,
   onRedeem,
   onClose,
+  onDoLater,
+  onDismissPermanent,
   onStartWalkthrough,
   plugin
 }) => {
@@ -105,6 +109,8 @@ export const InviteOverlay: React.FC<InviteOverlayProps> = ({
         error={error}
         onRedeem={onRedeem}
         onClose={onClose}
+        onDoLater={onDoLater}
+        onDismissPermanent={onDismissPermanent}
         plugin={plugin}
       />
     )
@@ -119,6 +125,8 @@ export const InviteOverlay: React.FC<InviteOverlayProps> = ({
       error={error}
       onRedeem={onRedeem}
       onClose={onClose}
+      onDoLater={onDoLater}
+      onDismissPermanent={onDismissPermanent}
       plugin={plugin}
     />
   )
@@ -369,8 +377,10 @@ const DefaultInviteModal: React.FC<{
   error: string | null
   onRedeem: (token: string) => Promise<InviteRedeemResponse>
   onClose: () => void
+  onDoLater?: () => void
+  onDismissPermanent?: () => void
   plugin?: any
-}> = ({ token, validation, isAuthenticated, redeeming, error, onRedeem, onClose, plugin }) => (
+}> = ({ token, validation, isAuthenticated, redeeming, error, onRedeem, onClose, onDoLater, onDismissPermanent, plugin }) => (
   <div className="invite-overlay" onClick={onClose}>
     <div className="invite-modal-dialog" onClick={e => e.stopPropagation()}>
       <div className="invite-modal-card">
@@ -426,18 +436,34 @@ const DefaultInviteModal: React.FC<{
 
           <div className="invite-modal-right-footer">
             {isAuthenticated ? (
-              <button
-                className="btn invite-modal-btn-primary w-100"
-                data-id="invite-activate-btn"
-                onClick={() => onRedeem(token)}
-                disabled={redeeming}
-              >
-                {redeeming ? (
-                  <><i className="fas fa-spinner fa-spin me-2"></i>Activating...</>
-                ) : (
-                  <><i className="fas fa-check me-2"></i>Activate Invite</>
+              <div className="w-100">
+                <button
+                  className="btn invite-modal-btn-primary w-100"
+                  data-id="invite-activate-btn"
+                  onClick={() => onRedeem(token)}
+                  disabled={redeeming}
+                >
+                  {redeeming ? (
+                    <><i className="fas fa-spinner fa-spin me-2"></i>Activating...</>
+                  ) : (
+                    <><i className="fas fa-check me-2"></i>Activate Invite</>
+                  )}
+                </button>
+                {(onDoLater || onDismissPermanent) && (
+                  <div className="d-flex justify-content-center gap-2 mt-3">
+                    {onDoLater && (
+                      <button className="btn invite-modal-btn-secondary" onClick={onDoLater}>
+                        I will join later
+                      </button>
+                    )}
+                    {onDismissPermanent && (
+                      <button className="btn invite-modal-btn-secondary" onClick={onDismissPermanent}>
+                        Don&apos;t show again
+                      </button>
+                    )}
+                  </div>
                 )}
-              </button>
+              </div>
             ) : (
               <div className="w-100">
                 <p className="invite-modal-muted text-center mb-3">
@@ -445,6 +471,20 @@ const DefaultInviteModal: React.FC<{
                   Sign in to activate this invite
                 </p>
                 <LoginButton className="btn-lg w-100" plugin={plugin} />
+                {(onDoLater || onDismissPermanent) && (
+                  <div className="d-flex justify-content-center gap-2 mt-3">
+                    {onDoLater && (
+                      <button className="btn invite-modal-btn-secondary" onClick={onDoLater}>
+                        I will join later
+                      </button>
+                    )}
+                    {onDismissPermanent && (
+                      <button className="btn invite-modal-btn-secondary" onClick={onDismissPermanent}>
+                        Don&apos;t show again
+                      </button>
+                    )}
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/libs/remix-ui/top-bar/src/components/BetaPromoPill.tsx
+++ b/libs/remix-ui/top-bar/src/components/BetaPromoPill.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useCallback } from 'react'
+import React, { useCallback } from 'react'
 import { useAuth } from '@remix-ui/app'
 import { CustomTooltip } from '@remix-ui/helper'
 
-const DISMISSED_KEY = 'remix_beta_promo_dismissed'
 const TOKEN_STORAGE_KEY = 'remix_anonymous_request_tokens'
 
 interface BetaPromoPillProps {
@@ -22,25 +21,14 @@ function hasExistingBetaToken(): boolean {
 
 export function BetaPromoPill({ plugin }: BetaPromoPillProps) {
   const { isAuthenticated, featureGroups } = useAuth()
-  const [dismissed, setDismissed] = useState(
-    () => localStorage.getItem(DISMISSED_KEY) === 'true'
-  )
 
   const handleClick = useCallback(() => {
     plugin.call('membershipRequest', 'showRequestForm', 'beta')
     plugin.call('matomo', 'trackEvent', 'topbar', 'betaPromo', 'joinClicked', undefined).catch(() => {})
   }, [plugin])
 
-  const handleDismiss = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-    e.preventDefault()
-    localStorage.setItem(DISMISSED_KEY, 'true')
-    setDismissed(true)
-    plugin.call('matomo', 'trackEvent', 'topbar', 'betaPromo', 'dismissed', undefined).catch(() => {})
-  }, [plugin])
-
   const hasBeta = featureGroups?.some(fg => fg.name === 'beta')
-  if (dismissed || isAuthenticated || hasBeta || hasExistingBetaToken()) return null
+  if (isAuthenticated || hasBeta || hasExistingBetaToken()) return null
 
   return (
     <CustomTooltip placement="bottom" tooltipText="Get early access to new features">
@@ -51,13 +39,6 @@ export function BetaPromoPill({ plugin }: BetaPromoPillProps) {
       >
         <i className="fas fa-flask me-1"></i>
         <span>Join Remix Beta</span>
-        <span
-          className="beta-promo-dismiss ms-1"
-          onClick={handleDismiss}
-          title="Dismiss"
-        >
-          <i className="fas fa-times"></i>
-        </span>
       </span>
     </CustomTooltip>
   )

--- a/libs/remix-ui/top-bar/src/css/topbar.css
+++ b/libs/remix-ui/top-bar/src/css/topbar.css
@@ -125,30 +125,48 @@
 
 /* Beta promo pill */
 .beta-promo-pill {
+  position: relative;
+  overflow: hidden;
   cursor: pointer;
   font-size: 0.75rem;
-  padding: 0.2rem 0.55rem;
+  font-weight: 500;
+  padding: 0.24rem 0.62rem;
   border-radius: 999px;
-  border: 1px solid var(--bs-primary);
-  color: var(--bs-primary);
+  border: 1px solid rgba(55, 201, 255, 0.55);
+  color: #9be7ff;
+  background: linear-gradient(115deg, rgba(0, 138, 203, 0.14) 0%, rgba(12, 86, 157, 0.22) 45%, rgba(0, 179, 255, 0.15) 100%);
+  box-shadow: 0 0 0 1px rgba(18, 138, 212, 0.2) inset, 0 6px 14px rgba(0, 97, 164, 0.22);
   white-space: nowrap;
-  transition: background-color 0.15s, color 0.15s;
+  transition: transform 0.18s ease, box-shadow 0.2s ease, color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
   user-select: none;
 }
+.beta-promo-pill::before {
+  content: '';
+  position: absolute;
+  top: -100%;
+  left: -36%;
+  width: 28%;
+  height: 300%;
+  transform: rotate(23deg);
+  background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(173, 239, 255, 0.34) 52%, rgba(255, 255, 255, 0) 100%);
+  opacity: 0.85;
+  pointer-events: none;
+}
 .beta-promo-pill:hover {
-  background-color: var(--bs-primary);
-  color: #fff;
+  color: #e8fbff;
+  border-color: rgba(110, 224, 255, 0.85);
+  background: linear-gradient(115deg, rgba(15, 168, 233, 0.28) 0%, rgba(54, 98, 190, 0.34) 45%, rgba(23, 203, 255, 0.3) 100%);
+  box-shadow: 0 0 0 1px rgba(146, 232, 255, 0.3) inset, 0 10px 22px rgba(22, 136, 228, 0.35), 0 0 18px rgba(26, 177, 255, 0.28);
+  transform: translateY(-1px);
 }
-.beta-promo-pill:hover .beta-promo-dismiss {
-  color: rgba(255, 255, 255, 0.7);
+.beta-promo-pill:hover::before {
+  animation: beta-pill-shine 0.9s ease;
 }
-.beta-promo-dismiss {
-  font-size: 0.6rem;
-  opacity: 0.5;
-  padding: 2px;
-  line-height: 1;
-  transition: opacity 0.15s;
-}
-.beta-promo-dismiss:hover {
-  opacity: 1;
+@keyframes beta-pill-shine {
+  0% {
+    left: -36%;
+  }
+  100% {
+    left: 128%;
+  }
 }


### PR DESCRIPTION
the beta corner widget which used to appear after some activity when logged out now will trigger the invite beta sign up modal, really fast. users can always dismiss it for the session until refresh or permanently. the join beta button in the top bar also opens the beta join sign up modal, and the widgets in the corner which sometimes appear, ie when using chat also trigger that. 
the backend has two values, we can always turn them off, then it doesnt happen
<img width="2251" height="114" alt="Screenshot 2026-04-23 at 19 47 29" src="https://github.com/user-attachments/assets/c4f1d3b9-bbc3-449a-b798-c6f945679239" />
