### PR TITLE
fix: default deployed contract functions to expanded state

### DIFF
--- a/apps/remix-ide-e2e/src/commands/clickInstance.ts
+++ b/apps/remix-ide-e2e/src/commands/clickInstance.ts
@@ -4,6 +4,7 @@ import EventEmitter from 'events'
 class ClickInstance extends EventEmitter {
   command (this: NightwatchBrowser, index: number): NightwatchBrowser {
     const selector = `[data-id="deployedContractItem-${index}"]`
+    const expandedContentSelector = `[data-id="functionDropdown-${index}"]`
 
     this.api
       .closeBetaPopUp()
@@ -11,7 +12,14 @@ class ClickInstance extends EventEmitter {
         locateStrategy: 'css selector',
         selector,
         timeout: 80000
-      }).waitForElementContainsText(selector, '', 80000).scrollAndClick(selector).perform(() => { this.emit('complete') })
+      }).waitForElementContainsText(selector, '', 80000)
+      .isVisible(expandedContentSelector, (result) => {
+        // Only click to expand if the contract is currently collapsed
+        if (!result.value) {
+          this.api.scrollAndClick(selector)
+        }
+      })
+      .perform(() => { this.emit('complete') })
     return this
   }
 }

--- a/libs/remix-ui/run-tab-deployed-contracts/src/lib/components/DeployedContractItem.tsx
+++ b/libs/remix-ui/run-tab-deployed-contracts/src/lib/components/DeployedContractItem.tsx
@@ -35,7 +35,7 @@ export function DeployedContractItem({ contract, index, registerRef, isKebabMenu
   const { features } = useAuth()
   const hasQuickdappAccess = features?.['dapp:quickdapp']?.is_enabled
   const [networkName, setNetworkName] = useState<string>('')
-  const [isExpanded, setIsExpanded] = useState<boolean>(false)
+  const [isExpanded, setIsExpanded] = useState<boolean>(true)
   const [contractABI, setContractABI] = useState(null)
   const [value, setValue] = useState<string>('0')
   const [valueUnit, setValueUnit] = useState<string>('wei')

--- a/libs/remix-ui/run-tab/src/lib/components/universalDappUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/universalDappUI.tsx
@@ -23,7 +23,7 @@ export function UniversalDappUI(props: UdappProps) {
   const intl = useIntl()
   const { trackMatomoEvent: baseTrackEvent } = useContext(TrackingContext)
   const trackMatomoEvent = <T extends UdappEvent = UdappEvent>(event: T) => baseTrackEvent?.<T>(event)
-  const [toggleExpander, setToggleExpander] = useState<boolean>(false)
+  const [toggleExpander, setToggleExpander] = useState<boolean>(true)
   const [contractABI, setContractABI] = useState<FuncABI[]>(null)
   const [address, setAddress] = useState<string>('')
   const [expandPath, setExpandPath] = useState<string[]>([])

--- a/libs/remix-ui/run-tab/src/lib/components/universalDappUI.tsx
+++ b/libs/remix-ui/run-tab/src/lib/components/universalDappUI.tsx
@@ -23,7 +23,7 @@ export function UniversalDappUI(props: UdappProps) {
   const intl = useIntl()
   const { trackMatomoEvent: baseTrackEvent } = useContext(TrackingContext)
   const trackMatomoEvent = <T extends UdappEvent = UdappEvent>(event: T) => baseTrackEvent?.<T>(event)
-  const [toggleExpander, setToggleExpander] = useState<boolean>(true)
+  const [toggleExpander, setToggleExpander] = useState<boolean>(false)
   const [contractABI, setContractABI] = useState<FuncABI[]>(null)
   const [address, setAddress] = useState<string>('')
   const [expandPath, setExpandPath] = useState<string[]>([])


### PR DESCRIPTION
## Summary
- Change the default state of deployed contracts from collapsed to expanded so developers can immediately interact with functions after deploying
- Previously, every deploy or contract switch collapsed the function list, requiring manual clicks to expand

**Files changed:**
- `DeployedContractItem.tsx` — `isExpanded` default: `false` → `true`
- `universalDappUI.tsx` — `toggleExpander` default: `true` → `false` (inverted logic, same effect)
- `clickInstance.ts` (E2E) — Updated to check visibility before toggling, so tests work correctly with the new default

Fixes #7132

## Test plan
- [ ] Deploy a contract — functions should be visible immediately without clicking
- [ ] Deploy multiple contracts — all should start expanded
- [ ] Clicking the contract header should still toggle collapse/expand
- [ ] E2E tests pass