### PR TITLE
E2E Chat History Test Patch 

### DIFF
--- a/apps/remix-ide-e2e/src/tests/chatHistory.test.ts
+++ b/apps/remix-ide-e2e/src/tests/chatHistory.test.ts
@@ -636,16 +636,60 @@ module.exports = {
         locateStrategy: 'xpath',
         timeout: 60000
       })
+      .executeAsync(function (done) {
+        const remixAIPlugin = (window as any).getRemixAIPlugin
+        if (!remixAIPlugin) {
+          done(false)
+          return
+        }
+
+        Promise.resolve()
+          .then(function () {
+            return remixAIPlugin.disableDeepAgent?.()
+          })
+          .then(function () {
+            return remixAIPlugin.disableMCPEnhancement?.()
+          })
+          .then(function () {
+            done(true)
+          })
+          .catch(function () {
+            done(false)
+          })
+      }, [], function (result) {
+        browser.assert.equal(result.value, true, 'Remote inferencer path enabled for prompt capture')
+      })
       .execute(function () {
-        const originalFetch = window.fetch;
         (window as any)._capturedPrompt = undefined
+        const capturePrompt = function (payload) {
+          if (payload && typeof payload.prompt === 'string') {
+            (window as any)._capturedPrompt = payload.prompt
+          }
+        }
+
+        const remixAIPlugin = (window as any).getRemixAIPlugin
+        const remoteInferencer = remixAIPlugin?.remoteInferencer
+        if (remoteInferencer && !remoteInferencer.__capturePromptPatched) {
+          const originalStreamRequest = remoteInferencer._streamInferenceRequest
+          const originalMakeRequest = remoteInferencer._makeRequest
+
+          remoteInferencer._streamInferenceRequest = function (payload, rType) {
+            capturePrompt(payload)
+            return originalStreamRequest.call(this, payload, rType)
+          }
+          remoteInferencer._makeRequest = function (payload, rType) {
+            capturePrompt(payload)
+            return originalMakeRequest.call(this, payload, rType)
+          }
+          remoteInferencer.__capturePromptPatched = true
+        }
+
+        const originalFetch = window.fetch
         window.fetch = function (input, init) {
           if (init && init.body && typeof init.body === 'string') {
             try {
               const body = JSON.parse(init.body)
-              if (typeof body.prompt === 'string') {
-                (window as any)._capturedPrompt = body.prompt
-              }
+              capturePrompt(body)
             } catch (e) { /* non-JSON body, ignore */ }
           }
           return originalFetch.call(this, input, init)
@@ -657,31 +701,45 @@ module.exports = {
       .pause(1000)
       .waitForElementVisible(`*[data-id="conversation-item-${convId}"]`, 5000)
       .click(`*[data-id="conversation-item-${convId}"]`)
-      .pause(1000)
+      .waitForElementPresent({
+        selector: "//*[@data-id='ai-user-chat-bubble' and contains(., 'Assistant answer number 8')]",
+        locateStrategy: 'xpath',
+        timeout: 10000
+      })
       // Send a new message to trigger the AI fetch request
       .waitForElementVisible('*[data-id="remix-ai-prompt-input"]')
       .setValue('*[data-id="remix-ai-prompt-input"]', 'What was the last thing we discussed?')
       .click('*[data-id="remix-ai-composer-send-btn"]')
       .waitForElementPresent({
-        selector: "//*[@data-id='remix-ai-streaming' and @data-streaming='false']",
+        selector: "//*[@data-id='ai-user-chat-bubble' and contains(., 'What was the last thing we discussed?')]",
         locateStrategy: 'xpath',
-        timeout: 120000
+        timeout: 10000
       })
-      .pause()
-      // Assert: the intercepted prompt explicitly embeds the seeded conversation.
-      .execute(function () {
-        return (window as any)._capturedPrompt
+      .executeAsync(function (done) {
+        const startedAt = Date.now()
+        const interval = setInterval(function () {
+          const prompt = (window as any)._capturedPrompt
+          if (typeof prompt === 'string' && prompt.length > 0) {
+            clearInterval(interval)
+            done(prompt)
+            return
+          }
+          if (Date.now() - startedAt > 10000) {
+            clearInterval(interval)
+            done(prompt)
+          }
+        }, 100)
       }, [], function (result) {
         const prompt = result.value as string
-        browser
-          .assert.ok(
-            typeof prompt === 'string' && prompt.length > 0,
-            'Prompt sent to AI is captured'
-          )
-          .assert.ok(
-            prompt.includes('Previous conversation:'),
-            'Prompt contains the embedded conversation header'
-          )
+        browser.assert.ok(
+          typeof prompt === 'string' && prompt.length > 0,
+          'Prompt sent to AI is captured'
+        )
+        if (typeof prompt !== 'string') return
+        browser.assert.ok(
+          prompt.includes('Previous conversation:'),
+          'Prompt contains the embedded conversation header'
+        )
           .assert.ok(
             prompt.includes('User: User question number 1'),
             'Prompt contains the oldest seeded user message'
@@ -698,6 +756,11 @@ module.exports = {
             prompt.includes('What was the last thing we discussed?'),
             'Prompt contains the current user request content'
           )
+      })
+      .waitForElementPresent({
+        selector: "//*[@data-id='remix-ai-streaming' and @data-streaming='false']",
+        locateStrategy: 'xpath',
+        timeout: 240000
       })
   },'Should show an emtpy bubble and not crash the UI when payload is null or undefined #group4': function (browser: NightwatchBrowser) {
     const convId = 'null-content-crash-test-conv-001'

--- a/libs/remix-ui/remix-ai-assistant/src/components/chatHistorySidebar.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/chatHistorySidebar.tsx
@@ -9,9 +9,9 @@ interface ChatHistorySidebarProps {
   currentConversationId: string | null
   showArchived: boolean
   onNewConversation: () => void
-  onLoadConversation: (id: string) => void
-  onArchiveConversation: (id: string) => void
-  onDeleteConversation: (id: string) => void
+  onLoadConversation: (id: string) => Promise<void>
+  onArchiveConversation: (id: string) => Promise<void>
+  onDeleteConversation: (id: string) => Promise<void>
   onDeleteAllConversations?: () => void
   onToggleArchived: () => void
   onClose: () => void
@@ -178,21 +178,21 @@ export const ChatHistorySidebar: React.FC<ChatHistorySidebarProps> = ({
               conversation={conv}
               theme={theme}
               active={conv.id === currentConversationId}
-              onClick={() => {
+              onClick={async () => {
                 // Automatically unarchive if the conversation is archived
                 if (conv.archived) {
-                  onArchiveConversation(conv.id)
+                  await onArchiveConversation(conv.id)
                 }
-                onLoadConversation(conv.id)
+                await onLoadConversation(conv.id)
               }}
-              onArchive={(e) => {
+              onArchive={async (e) => {
                 e.stopPropagation()
-                onArchiveConversation(conv.id)
+                await onArchiveConversation(conv.id)
               }}
-              onDelete={(e) => {
+              onDelete={async (e) => {
                 e.stopPropagation()
                 if (confirm(`Delete conversation "${conv.title}"?`)) {
-                  onDeleteConversation(conv.id)
+                  await onDeleteConversation(conv.id)
                 }
               }}
             />

--- a/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
@@ -38,9 +38,9 @@ export interface RemixUiRemixAiAssistantProps {
   showHistorySidebar?: boolean
   isMaximized?: boolean
   onNewConversation?: () => void
-  onLoadConversation?: (id: string) => void
-  onArchiveConversation?: (id: string) => void
-  onDeleteConversation?: (id: string) => void
+  onLoadConversation?: (id: string) => Promise<void>
+  onArchiveConversation?: (id: string) => Promise<void>
+  onDeleteConversation?: (id: string) => Promise<void>
   onDeleteAllConversations?: () => void
   onToggleHistorySidebar?: () => void
   onSearch?: (query: string) => Promise<ConversationMetadata[]>
@@ -1809,9 +1809,9 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
               currentConversationId={props.currentConversationId || null}
               showArchived={showArchivedConversations}
               onNewConversation={props.onNewConversation || (() => {})}
-              onLoadConversation={props.onLoadConversation || (() => {})}
-              onArchiveConversation={props.onArchiveConversation || (() => {})}
-              onDeleteConversation={props.onDeleteConversation || (() => {})}
+              onLoadConversation={props.onLoadConversation || (async (id: string) => {})}
+              onArchiveConversation={props.onArchiveConversation || (async (id: string) => {})}
+              onDeleteConversation={props.onDeleteConversation || (async (id: string) => {})}
               onDeleteAllConversations={props.onDeleteAllConversations}
               onToggleArchived={() => setShowArchivedConversations(!showArchivedConversations)}
               onClose={props.onToggleHistorySidebar || (() => {})}
@@ -1923,13 +1923,13 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
                     currentConversationId={props.currentConversationId || null}
                     showArchived={showArchivedConversations}
                     onNewConversation={props.onNewConversation || (() => {})}
-                    onLoadConversation={(id) => {
-                      props.onLoadConversation?.(id)
+                    onLoadConversation={async (id) => {
+                      await props.onLoadConversation?.(id)
                       // Close sidebar after loading conversation in non-maximized mode
-                      props.onToggleHistorySidebar?.()
+                      await props.onToggleHistorySidebar?.()
                     }}
-                    onArchiveConversation={props.onArchiveConversation || (() => {})}
-                    onDeleteConversation={props.onDeleteConversation || (() => {})}
+                    onArchiveConversation={props.onArchiveConversation || (async (id: string) => {})}
+                    onDeleteConversation={props.onDeleteConversation || (async (id: string) => {})}
                     onDeleteAllConversations={props.onDeleteAllConversations}
                     onToggleArchived={() => setShowArchivedConversations(!showArchivedConversations)}
                     onClose={props.onToggleHistorySidebar || (() => {})}


### PR DESCRIPTION
 **The test is asserting the remote inferencer prompt format (Previous conversation: / Current user request:), but DeepAgent does not produce that payload shape, so the window.fetch interceptor never sees a { prompt: string } body**.

I updated the test to:

- Disable DeepAgent and MCP enhancement for this test so it exercises the remote inferencer path it is asserting.
- Capture the prompt at remoteInferencer._streamInferenceRequest / _makeRequest, before the network layer.
- Keep fetch capture as a fallback.
- Wait for the loaded seeded history bubble before sending.
- Wait for the current user bubble after sending, so a future failure tells us whether send itself failed.
- Poll _capturedPrompt before running the prompt-content assertions.