### PR TITLE
refactor(quickdapp): replace workspace-per-dapp with folder-based model

### DIFF
--- a/apps/remix-ide/src/app/plugins/quick-dapp-v2.tsx
+++ b/apps/remix-ide/src/app/plugins/quick-dapp-v2.tsx
@@ -5,6 +5,7 @@ import { PluginViewWrapper } from '@remix-ui/helper'
 import { RemixUiQuickDappV2, getNetworkName } from '@remix-ui/quick-dapp-v2'
 import { EventEmitter } from 'events'
 import { remixAILogger } from '@remix/remix-ai-core'
+import { DappAppConfig } from '@remix-ui/quick-dapp-v2'
 
 const profile = {
   name: 'quick-dapp-v2',
@@ -18,12 +19,12 @@ const profile = {
   maintainedBy: 'Remix',
   permission: true,
   events: [],
-  methods: ['edit', 'clearInstance', 'startAiLoading', 'createDapp', 'createDappWorkspace', 'openDapp', 'consumePendingCreateDapp', 'listDapps']
+  methods: ['edit', 'clearInstance', 'startAiLoading', 'createDapp', 'createDappWorkspace', 'createDappApp', 'openDapp', 'consumePendingCreateDapp', 'listDapps', 'listDappApps']
 }
 
 export class QuickDappV2 extends ViewPlugin {
   element: HTMLDivElement
-  dispatch: React.Dispatch<any> = () => {}
+  dispatch: React.Dispatch<any> = () => { }
   event: any
   private listenersRegistered: boolean = false
   private pendingCreateDapp: any = null
@@ -178,7 +179,7 @@ export class QuickDappV2 extends ViewPlugin {
       let resolved: string | null = null;
       try {
         resolved = await this.call('blockchain' as any, 'getProvider');
-      } catch (_) {}
+      } catch (_) { }
       remixAILogger.warn(`[QuickDapp] chainId invalid ("${payload.chainId}"), resolved from provider: "${resolved}"`);
       payload.chainId = resolved || 'vm-osaka';
     }
@@ -216,9 +217,9 @@ export class QuickDappV2 extends ViewPlugin {
 
       // Pin contract in source workspace
       const pinPath = `.deploys/pinned-contracts/${payload.chainId}/${payload.address}.json`;
-      try { await this.call('fileManager', 'mkdir', '.deploys'); } catch (_) {}
-      try { await this.call('fileManager', 'mkdir', '.deploys/pinned-contracts'); } catch (_) {}
-      try { await this.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${payload.chainId}`); } catch (_) {}
+      try { await this.call('fileManager', 'mkdir', '.deploys'); } catch (_) { }
+      try { await this.call('fileManager', 'mkdir', '.deploys/pinned-contracts'); } catch (_) { }
+      try { await this.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${payload.chainId}`); } catch (_) { }
       await this.call('fileManager', 'writeFile', pinPath, JSON.stringify(pinnedData, null, 2));
       remixAILogger.log('[QuickDapp] Contract pinned in source workspace:', pinPath);
 
@@ -231,7 +232,7 @@ export class QuickDappV2 extends ViewPlugin {
         chainId: payload.chainId,
         createdAt: timestamp
       };
-      try { await this.call('fileManager', 'mkdir', '.deploys/dapp-mappings'); } catch (_) {}
+      try { await this.call('fileManager', 'mkdir', '.deploys/dapp-mappings'); } catch (_) { }
       await this.call('fileManager', 'writeFile', dappMappingPath, JSON.stringify(dappMapping, null, 2));
       remixAILogger.log('[QuickDapp] Dapp mapping saved:', dappMappingPath);
     } catch (e) {
@@ -246,7 +247,7 @@ export class QuickDappV2 extends ViewPlugin {
     let actualProvider: string | null = null;
     try {
       actualProvider = await this.call('blockchain' as any, 'getProvider');
-    } catch (_) {}
+    } catch (_) { }
     if (vmProviderName) {
       try {
         try {
@@ -254,7 +255,7 @@ export class QuickDappV2 extends ViewPlugin {
             this.call('blockchain' as any, 'dumpState'),
             new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 2000))
           ]);
-        } catch (_) {}
+        } catch (_) { }
         await new Promise(r => setTimeout(r, 100));
         const statePath = `.states/${vmProviderName}/state.json`;
         const stateExists = await this.call('fileManager', 'exists', statePath);
