### PR TITLE
Gate AI model picker pills by permissions

### DIFF
--- a/libs/remix-ui/remix-ai-assistant/src/components/aiChatPromptArea.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/aiChatPromptArea.tsx
@@ -25,6 +25,12 @@ interface AiChatPromptAreaProps {
     autoModeAvailable: boolean
     handleModelSelection: (modelName: string) => void
     onLockedModelClick?: (modelId: string, modelName: string) => void
+    /** Permission-derived state of the per-model "Upgrade plan" pill. */
+    upgradePillState?: 'hidden' | 'coming_soon' | 'available'
+    /** Permission-derived state of the per-model "Buy credits" pill. */
+    buyCreditsPillState?: 'hidden' | 'coming_soon' | 'available'
+    /** Called when the user clicks the "Buy credits" pill on a locked model. */
+    onBuyCreditsClick?: (modelId: string, modelName: string) => void
     input: string
     setInput: React.Dispatch<React.SetStateAction<string>>
     isStreaming: boolean
@@ -83,6 +89,10 @@ export default function AiChatPromptArea(props: AiChatPromptAreaProps) {
     props.onLockedModelClick?.(item.stateValue, item.label)
   }
 
+  const handleBuyCreditsClick = (item: groupListType) => {
+    props.onBuyCreditsClick?.(item.stateValue, item.label)
+  }
+
   {/* Prompt area - fixed at bottom */}
   return (
     <section
@@ -104,6 +114,9 @@ export default function AiChatPromptArea(props: AiChatPromptAreaProps) {
             choice={props.autoModeEnabled ? 'auto' : props.selectedModelId}
             groupList={modelList}
             onLockedItemClick={handleLockedItemClick}
+            upgradePillState={props.upgradePillState}
+            buyCreditsPillState={props.buyCreditsPillState}
+            onBuyCreditsClick={props.onBuyCreditsClick ? handleBuyCreditsClick : undefined}
           />
           {false && props.mcpEnabled && (
             <div className="border-top mt-2 pt-2">

--- a/libs/remix-ui/remix-ai-assistant/src/components/aiChatPromptAreaForHistory.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/aiChatPromptAreaForHistory.tsx
@@ -25,6 +25,12 @@ interface AiChatPromptAreaForHistoryProps {
       autoModeAvailable: boolean
       handleModelSelection: (modelName: string) => void
       onLockedModelClick?: (modelId: string, modelName: string) => void
+      /** Permission-derived state of the per-model "Upgrade plan" pill. */
+      upgradePillState?: 'hidden' | 'coming_soon' | 'available'
+      /** Permission-derived state of the per-model "Buy credits" pill. */
+      buyCreditsPillState?: 'hidden' | 'coming_soon' | 'available'
+      /** Called when the user clicks the "Buy credits" pill on a locked model. */
+      onBuyCreditsClick?: (modelId: string, modelName: string) => void
       input: string
       setInput: React.Dispatch<React.SetStateAction<string>>
       isStreaming: boolean
@@ -83,6 +89,10 @@ export default function AiChatPromptAreaForHistory(props: AiChatPromptAreaForHis
     props.onLockedModelClick?.(item.stateValue, item.label)
   }
 
+  const handleBuyCreditsClick = (item: groupListType) => {
+    props.onBuyCreditsClick?.(item.stateValue, item.label)
+  }
+
   return (
     <section
       id="remix-ai-prompt-area"
@@ -102,6 +112,9 @@ export default function AiChatPromptAreaForHistory(props: AiChatPromptAreaForHis
             choice={props.autoModeEnabled ? 'auto' : props.selectedModelId}
             groupList={modelList}
             onLockedItemClick={handleLockedItemClick}
+            upgradePillState={props.upgradePillState}
+            buyCreditsPillState={props.buyCreditsPillState}
+            onBuyCreditsClick={props.onBuyCreditsClick ? handleBuyCreditsClick : undefined}
           />
           {false && props.mcpEnabled && (
             <div className="border-top mt-2 pt-2">

--- a/libs/remix-ui/remix-ai-assistant/src/components/contextOptMenu.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/contextOptMenu.tsx
@@ -1,53 +1,124 @@
 import React, { Dispatch } from 'react'
 import { AiAssistantType, AiContextType, groupListType } from '../types/componentTypes'
 
+/**
+ * Permission-gated visibility for the "Upgrade plan" / "Buy credits"
+ * pills next to a locked item.
+ *
+ *   - 'hidden'      => pill is not rendered.
+ *   - 'coming_soon' => pill is rendered as a compact non-interactive
+ *                     "Coming soon" affordance.
+ *   - 'available'   => pill is the normal clickable CTA.
+ *
+ * Computed by the parent from the backend permissions
+ * (`ai:upgrade_available`, `ai:buy_credits`, `ai:modes_coming_soon`) so
+ * this component stays presentational.
+ */
+export type LockedPillState = 'hidden' | 'coming_soon' | 'available'
+
 export interface GroupListMenuProps {
   setChoice: Dispatch<React.SetStateAction<AiContextType | AiAssistantType | any>>
   choice: AiContextType | AiAssistantType | any
   setShowOptions: Dispatch<React.SetStateAction<boolean>>
   groupList: groupListType[]
   onLockedItemClick?: (item: groupListType) => void
+  /** State of the "Upgrade plan" pill on locked items. Defaults to `'available'`
+   *  to preserve the pre-existing always-on behaviour for non-permission-aware callers. */
+  upgradePillState?: LockedPillState
+  /** State of the "Buy credits" pill on locked items. Defaults to `'hidden'`
+   *  since this pill is new and only relevant when the parent opts in. */
+  buyCreditsPillState?: LockedPillState
+  /** Click handler for the "Buy credits" pill. Falls back to `onLockedItemClick`. */
+  onBuyCreditsClick?: (item: groupListType) => void
 }
 
 export default function GroupListMenu(props: GroupListMenuProps) {
+  const upgradeState: LockedPillState = props.upgradePillState ?? 'available'
+  const buyCreditsState: LockedPillState = props.buyCreditsPillState ?? 'hidden'
+  const hasVisibleLockedPill = upgradeState !== 'hidden' || buyCreditsState !== 'hidden'
+  const visibleItems = props.groupList.filter(item => !item.isLocked || hasVisibleLockedPill)
+
+  const renderPill = (
+    item: groupListType,
+    kind: 'upgrade' | 'buy_credits',
+    state: LockedPillState
+  ) => {
+    if (state === 'hidden') return null
+    const isComing = state === 'coming_soon'
+    const isUpgrade = kind === 'upgrade'
+    const label = isComing ? 'Coming soon' : isUpgrade ? 'Upgrade plan' : 'Buy credits'
+    const icon = isComing ? 'fa-clock' : isUpgrade ? 'fa-arrow-up' : 'fa-bolt'
+    const dataId = isUpgrade
+      ? `${item.dataId}-upgrade-pill`
+      : `${item.dataId}-buy-credits-pill`
+    const handleClick = (e: React.MouseEvent) => {
+      // Stop propagation so the pill click doesn't also trigger the outer
+      // row handler (which routes to onLockedItemClick).
+      e.stopPropagation()
+      if (isComing) return
+      props.setShowOptions(false)
+      if (kind === 'buy_credits' && props.onBuyCreditsClick) {
+        props.onBuyCreditsClick(item)
+      } else {
+        props.onLockedItemClick?.(item)
+      }
+    }
+    return (
+      <span
+        key={kind}
+        data-id={dataId}
+        data-pill-kind={kind}
+        data-pill-state={state}
+        className={`badge ms-2 text-white ${isComing ? 'bg-secondary' : 'bg-primary'}`}
+        style={{
+          fontSize: '0.65rem',
+          padding: '2px 6px',
+          cursor: isComing ? 'default' : 'pointer',
+          opacity: isComing ? 0.85 : 1
+        }}
+        aria-disabled={isComing || undefined}
+        onClick={isComing ? undefined : handleClick}
+      >
+        <i className={`fas ${icon} me-1`} style={{ fontSize: '0.6rem' }}></i>
+        {label}
+      </span>
+    )
+  }
 
   return (
     <div className="btn-group-vertical w-100">
-      {props.groupList.map((item, index) => (
-        <button
-          key={`${item.label}-${index}`}
-          className={`btn btn-light border-0 ${item.isLocked ? 'opacity-75' : ''}`}
-          data-id={item.dataId}
-          data-locked={item.isLocked ? 'true' : 'false'}
-          onClick={() => {
-            props.setShowOptions(false)
-            if (item.isLocked) {
-              props.onLockedItemClick?.(item)
-            } else {
-              props.setChoice(item.stateValue)
-            }
-          }}
-        >
-          <div className="d-flex flex-column small text-start">
-            <div className="d-flex align-items-center mb-1">
-              <span className="form-check-label fw-bold">{item.label}</span>
-              {item.isLocked && (
-                <span
-                  className="badge bg-primary ms-2 text-white"
-                  style={{ fontSize: '0.65rem', padding: '2px 6px' }}
-                >
-                  <i className="fas fa-arrow-up me-1" style={{ fontSize: '0.6rem' }}></i>
-                  Upgrade plan
-                </span>
-              )}
+      {visibleItems.map((item, index) => {
+        const upgradePill = item.isLocked ? renderPill(item, 'upgrade', upgradeState) : null
+        const buyCreditsPill = item.isLocked ? renderPill(item, 'buy_credits', buyCreditsState) : null
+        return (
+          <button
+            key={`${item.label}-${index}`}
+            className={`btn btn-light border-0 ${item.isLocked ? 'opacity-75' : ''}`}
+            data-id={item.dataId}
+            data-locked={item.isLocked ? 'true' : 'false'}
+            onClick={() => {
+              props.setShowOptions(false)
+              if (item.isLocked) {
+                props.onLockedItemClick?.(item)
+              } else {
+                props.setChoice(item.stateValue)
+              }
+            }}
+          >
+            <div className="d-flex flex-column small text-start">
+              <div className="d-flex align-items-center mb-1">
+                <span className="form-check-label fw-bold">{item.label}</span>
+                {upgradePill}
+                {buyCreditsPill}
+              </div>
+              <div className="d-flex justify-content-between">
+                <span className="form-check-label me-2 text-wrap">{item.bodyText}</span>
+                {props.choice === item.stateValue && !item.isLocked && <span className={item.icon}></span>}
+              </div>
             </div>
-            <div className="d-flex justify-content-between">
-              <span className="form-check-label me-2 text-wrap">{item.bodyText}</span>
-              {props.choice === item.stateValue && !item.isLocked && <span className={item.icon}></span>}
-            </div>
-          </div>
-        </button>
-      ))}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
@@ -104,6 +104,16 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
   // ready until they authenticate).
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false)
 
+  // Permission-derived state for the locked-model picker pills. Defaults
+  // to 'hidden' so an unauthenticated/loading account never flashes a
+  // checkout CTA. Re-computed whenever assistantState emits stateChanged.
+  // See contextOptMenu.tsx for the rendering rules.
+  type PillState = 'hidden' | 'coming_soon' | 'available'
+  const [pillStates, setPillStates] = useState<{ upgrade: PillState; buyCredits: PillState }>({
+    upgrade: 'hidden',
+    buyCredits: 'hidden'
+  })
+
   const [mcpEnhanced, setMcpEnhanced] = useState(false)
   const [pendingApprovals, setPendingApprovals] = useState<ToolApprovalRequest[]>([])
   const approvalQueueRef = useRef<ToolApprovalRequest[]>([])
@@ -889,6 +899,24 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
         ai_models_len: Array.isArray(snap?.permissions?.ai_models) ? snap.permissions.ai_models.length : 'absent'
       })
       setIsAuthenticated(!!snap?.isAuthenticated)
+      // Derive pill visibility from the same snapshot. `ai:modes_coming_soon`
+      // wins over the specific entitlement so a soft-launch account never
+      // exposes a working checkout pill.
+      const features = snap?.permissions?.features
+      const isOn = (key: string): boolean => {
+        if (!features) return false
+        if (Array.isArray(features)) return features.some((f: any) => f?.feature_name === key && f?.is_enabled !== false)
+        const entry = features[key]
+        if (entry == null) return false
+        if (typeof entry === 'boolean') return entry
+        return entry?.is_enabled !== false && entry?.allowed !== false
+      }
+      const comingSoon = isOn('ai:modes_coming_soon')
+      const nextPillStates = {
+        upgrade: comingSoon ? 'coming_soon' : isOn('ai:upgrade_available') ? 'available' : 'hidden',
+        buyCredits: comingSoon ? 'hidden' : isOn('ai:buy_credits') ? 'available' : 'hidden'
+      } as const
+      setPillStates(nextPillStates)
       void refreshCooldown()
       void refreshModels()
       void refreshFeatures()
@@ -907,7 +935,12 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
     ;(async () => {
       try {
         const snap: any = await props.plugin.call('assistantState' as any, 'getSnapshot')
-        if (snap) setIsAuthenticated(!!snap.isAuthenticated)
+        if (snap) {
+          setIsAuthenticated(!!snap.isAuthenticated)
+          // Reuse the same derivation as the event handler so the initial
+          // pill state is correct without waiting for a stateChanged.
+          onAssistantStateChange(snap)
+        }
       } catch { /* assistantState not active */ }
     })()
 
@@ -2120,6 +2153,17 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
     trackMatomoEvent({ category: 'ai', action: 'remixAI', name: 'locked_model_click', value: modelId, isClick: true })
   }, [props.plugin, availableModels])
 
+  // Buy-credits pill route: opens plan-manager with the quota-exhausted
+  // intent so it lands on the top-up section directly. `modelName` is
+  // currently unused but kept symmetrical with handleLockedModelClick in
+  // case we want to surface "which model triggered this" later.
+  const handleBuyCreditsClick = useCallback((modelId: string, _modelName: string) => {
+    props.plugin.call('planManager' as any, 'open', { reason: 'quota-exhausted' }).catch(() => {
+      props.plugin.call('betaCornerWidget', 'show').catch(() => { /* noop */ })
+    })
+    trackMatomoEvent({ category: 'ai', action: 'remixAI', name: 'buy_credits_pill_click', value: modelId, isClick: true })
+  }, [props.plugin])
+
   // Opens the plan-manager paywall/sign-in modal with reason=auth-required.
   // This is the same hand-off the locked-model picker uses for the
   // `__signin__` placeholder model — keeping it consistent means the user
@@ -2596,6 +2640,9 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
               autoModeAvailable={autoModeAvailable}
               handleModelSelection={handleModelSelection}
               onLockedModelClick={handleLockedModelClick}
+              upgradePillState={pillStates.upgrade}
+              buyCreditsPillState={pillStates.buyCredits}
+              onBuyCreditsClick={handleBuyCreditsClick}
               input={input}
               setInput={setInput}
               isStreaming={isStreaming}
@@ -2646,6 +2693,9 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
               autoModeAvailable={autoModeAvailable}
               handleModelSelection={handleModelSelection}
               onLockedModelClick={handleLockedModelClick}
+              upgradePillState={pillStates.upgrade}
+              buyCreditsPillState={pillStates.buyCredits}
+              onBuyCreditsClick={handleBuyCreditsClick}
               input={input}
               setInput={setInput}
               isStreaming={isStreaming}


### PR DESCRIPTION
## What changed

- Adds permission-driven states for locked AI model picker CTAs:
  - `hidden`
  - `coming_soon`
  - `available`
- Gates the per-model `Upgrade plan` pill with `ai:upgrade_available`.
- Gates the per-model `Buy credits` pill with `ai:buy_credits`.
- Uses `ai:modes_coming_soon` to show a single compact non-clickable `Coming soon` badge.
- Hides locked models entirely when the user has no visible CTA/pill for them.
- Routes `Buy credits` pill clicks to Plan Manager with `reason: 'quota-exhausted'`.

## Notes

The pill state is derived from the `assistantState` permission snapshot and refreshed on `stateChanged`, with an initial snapshot seed on mount so the picker does not wait for the next event.

## Validation

- Verified manually in the AI model picker.
- Ran `yarn nx lint remix-ui`.

Lint passes with existing unrelated warnings in:
- `libs/remix-ui/login/src/lib/login-button.tsx`
- `libs/remix-ui/top-bar/src/lib/remix-ui-topbar.tsx`