### PR TITLE
refresh all balances after transaction execution

### DIFF
--- a/apps/remix-ide/src/app/udapp/udappDeployedContracts.tsx
+++ b/apps/remix-ide/src/app/udapp/udappDeployedContracts.tsx
@@ -32,7 +32,15 @@ export class DeployedContractsPlugin extends Plugin {
   async addInstance(address, abi, name, contractData?, pinnedAt?, timestamp = Date.now()) {
     address = (address.slice(0, 2) === '0x' ? '' : '0x') + address.toString('hex')
     address = ethJSUtil.toChecksumAddress(address)
-    const instance = { address, abi, name, contractData, decodedResponse: {}, isPinned: !!pinnedAt, pinnedAt, timestamp }
+
+    let balance = '0'
+    try {
+      balance = await this.call('blockchain', 'getBalanceInEther', address)
+    } catch (e) {
+      console.error(`Failed to fetch initial balance for ${address}:`, e)
+    }
+
+    const instance = { address, abi, name, contractData, decodedResponse: {}, isPinned: !!pinnedAt, pinnedAt, timestamp, balance }
     const duplicateContract = this.getWidgetState()?.deployedContracts?.find(contract => contract.address === address)
 
     if (!duplicateContract) {

--- a/libs/remix-ui/run-tab-deployed-contracts/src/lib/actions/index.ts
+++ b/libs/remix-ui/run-tab-deployed-contracts/src/lib/actions/index.ts
@@ -94,6 +94,23 @@ export async function loadPinnedContracts (plugin: DeployedContractsPlugin, disp
   }
 }
 
+export async function refreshDeployedContractBalances (plugin: DeployedContractsPlugin, dispatch: React.Dispatch<Actions>) {
+  const deployedContracts = plugin.getWidgetState?.()?.deployedContracts || []
+
+  for (const contract of deployedContracts) {
+    if (!contract.address) continue
+    try {
+      const balance = await plugin.call('blockchain', 'getBalanceInEther', contract.address)
+
+      if (balance !== undefined && balance !== null) {
+        dispatch({ type: 'UPDATE_CONTRACT_BALANCE', payload: { address: contract.address, balance } })
+      }
+    } catch (e) {
+      console.error(`Failed to update balance for ${contract.address}:`, e)
+    }
+  }
+}
+
 export async function runTransactions (
   plugin: DeployedContractsPlugin,
   dispatch: React.Dispatch<Actions>,

--- a/libs/remix-ui/run-tab-deployed-contracts/src/lib/deployed-contracts.tsx
+++ b/libs/remix-ui/run-tab-deployed-contracts/src/lib/deployed-contracts.tsx
@@ -5,7 +5,7 @@ import DeployedContractsPortraitView from './widgets/deployedContractsPortraitVi
 import './css/index.css'
 // eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { DeployedContractsPlugin } from 'apps/remix-ide/src/app/udapp/udappDeployedContracts'
-import { loadPinnedContracts } from './actions'
+import { loadPinnedContracts, refreshDeployedContractBalances } from './actions'
 
 interface DeployedContractsWidgetProps {
   plugin: DeployedContractsPlugin
@@ -76,14 +76,9 @@ function DeployedContractsWidget({ plugin }: DeployedContractsWidgetProps) {
       }
     })
 
-    plugin.on('blockchain', 'transactionExecuted', async (error, _, to, __, ___, txResult) => {
+    plugin.on('blockchain', 'transactionExecuted', async (error) => {
       if (error) return
-      if (to || txResult?.receipt?.contractAddress) {
-        const address = to || txResult?.receipt?.contractAddress
-        const balance = await plugin.call('blockchain', 'getBalanceInEther', address)
-
-        if (balance) dispatch({ type: 'UPDATE_CONTRACT_BALANCE', payload: { address: address, balance } })
-      }
+      await refreshDeployedContractBalances(plugin, dispatch)
     })
 
     // Cleanup function to remove event listeners when component unmounts

--- a/libs/remix-ui/run-tab-environment/src/lib/environment.tsx
+++ b/libs/remix-ui/run-tab-environment/src/lib/environment.tsx
@@ -125,14 +125,9 @@ function EnvironmentWidget({ plugin }: { plugin: EnvironmentPlugin }) {
       dispatch({ type: 'SET_TRANSACTION_RECORDER_COUNT', payload: transactions.length })
     })
 
-    plugin.on('blockchain', 'transactionExecuted', async (error, address: string) => {
+    plugin.on('blockchain', 'transactionExecuted', async (error) => {
       if (error) return
-
-      if (address) {
-        const balance = await plugin.call('blockchain', 'getBalanceInEther', address)
-
-        if (balance) dispatch({ type: 'SET_ACCOUNT_BALANCE', payload: { address, balance: formatBalance(balance, 3) } })
-      }
+      await refreshAccountBalances(plugin, dispatch)
     })
 
     const registerInjectedPluginListener = (pluginName: string) => {


### PR DESCRIPTION
Fixes #7230

- The UI didn’t update balances when a transaction changed an address via an external contract call.

- Added `refreshAccountBalances` and `refreshDeployedContractBalances` in the `transactionExecuted` listener and implemented `refreshDeployedContractBalances` to refresh all relevant balances after each transaction.