@@ -295,7 +296,7 @@ export class QuickDappV2 extends ViewPlugin {
         name: payload.contractName,
         abi: payload.abi,
         chainId: payload.chainId,
-        networkName: payload.networkName || getNetworkName(payload.chainId)|| 'Unknown Network'
+        networkName: payload.networkName || getNetworkName(payload.chainId) || 'Unknown Network'
       },
       sourceWorkspace: {
         name: sourceWorkspaceName,
@@ -313,12 +314,12 @@ export class QuickDappV2 extends ViewPlugin {
     };
 
     await this.call('fileManager', 'writeFile', 'dapp.config.json', JSON.stringify(initialConfig, null, 2));
-    try { await this.call('fileManager', 'mkdir', 'src'); } catch (_) {}
+    try { await this.call('fileManager', 'mkdir', 'src'); } catch (_) { }
 
     if (vmStateSnapshot && vmProviderName) {
       try {
-        try { await this.call('fileManager', 'mkdir', '.states'); } catch (_) {}
-        try { await this.call('fileManager', 'mkdir', `.states/${vmProviderName}`); } catch (_) {}
+        try { await this.call('fileManager', 'mkdir', '.states'); } catch (_) { }
+        try { await this.call('fileManager', 'mkdir', `.states/${vmProviderName}`); } catch (_) { }
         await this.call('fileManager', 'writeFile', `.states/${vmProviderName}/state.json`, vmStateSnapshot);
 
         // Explicitly reload VM state into memory.
@@ -335,9 +336,9 @@ export class QuickDappV2 extends ViewPlugin {
     // Pin contract in dapp workspace
     try {
       const pinnedPath = `.deploys/pinned-contracts/${payload.chainId}/${payload.address}.json`;
-      try { await this.call('fileManager', 'mkdir', '.deploys'); } catch (_) {}
-      try { await this.call('fileManager', 'mkdir', '.deploys/pinned-contracts'); } catch (_) {}
-      try { await this.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${payload.chainId}`); } catch (_) {}
+      try { await this.call('fileManager', 'mkdir', '.deploys'); } catch (_) { }
+      try { await this.call('fileManager', 'mkdir', '.deploys/pinned-contracts'); } catch (_) { }
+      try { await this.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${payload.chainId}`); } catch (_) { }
       const pinnedData = {
         name: payload.contractName,
         address: payload.address,
@@ -437,6 +438,132 @@ export class QuickDappV2 extends ViewPlugin {
     } catch (e) {
       remixAILogger.error('[QuickDapp] listDapps failed:', e)
       return []
+    }
+  }
+
+  // ──────────────────────────────────────────────
+  // New folder-based DApp methods
+  // DApp lives inside current workspace as apps/<slug>/
+  // No workspace switching required.
+  // ──────────────────────────────────────────────
+
+  /**
+   * Create a DApp as a subfolder inside the current workspace.
+   * No new workspace is created; no workspace switching occurs.
+   * Metadata is stored in .quickdapp/apps/<slug>.json.
+   */
+  async createDappApp(payload: {
+    contractName: string;
+    address: string;
+    abi: any[];
+    chainId: string | number;
+    networkName?: string;
+    sourceFilePath?: string;
+    isBaseMiniApp?: boolean;
+  }): Promise<{ appId: string; frontendDir: string }> {
+    // ── Payload validation ──
+    if (!payload.address || typeof payload.address !== 'string' || !payload.address.startsWith('0x')) {
+      throw new Error(`createDappApp: Invalid contract address: ${payload.address}`);
+    }
+    if (!Array.isArray(payload.abi) || payload.abi.length === 0) {
+      throw new Error(`createDappApp: ABI must be a non-empty array`);
+    }
+    if (!payload.chainId || payload.chainId === '-' || String(payload.chainId) === 'undefined') {
+      let resolved: string | null = null;
+      try {
+        resolved = await this.call('blockchain' as any, 'getProvider');
+      } catch (_) { }
+      remixAILogger.warn(`[QuickDapp] chainId invalid ("${payload.chainId}"), resolved from provider: "${resolved}"`);
+      payload.chainId = resolved || 'vm-osaka';
+    }
+
+    const name = payload.contractName || 'Untitled';
+    const id = Date.now().toString(36) + Math.random().toString(36).substring(2, 8);
+    const slug = `${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${id.slice(0, 6)}`;
+    const frontendDir = `apps/${slug}`;
+    const timestamp = Date.now();
+    const networkName = payload.networkName || getNetworkName(payload.chainId) || 'Unknown Network';
+
+    // Create folder structure — no workspace creation or switching!
+    const dirsToCreate = [
+      'apps',
+      frontendDir,
+      `${frontendDir}/src`,
+      '.quickdapp',
+      '.quickdapp/apps',
+      '.quickdapp/previews',
+    ];
+    for (const dir of dirsToCreate) {
+      try { await this.call('fileManager', 'mkdir', dir); } catch (_) { }
+    }
+
+    const appConfig: DappAppConfig = {
+      id,
+      name,
+      frontendDir,
+      status: 'creating',
+      processingStartedAt: timestamp,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      contracts: [{
+        id: name.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+        name: payload.contractName,
+        sourceFilePath: payload.sourceFilePath || '',
+        abi: payload.abi,
+        deployments: [{
+          address: payload.address,
+          chainId: payload.chainId,
+          networkName,
+          deployedAt: timestamp,
+        }],
+        activeDeploymentIndex: 0,
+      }],
+      config: {
+        title: name,
+        details: 'Generated by AI',
+        isBaseMiniApp: payload.isBaseMiniApp || false,
+      },
+    };
+
+    await this.call(
+      'fileManager', 'writeFile',
+      `.quickdapp/apps/${slug}.json`,
+      JSON.stringify(appConfig, null, 2)
+    );
+
+    remixAILogger.log('[QuickDapp] createDappApp done (folder-based)', { appId: slug, frontendDir });
+    return { appId: slug, frontendDir };
+  }
+
+  /**
+   * List all folder-based DApps in the current workspace.
+   * Reads .quickdapp/apps/*.json — no workspace scanning needed.
+   */
+  async listDappApps(): Promise<DappAppConfig[]> {
+    remixAILogger.log('[QuickDapp] listDappApps called')
+    try {
+      const metaDir = '.quickdapp/apps';
+      const exists = await this.call('fileManager', 'exists', metaDir);
+      if (!exists) return [];
+
+      const files = await this.call('fileManager', 'readdir', metaDir);
+      const configs: DappAppConfig[] = [];
+
+      for (const filePath of Object.keys(files || {})) {
+        if (!filePath.endsWith('.json')) continue;
+        try {
+          const content = await this.call('fileManager', 'readFile', filePath);
+          if (content) configs.push(JSON.parse(content));
+        } catch (e) {
+          remixAILogger.warn('[QuickDapp] Failed to read app config:', filePath, e);
+        }
+      }
+
+      remixAILogger.log('[QuickDapp] listDappApps returned', configs.length, 'apps');
+      return configs.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+    } catch (e) {
+      remixAILogger.error('[QuickDapp] listDappApps failed:', e);
+      return [];
     }
   }
 

--- a/libs/remix-ui/quick-dapp-v2/src/lib/types.ts
+++ b/libs/remix-ui/quick-dapp-v2/src/lib/types.ts
@@ -42,12 +42,14 @@ export interface DappConfig {
   thumbnailPath?: string;
 }
 
+export { DappAppConfig, DappContractBinding, DappContractDeployment } from './types/dapp';
+
 export interface AppState {
   loading: { screen: boolean };
   isAiLoading: boolean;
   view: 'loading' | 'dashboard' | 'editor' | 'create';
-  dapps: DappConfig[];
-  activeDapp: DappConfig | null;
+  dapps: (DappConfig | any)[];
+  activeDapp: (DappConfig | any) | null;
   instance: any;
   dappProcessing: Record<string, boolean>;
   generationProgress: GenerationProgress | null;

--- a/libs/remix-ui/quick-dapp-v2/src/lib/types/dapp.ts
+++ b/libs/remix-ui/quick-dapp-v2/src/lib/types/dapp.ts
@@ -41,3 +41,55 @@ export interface DappConfig {
 
   thumbnailPath?: string;
 }
+
+// ──────────────────────────────────────────────
+// New folder-based DApp model
+// DApp lives inside the current workspace as a subfolder (apps/<slug>/),
+// with metadata stored in .quickdapp/apps/<slug>.json.
+// No workspace switching required.
+// ──────────────────────────────────────────────
+
+export interface DappAppConfig {
+  id: string;
+  name: string;
+  /** Relative path from workspace root to DApp frontend folder, e.g. "apps/mytoken-dapp" */
+  frontendDir: string;
+  status: DappStatus;
+  processingStartedAt?: number | null;
+  createdAt: number;
+  updatedAt: number;
+
+  /** Array of contracts bound to this DApp. Can be empty for frontend-first. */
+  contracts: DappContractBinding[];
+
+  deployment?: {
+    ipfsCid?: string | null;
+    gatewayUrl?: string | null;
+    ensDomain?: string | null;
+  };
+
+  config: {
+    title?: string;
+    details?: string;
+    logo?: string;
+    isBaseMiniApp?: boolean;
+  };
+}
+
+export interface DappContractBinding {
+  /** Unique identifier for this binding, e.g. "mytoken" */
+  id: string;
+  name: string;
+  /** Path to Solidity source relative to workspace root, e.g. "contracts/MyToken.sol" */
+  sourceFilePath: string;
+  abi: any[];
+  deployments: DappContractDeployment[];
+  activeDeploymentIndex: number;
+}
+
+export interface DappContractDeployment {
+  address: string;
+  chainId: string | number;
+  networkName: string;
+  deployedAt: number;
+}

--- a/libs/remix-ui/quick-dapp-v2/src/lib/utils/DappManager.ts
+++ b/libs/remix-ui/quick-dapp-v2/src/lib/utils/DappManager.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { PluginClient } from '@remixproject/plugin';
-import { DappConfig } from '../types/dapp';
+import { DappConfig, DappAppConfig } from '../types/dapp';
 
 const DAPP_WORKSPACE_PREFIX = 'dapp-';
 const CONFIG_FILENAME = 'dapp.config.json';
@@ -202,7 +202,7 @@ export class DappManager {
                   config.thumbnailPath = previewContent;
                 }
               }
-            } catch (e) {}
+            } catch (e) { }
 
             configs.push(this.sanitizeConfig(config));
 
@@ -387,9 +387,9 @@ export class DappManager {
     if (vmStateSnapshot && vmProviderName) {
       const foldersToWrite = [vmProviderName];
       try {
-        try { await this.plugin.call('fileManager', 'mkdir', '.states'); } catch (_) {}
+        try { await this.plugin.call('fileManager', 'mkdir', '.states'); } catch (_) { }
         for (const folder of foldersToWrite) {
-          try { await this.plugin.call('fileManager', 'mkdir', `.states/${folder}`); } catch (_) {}
+          try { await this.plugin.call('fileManager', 'mkdir', `.states/${folder}`); } catch (_) { }
           await (this.plugin as any).call(
             'fileManager', 'writeFile',
             `.states/${folder}/state.json`,
@@ -416,9 +416,9 @@ export class DappManager {
       const pinnedChainId = contractData.chainId;
       const pinnedPath = `.deploys/pinned-contracts/${pinnedChainId}/${contractData.address}.json`;
 
-      try { await this.plugin.call('fileManager', 'mkdir', '.deploys'); } catch (_) {}
-      try { await this.plugin.call('fileManager', 'mkdir', '.deploys/pinned-contracts'); } catch (_) {}
-      try { await this.plugin.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${pinnedChainId}`); } catch (_) {}
+      try { await this.plugin.call('fileManager', 'mkdir', '.deploys'); } catch (_) { }
+      try { await this.plugin.call('fileManager', 'mkdir', '.deploys/pinned-contracts'); } catch (_) { }
+      try { await this.plugin.call('fileManager', 'mkdir', `.deploys/pinned-contracts/${pinnedChainId}`); } catch (_) { }
 
       await (this.plugin as any).call(
         'fileManager', 'writeFile',
@@ -571,7 +571,7 @@ export class DappManager {
           currentPath = currentPath ? `${currentPath}/${folder}` : folder;
           try {
             await this.plugin.call('fileManager', 'mkdir', currentPath);
-          } catch (e) {}
+          } catch (e) { }
         }
       }
 
@@ -611,14 +611,14 @@ export class DappManager {
     try {
       await this.switchToWorkspace(sourceWs);
     } catch (e) {
-      try { await this.switchToWorkspace('default_workspace'); } catch {}
+      try { await this.switchToWorkspace('default_workspace'); } catch { }
     }
 
     if (dappConfig?.sourceWorkspace?.name && dappConfig?.contract?.address) {
       const mappingPath = `.deploys/dapp-mappings/${dappConfig.contract.address}_${workspaceName}.json`;
       try {
         await (this.plugin as any).call('fileManager', 'remove', mappingPath);
-      } catch (e) {}
+      } catch (e) { }
     }
 
     await this.focusPlugin();
@@ -719,7 +719,7 @@ export class DappManager {
           if (previewContent) {
             config.thumbnailPath = previewContent;
           }
-        } catch (e) {}
+        } catch (e) { }
 
         if (currentWorkspace.name !== workspaceName) {
           await this.switchToWorkspace(currentWorkspace.name);
@@ -740,7 +740,7 @@ export class DappManager {
         try {
           await this.switchToWorkspace(currentWorkspace.name);
           await this.focusPlugin();
-        } catch (switchErr) {}
+        } catch (switchErr) { }
       }
     }
     return null;
@@ -797,7 +797,7 @@ export class DappManager {
         try {
           await this.switchToWorkspace(currentWorkspace.name);
           await this.focusPlugin();
-        } catch (switchErr) {}
+        } catch (switchErr) { }
       }
       return null;
     }
@@ -806,5 +806,163 @@ export class DappManager {
   async openDappWorkspace(workspaceName: string): Promise<void> {
     await this.switchToWorkspace(workspaceName);
     await this.focusPlugin();
+  }
+
+  // ──────────────────────────────────────────────
+  // New folder-based DApp methods
+  // All operate within the current workspace.
+  // No workspace switching required.
+  // ──────────────────────────────────────────────
+
+  private static readonly QUICKDAPP_META_DIR = '.quickdapp/apps';
+
+  /**
+   * List all folder-based DApps in the current workspace.
+   * Reads .quickdapp/apps/*.json — no workspace scanning, no switching.
+   */
+  async getDappApps(): Promise<DappAppConfig[]> {
+    try {
+      const metaDir = DappManager.QUICKDAPP_META_DIR;
+      const exists = await (this.plugin as any).call('fileManager', 'exists', metaDir);
+      if (!exists) return [];
+
+      const files = await this.plugin.call('fileManager', 'readdir', metaDir);
+      const configs: DappAppConfig[] = [];
+
+      for (const filePath of Object.keys(files || {})) {
+        if (!filePath.endsWith('.json')) continue;
+        try {
+          const content = await this.plugin.call('fileManager', 'readFile', filePath);
+          if (content) {
+            const config: DappAppConfig = JSON.parse(content);
+
+            // Load preview thumbnail if available
+            try {
+              const previewPath = `.quickdapp/previews/${config.id}.png`;
+              const previewExists = await (this.plugin as any).call('fileManager', 'exists', previewPath);
+              if (previewExists) {
+                const previewContent = await this.plugin.call('fileManager', 'readFile', previewPath);
+                if (previewContent) {
+                  (config as any).thumbnailPath = previewContent;
+                }
+              }
+            } catch (_) { }
+
+            configs.push(config);
+          }
+        } catch (e) {
+          console.warn('[DappManager] Failed to read app config:', filePath, e);
+        }
+      }
+
+      return configs.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+    } catch (e) {
+      console.error('[DappManager] getDappApps failed:', e);
+      return [];
+    }
+  }
+
+  /**
+   * Update a folder-based DApp's config.
+   * Reads and merges updates into .quickdapp/apps/<appId>.json.
+   * No workspace switching.
+   */
+  async updateDappAppConfig(appId: string, updates: Partial<DappAppConfig>): Promise<DappAppConfig | null> {
+    const configPath = `${DappManager.QUICKDAPP_META_DIR}/${appId}.json`;
+    try {
+      const content = await this.plugin.call('fileManager', 'readFile', configPath);
+      if (!content) throw new Error('Config file not found');
+
+      const current: DappAppConfig = JSON.parse(content);
+      const updated: DappAppConfig = {
+        ...current,
+        ...updates,
+        // Deep merge config and deployment
+        config: {
+          ...current.config,
+          ...(updates.config || {}),
+        },
+        deployment: {
+          ...current.deployment,
+          ...(updates.deployment || {}),
+        },
+        // Preserve contracts unless explicitly overridden
+        contracts: updates.contracts || current.contracts,
+        updatedAt: Date.now(),
+      };
+
+      const sanitized = this.sanitizeAppConfig(updated);
+      await (this.plugin as any).call(
+        'fileManager', 'writeFile',
+        configPath, JSON.stringify(sanitized, null, 2),
+        { silent: true }
+      );
+
+      return sanitized;
+    } catch (e) {
+      console.error('[DappManager] updateDappAppConfig failed:', e);
+      return null;
+    }
+  }
+
+  /**
+   * Delete a folder-based DApp.
+   * Removes both the frontend folder and the metadata file.
+   * No workspace deletion or switching.
+   */
+  async deleteDappApp(appId: string): Promise<void> {
+    const configPath = `${DappManager.QUICKDAPP_META_DIR}/${appId}.json`;
+    try {
+      // Read config to get frontendDir
+      const content = await this.plugin.call('fileManager', 'readFile', configPath);
+      if (content) {
+        const config: DappAppConfig = JSON.parse(content);
+
+        // Delete frontend folder
+        try {
+          await (this.plugin as any).call('fileManager', 'remove', config.frontendDir);
+        } catch (e) {
+          console.warn('[DappManager] deleteDappApp: failed to remove frontendDir:', config.frontendDir, e);
+        }
+      }
+
+      // Delete metadata
+      try {
+        await (this.plugin as any).call('fileManager', 'remove', configPath);
+      } catch (e) {
+        console.warn('[DappManager] deleteDappApp: failed to remove config:', configPath, e);
+      }
+
+      // Delete preview
+      try {
+        await (this.plugin as any).call('fileManager', 'remove', `.quickdapp/previews/${appId}.png`);
+      } catch (_) { }
+
+    } catch (e) {
+      console.error('[DappManager] deleteDappApp failed:', e);
+    }
+  }
+
+  /**
+   * Get a single folder-based DApp config by appId.
+   * No workspace switching.
+   */
+  async getDappAppConfig(appId: string): Promise<DappAppConfig | null> {
+    const configPath = `${DappManager.QUICKDAPP_META_DIR}/${appId}.json`;
+    try {
+      const content = await this.plugin.call('fileManager', 'readFile', configPath);
+      if (!content) return null;
+      return JSON.parse(content);
+    } catch (e) {
+      console.warn('[DappManager] getDappAppConfig failed for', appId, e);
+      return null;
+    }
+  }
+
+  private sanitizeAppConfig(config: DappAppConfig): DappAppConfig {
+    if (config.config && config.config.logo) {
+      config.config.logo = this.normalizeLogo(config.config.logo) as string | undefined;
+    }
+    return config;
   }
 }


### PR DESCRIPTION
Replace separate `dapp-*` workspaces with `apps/<slug>/` subfolders inside the current workspace. Eliminates all implicit workspace switching during DApp creation, preview, and editing.

Refs: #7116, #7165, #7207

### Phase 1: Data model + folder-based creation
- [x] `DappAppConfig` types with `contracts[]` array
- [x] `createDappApp()` / `listDappApps()` plugin methods
- [x] `DappManager` folder-based CRUD (no `switchToWorkspace`)

### Phase 2: UI + Preview
- [ ] Dashboard shows folder-based DApps
- [ ] `EditHtmlTemplate` builds from `apps/<slug>/`
- [ ] Remove workspace auto-switch from preview flow

### Phase 3: MCP tools + AI integration + legacy cleanup
- [ ] Update `generate_dapp` / `update_dapp` / `finalize` / `list` tools
- [ ] Switch feature flag default to new model
- [ ] Remove legacy workspace code

### Phase 4: Multi-contract + frontend-first
- [ ] Add/remove contract bindings UI
- [ ] Frontend-first DApp creation (empty `contracts[]`)