### PR TITLE
[QuickDApp] UX improvements and bug fixes

### DIFF
--- a/apps/remix-ide/src/app/plugins/nudge-plugin.tsx
+++ b/apps/remix-ide/src/app/plugins/nudge-plugin.tsx
@@ -394,14 +394,14 @@ export class NudgePlugin extends Plugin {
       priority: 8
     })
 
-    // QuickDApp — triggers when user compiles a contract successfully
+    // QuickDApp — triggers when user deploys a contract successfully
     this.engine_.addRule({
       id: 'try-quickdapp',
-      condition: all('user:logged_in_beta', 'contract:compiled'),
+      condition: all('user:logged_in_beta', 'contract:deployed'),
       action: {
         type: 'widget',
         title: 'Try QuickDApp',
-        message: 'Your contract compiled! Generate a ready-to-use frontend dashboard to interact with it — no front-end code needed.',
+        message: 'Your contract is deployed! Generate a ready-to-use frontend dashboard to interact with it — no front-end code needed.',
         actionLabel: 'Learn More',
         actionTarget: 'helpPlugin::showModal::quickdapp',
         icon: 'fas fa-rocket',

--- a/apps/remix-ide/src/app/plugins/quick-dapp-v2.tsx
+++ b/apps/remix-ide/src/app/plugins/quick-dapp-v2.tsx
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events'
 
 const profile = {
   name: 'quick-dapp-v2',
-  displayName: 'Quick Dapp V2',
+  displayName: 'QuickDApp',
   icon: 'assets/img/quickdappv2.webp',
   description: 'Edit & deploy a Dapp',
   kind: 'quick-dapp-v2',

--- a/libs/remix-ai-core/src/inferencers/deepagent/SubagentConfig.ts
+++ b/libs/remix-ai-core/src/inferencers/deepagent/SubagentConfig.ts
@@ -59,6 +59,7 @@ export async function buildSubagentConfigs(
   const hasWebSearchPermission = await plugin.call('auth', 'hasPermission', 'mcp:web-search')
   const hasCirclePermission = await plugin.call('auth', 'hasPermission', 'mcp:circle')
   const hasOZpermission = await plugin.call('auth', 'hasPermission', 'mcp:openzeppelin')
+  const hasQuickdappPermission = await plugin.call('auth', 'hasPermission', 'dapp:quickdapp')
 
   const etherscanTools = getEtherscanToolsForEtherscanSpecialist(tools)
   const theGraphTools = getTheGraphToolsForTheGraphSpecialist(tools)
@@ -93,13 +94,7 @@ export async function buildSubagentConfigs(
       tools: deployerTools,
       description: CONTRACT_RUNNER_PROMPT
     },
-    {
-      name: 'QuickDapp Specialist',
-      systemPrompt: QUICKDAPP_SPECIALIST_SUBAGENT_PROMPT,
-      model: modelAny,
-      tools: quickDappTools,
-      description: 'Specializes in generating and updating React-based DApp frontends using file_write tools.'
-    },
+
     {
       name: 'Debug Specialist',
       systemPrompt: DEBUG_SPECIALIST_SUBAGENT_PROMPT,
@@ -115,6 +110,17 @@ export async function buildSubagentConfigs(
       description: 'Specializes in providing conversion utilities for various data formats.'
     }
   ]
+
+  // dapp:quickdapp permission required
+  if (hasQuickdappPermission) {
+    agents.push({
+      name: 'QuickDapp Specialist',
+      systemPrompt: QUICKDAPP_SPECIALIST_SUBAGENT_PROMPT,
+      model: modelAny,
+      tools: quickDappTools,
+      description: 'Specializes in generating and updating React-based DApp frontends using file_write tools.'
+    })
+  }
 
   // ai:auditor permission required
   if (hasAuditorPermission) {

--- a/libs/remix-ai-core/src/inferencers/deepagent/helpers/subagentToolFilters.ts
+++ b/libs/remix-ai-core/src/inferencers/deepagent/helpers/subagentToolFilters.ts
@@ -142,8 +142,8 @@ export function getEtherscanToolsForEtherscanSpecialist(tools: DynamicStructured
     // Check if tool comes from Etherscan MCP server
     const description = tool.description.toLowerCase()
     return description.includes('[etherscan]') ||
-           tool.name.toLowerCase().includes('etherscan') ||
-           description.includes('etherscan')
+      tool.name.toLowerCase().includes('etherscan') ||
+      description.includes('etherscan')
   })
 
   return etherscanTools
@@ -154,12 +154,12 @@ export function getTheGraphToolsForTheGraphSpecialist(tools: DynamicStructuredTo
     // Check if tool comes from TheGraph MCP server
     const description = tool.description.toLowerCase()
     return description.includes('[the graph api]') ||
-           description.includes('[thegraph]') ||
-           tool.name.toLowerCase().includes('thegraph') ||
-           tool.name.toLowerCase().includes('graph') ||
-           description.includes('thegraph') ||
-           description.includes('subgraph') ||
-           description.includes('graphql')
+      description.includes('[thegraph]') ||
+      tool.name.toLowerCase().includes('thegraph') ||
+      tool.name.toLowerCase().includes('graph') ||
+      description.includes('thegraph') ||
+      description.includes('subgraph') ||
+      description.includes('graphql')
   })
 
   return theGraphTools
@@ -170,8 +170,8 @@ export function getAlchemyToolsForAlchemySpecialist(tools: DynamicStructuredTool
     // Check if tool comes from Alchemy MCP server
     const description = tool.description.toLowerCase()
     return description.includes('[alchemy]') ||
-           tool.name.toLowerCase().includes('alchemy') ||
-           description.includes('alchemy')
+      tool.name.toLowerCase().includes('alchemy') ||
+      description.includes('alchemy')
   })
 
   return alchemyTools
@@ -259,6 +259,9 @@ export function filterOutFileOperationTools(tools: DynamicStructuredTool[]): Dyn
 
 export function getQuickDappToolsForQuickDappSpecialist(tools: DynamicStructuredTool[]): DynamicStructuredTool[] {
   const quickDappToolNames = [
+    'generate_dapp',
+    'update_dapp',
+    'list_dapps',
     'finalize_dapp_generation',
     'fetch_figma_design'
   ]

--- a/libs/remix-ai-core/src/inferencers/deepagent/prompts/system/lightPrompts.ts
+++ b/libs/remix-ai-core/src/inferencers/deepagent/prompts/system/lightPrompts.ts
@@ -52,7 +52,7 @@ When being asked to perform a conversion, always use the conversion tools and ne
 export const CIRCLE_SUBAGENT_PROMPT = `Circle Specialist: Expert in Circle product documentation, APIs, and development resources.
 Searches Circle docs, retrieves product summaries, lists coding resources, and provides detailed resource information.`
 
-export const QUICKDAPP_SPECIALIST_SUBAGENT_PROMPT = `QuickDapp Specialist: Generate and update React-based DApp frontends using file_write tool.
+export const QUICKDAPP_SPECIALIST_SUBAGENT_PROMPT = `QuickDapp Specialist: Full DApp lifecycle — use list_dapps, generate_dapp, update_dapp for orchestration, then file_write for implementation, and finalize_dapp_generation to complete.
 File paths are relative to workspace root. After writing all files, call finalize_dapp_generation.`
 
 export const CONTRACT_CLASSIFIER_PROMPT = 'Contract Classifier: Analyze smart contract structure and classify features (proxy patterns, token standards, DeFi protocols, governance mechanisms). Extract contract skeleton and identify architectural patterns, complexity indicators, and risk factors using structured analysis.'

--- a/libs/remix-ai-core/src/remix-mcp-server/handlers/DAppGeneratorHandler.ts
+++ b/libs/remix-ai-core/src/remix-mcp-server/handlers/DAppGeneratorHandler.ts
@@ -250,7 +250,8 @@ export class GenerateDAppHandler extends BaseToolHandler {
               `- Use window.ethereum directly: new ethers.BrowserProvider(window.ethereum). The Remix IDE preview provides it automatically.\n` +
               `- Do NOT use window.__qdapp_getProvider(). Do NOT call wallet_switchEthereumChain or wallet_addEthereumChain.\n` +
               `- Do NOT show "Install MetaMask", "Wrong Network" warnings, or chain ID checks. The provider is always available and on the correct network.\n` +
-              `- Simply connect: const provider = new ethers.BrowserProvider(window.ethereum); await provider.send("eth_requestAccounts", []); const signer = await provider.getSigner();\n`
+              `- Simply connect: const provider = new ethers.BrowserProvider(window.ethereum); await provider.send("eth_requestAccounts", []); const signer = await provider.getSigner();\n` +
+              `- MUST listen for window.ethereum accountsChanged and immediately update the visible connected account, signer, and contract instance when Deploy & Run account changes. Do not require a preview refresh.\n`
             : `\nREAL NETWORK WALLET RULES (CRITICAL - use EXACT values below):\n` +
               `- The contract is deployed on chain ${args.chainId}. Set TARGET_CHAIN_ID = ${args.chainId} in the generated code.\n` +
               `- For wallet_switchEthereumChain, use chainId: '0x${Number(args.chainId).toString(16)}'. Do NOT use '0x1' or any other chain.\n` +
@@ -528,7 +529,8 @@ export class UpdateDAppHandler extends BaseToolHandler {
             ? `\nREMIX VM RULES (LOCAL DEV MODE - CRITICAL):\n` +
               `- Use window.ethereum directly: new ethers.BrowserProvider(window.ethereum). The Remix IDE preview provides it automatically.\n` +
               `- Do NOT use window.__qdapp_getProvider(). Do NOT call wallet_switchEthereumChain or wallet_addEthereumChain.\n` +
-              `- Do NOT show "Install MetaMask", "Wrong Network" warnings, or chain ID checks.\n`
+              `- Do NOT show "Install MetaMask", "Wrong Network" warnings, or chain ID checks.\n` +
+              `- MUST listen for window.ethereum accountsChanged and immediately update the visible connected account, signer, and contract instance when Deploy & Run account changes. Do not require a preview refresh.\n`
             : `\nREAL NETWORK WALLET RULES (CRITICAL - use EXACT values below):\n` +
               `- The contract is deployed on chain ${contractResolved.chainId}. Set TARGET_CHAIN_ID = ${contractResolved.chainId} in the generated code.\n` +
               `- For wallet_switchEthereumChain, use chainId: '0x${Number(contractResolved.chainId).toString(16)}'. Do NOT use '0x1' or any other chain.\n` +
@@ -932,4 +934,3 @@ export function createDAppGeneratorTools(): RemixToolDefinition[] {
     }
   ]
 }
-

--- a/libs/remix-ai-core/src/remix-mcp-server/handlers/DAppGeneratorHandler.ts
+++ b/libs/remix-ai-core/src/remix-mcp-server/handlers/DAppGeneratorHandler.ts
@@ -197,7 +197,6 @@ export class GenerateDAppHandler extends BaseToolHandler {
       // Return concise context to the agent for file generation.
       // Do NOT include the full system prompt or file dumps — they cause tool result overflow.
       // The agent/subagent already knows DApp frontend patterns.
-      console.log(`[GenerateDApp] Workspace setup complete. Delegating file creation to agent. slug=${workspaceSlug}`)
 
       // Extract contract ABI summary for concise context
       const abiSummary = args.contractAbi
@@ -218,8 +217,7 @@ export class GenerateDAppHandler extends BaseToolHandler {
         contractName: args.contractName,
         workspaceReady: true,
         message: `DApp workspace "${workspaceSlug}" created successfully.\n\n` +
-          `**IMPORTANT: You MUST delegate file generation to a QuickDapp Specialist subagent using the task tool.**\n\n` +
-          `Use the task tool with subagent_type "QuickDapp Specialist" and provide the following context in the task prompt:\n\n` +
+          `Now proceed to generate the DApp files directly using file_write.\n\n` +
           `---\n` +
           `TASK: Generate a new DApp frontend\n` +
           `CONTRACT: ${args.contractName} at ${args.contractAddress} on chain ${args.chainId}${isLocalVM ? ' (Remix VM)' : ''}\n` +
@@ -227,16 +225,16 @@ export class GenerateDAppHandler extends BaseToolHandler {
           `USER DESIGN REQUEST: ${typeof args.description === 'string' ? args.description : JSON.stringify(args.description)}\n` +
           (args.isBaseMiniApp
             ? `\nBASE APP RULES:\n` +
-              `- Do NOT import @farcaster/miniapp-sdk (deprecated). Do NOT include fc:frame or fc:miniapp meta tags.\n` +
-              `- Use standard wallet pattern (window.__qdapp_getProvider or window.ethereum).\n` +
-              `- Default to Base Mainnet (8453) or Base Sepolia (84532).\n`
+            `- Do NOT import @farcaster/miniapp-sdk (deprecated). Do NOT include fc:frame or fc:miniapp meta tags.\n` +
+            `- Use standard wallet pattern (window.__qdapp_getProvider or window.ethereum).\n` +
+            `- Default to Base Mainnet (8453) or Base Sepolia (84532).\n`
             : '') +
           `${figmaLine}` +
           (args.figmaUrl
             ? `\nFIGMA DESIGN RULES:\n` +
-              `- Use max-w-7xl mx-auto px-4 instead of fixed widths. Use flex-wrap for mobile responsiveness.\n` +
-              `- Avoid position: absolute. Create separate component files for distinct sections.\n` +
-              `- Adapt Figma dimensions to fluid/responsive code.\n`
+            `- Use max-w-7xl mx-auto px-4 instead of fixed widths. Use flex-wrap for mobile responsiveness.\n` +
+            `- Avoid position: absolute. Create separate component files for distinct sections.\n` +
+            `- Adapt Figma dimensions to fluid/responsive code.\n`
             : '') +
           `\n${QUICKDAPP_BUILD_RULES}\n` +
           `CRITICAL PATH RULES:\n` +
@@ -247,20 +245,19 @@ export class GenerateDAppHandler extends BaseToolHandler {
           `2. Use ethers.js v6 (BrowserProvider, Contract). Embed full ABI and contract address in code.\n` +
           (isLocalVM
             ? `\nREMIX VM RULES (LOCAL DEV MODE - CRITICAL):\n` +
-              `- Use window.ethereum directly: new ethers.BrowserProvider(window.ethereum). The Remix IDE preview provides it automatically.\n` +
-              `- Do NOT use window.__qdapp_getProvider(). Do NOT call wallet_switchEthereumChain or wallet_addEthereumChain.\n` +
-              `- Do NOT show "Install MetaMask", "Wrong Network" warnings, or chain ID checks. The provider is always available and on the correct network.\n` +
-              `- Simply connect: const provider = new ethers.BrowserProvider(window.ethereum); await provider.send("eth_requestAccounts", []); const signer = await provider.getSigner();\n` +
-              `- MUST listen for window.ethereum accountsChanged and immediately update the visible connected account, signer, and contract instance when Deploy & Run account changes. Do not require a preview refresh.\n`
+            `- Use window.ethereum directly: new ethers.BrowserProvider(window.ethereum). The Remix IDE preview provides it automatically.\n` +
+            `- Do NOT use window.__qdapp_getProvider(). Do NOT call wallet_switchEthereumChain or wallet_addEthereumChain.\n` +
+            `- Do NOT show "Install MetaMask", "Wrong Network" warnings, or chain ID checks. The provider is always available and on the correct network.\n` +
+            `- Simply connect: const provider = new ethers.BrowserProvider(window.ethereum); await provider.send("eth_requestAccounts", []); const signer = await provider.getSigner();\n` +
+            `- MUST listen for window.ethereum accountsChanged and immediately update the visible connected account, signer, and contract instance when Deploy & Run account changes. Do not require a preview refresh.\n`
             : `\nREAL NETWORK WALLET RULES (CRITICAL - use EXACT values below):\n` +
-              `- The contract is deployed on chain ${args.chainId}. Set TARGET_CHAIN_ID = ${args.chainId} in the generated code.\n` +
-              `- For wallet_switchEthereumChain, use chainId: '0x${Number(args.chainId).toString(16)}'. Do NOT use '0x1' or any other chain.\n` +
-              `- Use window.__qdapp_getProvider ? await window.__qdapp_getProvider() : window.ethereum for wallet discovery (EIP-6963).\n` +
-              `- Store raw provider in a React ref for reuse in network switching.\n` +
-              `- Show Connect Wallet / Disconnect / Switch Network buttons. Compare chain IDs as decimal numbers (not hex).\n`) +
+            `- The contract is deployed on chain ${args.chainId}. Set TARGET_CHAIN_ID = ${args.chainId} in the generated code.\n` +
+            `- For wallet_switchEthereumChain, use chainId: '0x${Number(args.chainId).toString(16)}'. Do NOT use '0x1' or any other chain.\n` +
+            `- Use window.__qdapp_getProvider ? await window.__qdapp_getProvider() : window.ethereum for wallet discovery (EIP-6963).\n` +
+            `- Store raw provider in a React ref for reuse in network switching.\n` +
+            `- Show Connect Wallet / Disconnect / Switch Network buttons. Compare chain IDs as decimal numbers (not hex).\n`) +
           `3. After ALL files written, call finalize_dapp_generation with workspaceName="${workspaceSlug}" and contractAddress="${args.contractAddress}"\n` +
-          `---\n\n` +
-          `Do NOT attempt to write files directly -- let the subagent handle it.`
+          `---`
       })
 
     } catch (error: any) {
@@ -490,8 +487,6 @@ export class UpdateDAppHandler extends BaseToolHandler {
       plugin.emit('dappUpdateStart', { slug: targetWorkspace })
       plugin.emit('generationProgress', { status: 'preparing', contractAddress: contractResolved.address, slug: targetWorkspace })
 
-      console.log(`[UpdateDApp] Workspace validated. Delegating to subagent. slug=${targetWorkspace}`)
-
       // Build a concise file list (names only — no content in the main agent's context).
       // The subagent will read file contents in its own isolated context via file_read,
       // avoiding the context accumulation that causes "request entity too large" errors.
@@ -506,8 +501,7 @@ export class UpdateDAppHandler extends BaseToolHandler {
         contractAddress: contractResolved.address,
         workspaceReady: true,
         message: `DApp workspace "${targetWorkspace}" is ready for update.\n\n` +
-          `**IMPORTANT: You MUST delegate this update to a QuickDapp Specialist subagent using the task tool.**\n\n` +
-          `Use the task tool with subagent_type "QuickDapp Specialist" and provide the following context in the task prompt:\n\n` +
+          `Now proceed to update the DApp files directly.\n\n` +
           `---\n` +
           `TASK: Modify the DApp in workspace "${targetWorkspace}"\n` +
           `USER REQUEST: ${description}\n` +
@@ -527,19 +521,18 @@ export class UpdateDAppHandler extends BaseToolHandler {
           `2. Modify only the relevant files using file_write\n` +
           (isLocalVM
             ? `\nREMIX VM RULES (LOCAL DEV MODE - CRITICAL):\n` +
-              `- Use window.ethereum directly: new ethers.BrowserProvider(window.ethereum). The Remix IDE preview provides it automatically.\n` +
-              `- Do NOT use window.__qdapp_getProvider(). Do NOT call wallet_switchEthereumChain or wallet_addEthereumChain.\n` +
-              `- Do NOT show "Install MetaMask", "Wrong Network" warnings, or chain ID checks.\n` +
-              `- MUST listen for window.ethereum accountsChanged and immediately update the visible connected account, signer, and contract instance when Deploy & Run account changes. Do not require a preview refresh.\n`
+            `- Use window.ethereum directly: new ethers.BrowserProvider(window.ethereum). The Remix IDE preview provides it automatically.\n` +
+            `- Do NOT use window.__qdapp_getProvider(). Do NOT call wallet_switchEthereumChain or wallet_addEthereumChain.\n` +
+            `- Do NOT show "Install MetaMask", "Wrong Network" warnings, or chain ID checks.\n` +
+            `- MUST listen for window.ethereum accountsChanged and immediately update the visible connected account, signer, and contract instance when Deploy & Run account changes. Do not require a preview refresh.\n`
             : `\nREAL NETWORK WALLET RULES (CRITICAL - use EXACT values below):\n` +
-              `- The contract is deployed on chain ${contractResolved.chainId}. Set TARGET_CHAIN_ID = ${contractResolved.chainId} in the generated code.\n` +
-              `- For wallet_switchEthereumChain, use chainId: '0x${Number(contractResolved.chainId).toString(16)}'. Do NOT use '0x1' or any other chain.\n` +
-              `- Use window.__qdapp_getProvider ? await window.__qdapp_getProvider() : window.ethereum for wallet discovery (EIP-6963).\n` +
-              `- Store raw provider in a React ref for reuse in network switching.\n` +
-              `- Show Connect Wallet / Disconnect / Switch Network buttons. Compare chain IDs as decimal numbers (not hex).\n`) +
+            `- The contract is deployed on chain ${contractResolved.chainId}. Set TARGET_CHAIN_ID = ${contractResolved.chainId} in the generated code.\n` +
+            `- For wallet_switchEthereumChain, use chainId: '0x${Number(contractResolved.chainId).toString(16)}'. Do NOT use '0x1' or any other chain.\n` +
+            `- Use window.__qdapp_getProvider ? await window.__qdapp_getProvider() : window.ethereum for wallet discovery (EIP-6963).\n` +
+            `- Store raw provider in a React ref for reuse in network switching.\n` +
+            `- Show Connect Wallet / Disconnect / Switch Network buttons. Compare chain IDs as decimal numbers (not hex).\n`) +
           `3. Call finalize_dapp_generation with workspaceName="${targetWorkspace}", contractAddress="${contractResolved.address}", isUpdate=true\n` +
-          `---\n\n` +
-          `Do NOT attempt to read or write files directly — let the subagent handle it.`
+          `---`
       })
 
     } catch (error: any) {

--- a/libs/remix-ui/quick-dapp-v2/src/lib/components/DeployPanel/index.tsx
+++ b/libs/remix-ui/quick-dapp-v2/src/lib/components/DeployPanel/index.tsx
@@ -21,6 +21,7 @@ function DeployPanel(): JSX.Element {
   const { appState, dispatch, dappManager, plugin } = useContext(AppContext);
   const { activeDapp } = appState;
   const { title, details, logo } = appState.instance;
+  const isVM = !!activeDapp?.contract?.chainId && activeDapp.contract.chainId.toString().startsWith('vm');
 
   const [deployResult, setDeployResult] = useState({
     cid: activeDapp?.deployment?.ipfsCid || '',
@@ -322,9 +323,15 @@ function DeployPanel(): JSX.Element {
         </Card.Header>
         <Collapse in={isPublishOpen}>
           <Card.Body>
-            <Button variant="primary" className="w-100" onClick={() => handleIpfsDeploy()} disabled={isDeploying} data-id="deploy-ipfs-btn">
+            <Button variant="primary" className="w-100" onClick={() => handleIpfsDeploy()} disabled={isDeploying || isVM} data-id="deploy-ipfs-btn">
               {isDeploying ? <><i className="fas fa-spinner fa-spin me-1"></i> Uploading...</> : <FormattedMessage id="quickDapp.deployToIPFS" defaultMessage="Deploy to IPFS" />}
             </Button>
+            {isVM && (
+              <Alert variant="warning" className="mt-2 small mb-0">
+                <i className="fas fa-exclamation-triangle me-1"></i>
+                IPFS deployment is not available for Remix VM contracts. Deploy your contract to a public network first.
+              </Alert>
+            )}
             {displayCid && (
               <Alert variant="success" className="mt-3" style={{ wordBreak: 'break-all' }} data-id="deploy-ipfs-success">
                 <div className="fw-bold">Deployed Successfully!</div>
@@ -340,7 +347,7 @@ function DeployPanel(): JSX.Element {
       {displayCid && (
         <Card className="mb-2">
           <Card.Header onClick={() => setIsEnsOpen(!isEnsOpen)} style={{ cursor: 'pointer' }} className="d-flex justify-content-between bg-transparent border-0" data-id="ens-section-header">
-            Register ENS (Arbitrum) <i className={`fas ${isEnsOpen ? 'fa-chevron-up' : 'fa-chevron-down'}`}></i>
+            Register ENS Name <i className={`fas ${isEnsOpen ? 'fa-chevron-up' : 'fa-chevron-down'}`}></i>
           </Card.Header>
           <Collapse in={isEnsOpen}>
             <Card.Body>

--- a/libs/remix-ui/quick-dapp-v2/src/lib/components/EditHtmlTemplate/index.tsx
+++ b/libs/remix-ui/quick-dapp-v2/src/lib/components/EditHtmlTemplate/index.tsx
@@ -325,18 +325,38 @@ window.addEventListener('unhandledrejection', function(e) {
 (function() {
   if (parent.__remixVMBridge) {
     var _listeners = {};
+    function emit(event, payload) {
+      (_listeners[event] || []).slice().forEach(function(cb) {
+        try { cb(payload); } catch (e) { setTimeout(function() { throw e; }, 0); }
+      });
+    }
+    function setAccounts(accounts, emitChange) {
+      window.ethereum.selectedAddress = accounts && accounts[0] ? accounts[0] : null;
+      if (emitChange) {
+        emit('accountsChanged', accounts || []);
+      }
+      return accounts;
+    }
+    function syncSelectedAddress(method, result) {
+      if (method === 'eth_accounts' || method === 'eth_requestAccounts') {
+        return setAccounts(result, false);
+      }
+      return result;
+    }
     window.ethereum = {
       isMetaMask: false,
       isRemixVM: true,
       _events: {},
       request: function(args) {
-        return parent.__remixVMBridge.request(args);
+        return parent.__remixVMBridge.request(args).then(function(result) {
+          return syncSelectedAddress(args && args.method, result);
+        });
       },
       send: function(method, params) {
-        if (typeof method === 'object') {
-          return parent.__remixVMBridge.request(method);
-        }
-        return parent.__remixVMBridge.request({ method: method, params: params || [] });
+        var requestArgs = typeof method === 'object' ? method : { method: method, params: params || [] };
+        return parent.__remixVMBridge.request(requestArgs).then(function(result) {
+          return syncSelectedAddress(requestArgs && requestArgs.method, result);
+        });
       },
       on: function(event, cb) {
         if (!_listeners[event]) _listeners[event] = [];
@@ -353,6 +373,9 @@ window.addEventListener('unhandledrejection', function(e) {
     };
     window.ethereum.chainId = '0x539';
     window.ethereum.selectedAddress = null;
+    window.__remixVMUpdateAccounts = function(accounts) {
+      return setAccounts(accounts, true);
+    };
   } else if (parent.window && parent.window.ethereum) {
     window.ethereum = parent.window.ethereum;
   }
@@ -583,6 +606,24 @@ window.addEventListener('unhandledrejection', function(e) {
       return;
     }
 
+    const getSelectedVMAccount = async (): Promise<string | null> => {
+      const selected = await plugin.call('udappEnv', 'getSelectedAccount').catch(() => null);
+      return typeof selected === 'string' ? selected : null;
+    };
+
+    const orderAccountsBySelected = (accounts: string[], selected: string | null) => {
+      if (!selected) return accounts;
+      const selectedLower = selected.toLowerCase();
+      const match = accounts.find((account) => account.toLowerCase() === selectedLower);
+      if (!match) return accounts;
+      return [match, ...accounts.filter((account) => account.toLowerCase() !== selectedLower)];
+    };
+
+    const getOrderedVMAccounts = async (web3: any, method = 'eth_accounts', params: any[] = []) => {
+      const accounts: string[] = await web3.send(method, params);
+      return orderAccountsBySelected(accounts, await getSelectedVMAccount());
+    };
+
     const bridge = {
       request: async ({ method, params }: { method: string; params?: any[] }) => {
         if (method === 'wallet_switchEthereumChain' || method === 'wallet_addEthereumChain') {
@@ -595,7 +636,21 @@ window.addEventListener('unhandledrejection', function(e) {
           throw new Error('VM not ready');
         }
         try {
-          const result = await web3.send(method, params || []);
+          if (method === 'eth_accounts' || method === 'eth_requestAccounts') {
+            const accounts = await getOrderedVMAccounts(web3, method, params || []);
+            if (!isMounted) return;
+            return accounts;
+          }
+
+          const nextParams = Array.isArray(params) ? [...params] : [];
+          if ((method === 'eth_sendTransaction' || method === 'eth_call') && nextParams[0] && !nextParams[0].from) {
+            const selected = await getSelectedVMAccount();
+            if (selected) {
+              nextParams[0] = { ...nextParams[0], from: selected };
+            }
+          }
+
+          const result = await web3.send(method, nextParams);
           if (!isMounted) return;
           if (method === 'eth_sendTransaction') {
             // dumpState is non-critical, fire-and-forget
@@ -612,8 +667,58 @@ window.addEventListener('unhandledrejection', function(e) {
 
     (window as any).__remixVMBridge = bridge;
 
+    let selectedAccount: string | null = null;
+    let isCheckingAccount = false;
+    let pendingAccountsChanged: string[] | null = null;
+
+    const emitIframeAccountsChanged = (accounts: string[]) => {
+      const updateAccounts = (iframeRef.current?.contentWindow as any)?.__remixVMUpdateAccounts;
+      if (typeof updateAccounts === 'function') {
+        updateAccounts(accounts);
+        pendingAccountsChanged = null;
+        return;
+      }
+      pendingAccountsChanged = accounts;
+    };
+
+    const checkSelectedAccount = async () => {
+      if (!isMounted || isCheckingAccount) return;
+      isCheckingAccount = true;
+      try {
+        if (pendingAccountsChanged) {
+          emitIframeAccountsChanged(pendingAccountsChanged);
+        }
+
+        const nextSelectedAccount = await getSelectedVMAccount();
+        if (!nextSelectedAccount) return;
+
+        if (selectedAccount === null) {
+          selectedAccount = nextSelectedAccount;
+          return;
+        }
+
+        if (selectedAccount.toLowerCase() === nextSelectedAccount.toLowerCase()) return;
+
+        const web3 = (window as any).__remixVM_web3;
+        if (!web3) return;
+
+        selectedAccount = nextSelectedAccount;
+        const accounts = await getOrderedVMAccounts(web3);
+        if (!isMounted) return;
+        emitIframeAccountsChanged(accounts);
+      } catch (e) {
+        // Account-change propagation is best-effort; RPC calls still read the latest selected account.
+      } finally {
+        isCheckingAccount = false;
+      }
+    };
+
+    checkSelectedAccount();
+    const accountCheckInterval = window.setInterval(checkSelectedAccount, 1000);
+
     return () => {
       isMounted = false;
+      window.clearInterval(accountCheckInterval);
       delete (window as any).__remixVMBridge;
     };
   }, [isVM, isCurrentProviderVM, plugin]);

--- a/libs/remix-ui/quick-dapp-v2/src/lib/quick-dapp-v2.tsx
+++ b/libs/remix-ui/quick-dapp-v2/src/lib/quick-dapp-v2.tsx
@@ -31,7 +31,7 @@ export function RemixUiQuickDappV2({ plugin }: RemixUiQuickDappV2Props): JSX.Ele
   const activeDappRef = useRef(appState.activeDapp);
 
   // Permission gating
-  const hasAccess = features?.['dapp:quickdapp']
+  const hasAccess = features?.['dapp:quickdapp']?.is_enabled
   const quickdappEnabled = remixAppContext?.appConfig?.['quickdapp.enabled']
   const quickdappEnabledRef = useRef(quickdappEnabled)
   quickdappEnabledRef.current = quickdappEnabled

--- a/libs/remix-ui/run-tab-deployed-contracts/src/lib/components/DeployedContractItem.tsx
+++ b/libs/remix-ui/run-tab-deployed-contracts/src/lib/components/DeployedContractItem.tsx
@@ -14,6 +14,7 @@ import { ContractKebabMenu } from './ContractKebabMenu'
 import { TreeView, TreeViewItem } from '@remix-ui/tree-view'
 import BN from 'bn.js'
 import { TrackingContext } from '@remix-ide/tracking'
+import { useAuth } from '@remix-ui/app'
 
 const txHelper = remixLib.execution.txHelper
 const txFormat = remixLib.execution.txFormat
@@ -31,6 +32,8 @@ export function DeployedContractItem({ contract, index, registerRef, isKebabMenu
   const { dispatch, plugin, themeQuality } = useContext(DeployedContractsAppContext)
   const { trackMatomoEvent } = useContext(TrackingContext)
   const intl = useIntl()
+  const { features } = useAuth()
+  const hasQuickdappAccess = features?.['dapp:quickdapp']?.is_enabled
   const [networkName, setNetworkName] = useState<string>('')
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
   const [contractABI, setContractABI] = useState(null)
@@ -378,6 +381,13 @@ export function DeployedContractItem({ contract, index, registerRef, isKebabMenu
     }
 
     try {
+      // Permission gate: non-beta users see the QuickDapp lock screen
+      if (!hasQuickdappAccess) {
+        await plugin.call('manager', 'activatePlugin', 'quick-dapp-v2')
+        await plugin.call('tabs' as any, 'focus', 'quick-dapp-v2')
+        return
+      }
+
       console.log('[QuickDapp] handleCreateDapp START', { name: contract.name, address: contract.address, timestamp: Date.now() });
 
       // Send contract details to AI Assistant for DApp generation

--- a/libs/remix-ui/tabs/src/lib/remix-ui-tabs.tsx
+++ b/libs/remix-ui/tabs/src/lib/remix-ui-tabs.tsx
@@ -618,6 +618,16 @@ export const TabsUI = (props: TabsUIProps) => {
   }
 
   const handleQuickDappStartNow = async () => {
+    // Permission gate: non-beta users see the QuickDapp lock screen
+    const quickdappFeature = features?.['dapp:quickdapp']
+    if (!quickdappFeature?.is_enabled) {
+      try {
+        await props.plugin.call('manager', 'activatePlugin', 'quick-dapp-v2')
+        await props.plugin.call('tabs' as any, 'focus', 'quick-dapp-v2')
+      } catch (e) { /* best-effort */ }
+      return
+    }
+
     const currentFile = tabsState.name
     const currentFileName = currentFile?.split('/').pop() || ''
 
@@ -758,8 +768,6 @@ export const TabsUI = (props: TabsUIProps) => {
     if (tabsState.currentExt !== 'sol' || !bannerVisible) return false
     const quickdappEnabled = appContext?.appConfig?.['quickdapp.enabled']
     if (quickdappEnabled === false) return false
-    const quickdappFeature = features?.['dapp:quickdapp']
-    if (!quickdappFeature?.is_enabled) return false
     return true
   })()
 


### PR DESCRIPTION
- [x] Rename tab display name from "Quick Dapp V2" to "QuickDApp"
- [x] Remove "(Arbitrum)" from ENS registration section header
- [x] Disable "Deploy to IPFS" button when contract is on Remix VM (issue #7179)
- [x] Change QuickDApp nudge trigger from `contract:compiled` to `contract:deployed`
- [x] Fix VM bridge to reorder accounts based on Deploy & Run selected account (issue #7115, #7182)
- [x] Move all QuickDApp orchestration tools (list_dapps, generate_dapp, update_dapp) into QuickDApp Specialist subagent
- [x] Gate QuickDApp access behind `dapp:quickdapp` permission across all entry points