### PR TITLE
Fix/ai tool approval stall

### DIFF
--- a/libs/remix-ai-core/src/helpers/apiKeyValidator.ts
+++ b/libs/remix-ai-core/src/helpers/apiKeyValidator.ts
@@ -139,10 +139,11 @@ async function testAnthropicKey(apiKey: string): Promise<ApiKeyValidationResult>
       headers: {
         'Content-Type': 'application/json',
         'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01'
+        'anthropic-version': '2023-06-01',
+        'anthropic-dangerous-direct-browser-access': 'true'
       },
       body: JSON.stringify({
-        model: 'claude-3-haiku-20240307',
+        model: 'claude-sonnet-4-6',
         max_tokens: 1,
         messages: [{ role: 'user', content: 'test' }]
       })

--- a/libs/remix-ai-core/src/inferencers/deepagent/DeepAgentInferencer.ts
+++ b/libs/remix-ai-core/src/inferencers/deepagent/DeepAgentInferencer.ts
@@ -190,13 +190,13 @@ export class DeepAgentInferencer implements ICompletions, IGeneration {
     this.userApiKeys = config?.userApiKeys
 
     // Initialize filesystem backend with shared EventEmitter for approval
-    this.filesystemBackend = new RemixFilesystemBackend(plugin, this.event, 'deployment_only') as any
+    this.filesystemBackend = new RemixFilesystemBackend(plugin, this.event) as any
 
     // Store MCP inferencer for resource access
     this.mcpInferencer = mcpInferencer
 
     // Initialize tools with approval gate
-    this.approvalGate = new ToolApprovalGate(plugin, this.event, 'deployment_only')
+    this.approvalGate = new ToolApprovalGate(plugin, this.event, 'ask_risky')
     this.initializeTools(toolRegistry, mcpInferencer)
 
     // TEMP GC PROBE — register this instance so we get a console line when
@@ -969,19 +969,8 @@ export class DeepAgentInferencer implements ICompletions, IGeneration {
       this.currentAbortController.abort()
       this.currentAbortController = null
     }
-    // Always emit so plugin.isInferencing can never get stuck, even when no
-    // controller was set (e.g. cancel arrived between turns). The manager
-    // builds a brand-new instance with a fresh thread, so there is no need to
-    // resetSessionThread() on this about-to-be-discarded instance.
     this.event.emit('onInferenceDone')
 
-    // Clear any in-flight generation progress spinner. Do NOT emit
-    // dappGenerationError here: cancelling a chat request (new chat, button
-    // action) is not a dapp generation failure. A genuine mid-flight dapp
-    // generation that gets aborted is reported by DAppGeneratorHandler's own
-    // catch with the correct slug/workspace scope. Emitting a slug-less error
-    // here made the QuickDapp "Update Failed" modal pop on every cancel once a
-    // dapp existed (the listener treats a slug-less error as matching any dapp).
     try {
       this.plugin.emit('generationProgress', null)
     } catch (_) { /* best-effort cleanup */ }

--- a/libs/remix-ai-core/src/inferencers/deepagent/DeepAgentInferencer.ts
+++ b/libs/remix-ai-core/src/inferencers/deepagent/DeepAgentInferencer.ts
@@ -190,13 +190,13 @@ export class DeepAgentInferencer implements ICompletions, IGeneration {
     this.userApiKeys = config?.userApiKeys
 
     // Initialize filesystem backend with shared EventEmitter for approval
-    this.filesystemBackend = new RemixFilesystemBackend(plugin, this.event) as any
+    this.filesystemBackend = new RemixFilesystemBackend(plugin, this.event, 'deployment_only') as any
 
     // Store MCP inferencer for resource access
     this.mcpInferencer = mcpInferencer
 
     // Initialize tools with approval gate
-    this.approvalGate = new ToolApprovalGate(plugin, this.event, 'ask_risky')
+    this.approvalGate = new ToolApprovalGate(plugin, this.event, 'deployment_only')
     this.initializeTools(toolRegistry, mcpInferencer)
 
     // TEMP GC PROBE — register this instance so we get a console line when
@@ -975,12 +975,15 @@ export class DeepAgentInferencer implements ICompletions, IGeneration {
     // resetSessionThread() on this about-to-be-discarded instance.
     this.event.emit('onInferenceDone')
 
+    // Clear any in-flight generation progress spinner. Do NOT emit
+    // dappGenerationError here: cancelling a chat request (new chat, button
+    // action) is not a dapp generation failure. A genuine mid-flight dapp
+    // generation that gets aborted is reported by DAppGeneratorHandler's own
+    // catch with the correct slug/workspace scope. Emitting a slug-less error
+    // here made the QuickDapp "Update Failed" modal pop on every cancel once a
+    // dapp existed (the listener treats a slug-less error as matching any dapp).
     try {
       this.plugin.emit('generationProgress', null)
-      this.plugin.emit('dappGenerationError', {
-        slug: undefined,
-        error: 'Generation cancelled by user'
-      })
     } catch (_) { /* best-effort cleanup */ }
   }
 

--- a/libs/remix-ai-core/src/inferencers/deepagent/RemixFilesystemBackend.ts
+++ b/libs/remix-ai-core/src/inferencers/deepagent/RemixFilesystemBackend.ts
@@ -1,10 +1,11 @@
 import { remixAILogger } from '../../helpers/logger'
 import { Plugin } from '@remixproject/engine'
 import EventEmitter from 'events'
-import { ToolApprovalRequest, ToolApprovalResponse } from '../../types/humanInTheLoop'
+import { ToolApprovalRequest, ToolApprovalResponse, ToolApprovalPolicy, shouldRequireApproval } from '../../types/humanInTheLoop'
 
 // File size limit for auto-summarization (100KB)
 const MAX_FILE_SIZE = 100 * 1024
+const FS_APPROVAL_TIMEOUT_MS = 180000
 
 interface EditInstruction {
   oldText: string
@@ -15,6 +16,7 @@ export class RemixFilesystemBackend {
   private plugin: Plugin
   private workspaceRoot: string = '/'
   private eventEmitter: EventEmitter | null = null
+  private policy: ToolApprovalPolicy
   private pendingApprovals = new Map<string, (result: { approved: boolean; modifiedContent?: string; timedOut?: boolean }) => void>()
 
   private editBatches = new Map<string, {
@@ -23,8 +25,9 @@ export class RemixFilesystemBackend {
     totalEdits: number
   }>()
 
-  constructor(plugin: Plugin, eventEmitter?: EventEmitter) {
+  constructor(plugin: Plugin, eventEmitter?: EventEmitter, policy: ToolApprovalPolicy = 'deployment_only') {
     this.plugin = plugin
+    this.policy = policy
 
     if (eventEmitter) {
       this.eventEmitter = eventEmitter
@@ -544,6 +547,10 @@ export class RemixFilesystemBackend {
       return { approved: true }
     }
 
+    if (!shouldRequireApproval(toolName, this.policy)) {
+      return { approved: true }
+    }
+
     const requestId = `fs_approval_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
 
     const request: ToolApprovalRequest = {
@@ -559,7 +566,16 @@ export class RemixFilesystemBackend {
     }
 
     return new Promise<{ approved: boolean; modifiedContent?: string; timedOut?: boolean }>((resolve) => {
-      this.pendingApprovals.set(requestId, resolve)
+      const timer = setTimeout(() => {
+        if (this.pendingApprovals.delete(requestId)) {
+          remixAILogger.warn('[HITL][Backend] approval timed out — auto-rejecting to unblock stream', toolName, requestId)
+          resolve({ approved: false, timedOut: true })
+        }
+      }, FS_APPROVAL_TIMEOUT_MS)
+      this.pendingApprovals.set(requestId, (result) => {
+        clearTimeout(timer)
+        resolve(result)
+      })
       this.eventEmitter.emit('onToolApprovalRequired', request)
     })
   }

--- a/libs/remix-ai-core/src/inferencers/deepagent/prompts/system/lightPrompts.ts
+++ b/libs/remix-ai-core/src/inferencers/deepagent/prompts/system/lightPrompts.ts
@@ -3,7 +3,7 @@
  * Each system prompt limited to maximum 2 lines for optimal performance
  */
 
-export const REMIX_DEEPAGENT_SYSTEM_PROMPT = `Expert Web3 assistant in Remix IDE. CRITICAL: Be extremely concise. Max 2-3 sentences per response unless code is needed. Never explain what you're about to do — just do it. Never summarize what you did. No preambles, no conclusions. When asked a task, check if a subagent can fulfill it.`
+export const REMIX_DEEPAGENT_SYSTEM_PROMPT = `Expert Web3 assistant in Remix. CRITICAL — keep chat output minimal: at most 2 sentences of prose per reply, carrying only the most relevant details. Code blocks and file writes don't count toward that limit, but never wrap them in explanation. Never narrate tool calls or subagent steps, never explain what you're about to do, never summarize what you did, no preambles, no conclusions, no filler. Act silently, then state only the result in one line. When asked a task, check if a subagent can fulfill it.`
 
 export const CONTRACT_COMPILER_PROMPT = 'Access to the following tools: solidity_compile, get_compilation_result, get_compilation_result_sources_by_file_path, set_compiler_config, get_compiler_config, get_compiler_versions'
 

--- a/libs/remix-ai-core/src/inferencers/deepagent/tools/ToolApprovalGate.ts
+++ b/libs/remix-ai-core/src/inferencers/deepagent/tools/ToolApprovalGate.ts
@@ -11,11 +11,15 @@ import {
   DIRECT_WRITE_TOOLS
 } from '../../../types/humanInTheLoop'
 
+// Hard upper bound on how long a single tool approval may block the agent stream
+const APPROVAL_TIMEOUT_MS = 180000
+
 export class ToolApprovalGate {
   private eventEmitter: EventEmitter
   private policy: ToolApprovalPolicy
   private plugin: Plugin
-  private pendingApprovals = new Map<string, { resolve: (approved: boolean, modified?: Record<string, any>) => void }>()
+  private disposed = false
+  private pendingApprovals = new Map<string, { resolve: (approved: boolean, modified?: Record<string, any>) => void; timer?: ReturnType<typeof setTimeout> }>()
 
   constructor(plugin: Plugin, eventEmitter: EventEmitter, policy: ToolApprovalPolicy = 'ask_risky') {
     this.plugin = plugin
@@ -27,8 +31,9 @@ export class ToolApprovalGate {
       const pending = this.pendingApprovals.get(response.requestId)
       remixAILogger.log('[ToolApprovalGate] onToolApprovalResponse', response.requestId, 'approved=', response.approved, 'pendingFound=', !!pending, 'pendingKeys=', Array.from(this.pendingApprovals.keys()))
       if (pending) {
-        pending.resolve(response.approved, response.modifiedArgs)
+        if (pending.timer) clearTimeout(pending.timer)
         this.pendingApprovals.delete(response.requestId)
+        pending.resolve(response.approved, response.modifiedArgs)
       }
     })
   }
@@ -63,6 +68,10 @@ export class ToolApprovalGate {
       if (!shouldRequireApproval(toolName, this.policy)) {
 
         return originalFunc(args)
+      }
+
+      if (this.disposed) {
+        return JSON.stringify({ cancelled: true, reason: `Agent was reset before this ${toolName} operation could be approved.` })
       }
 
       const meta = getToolMetadata(toolName)
@@ -115,11 +124,18 @@ export class ToolApprovalGate {
         timestamp: Date.now()
       }
 
-      // Wait for user decision
+      // Wait for user decision — with a timeout backstop so a lost response
       const { approved, modifiedArgs } = await new Promise<{ approved: boolean; modifiedArgs?: Record<string, any> }>(
         (resolve) => {
+          const timer = setTimeout(() => {
+            if (this.pendingApprovals.delete(requestId)) {
+              remixAILogger.warn('[ToolApprovalGate] approval timed out — rejecting to unblock stream', toolName, requestId)
+              resolve({ approved: false })
+            }
+          }, APPROVAL_TIMEOUT_MS)
           this.pendingApprovals.set(requestId, {
-            resolve: (approved, modified) => resolve({ approved, modifiedArgs: modified })
+            resolve: (approved, modified) => resolve({ approved, modifiedArgs: modified }),
+            timer
           })
           remixAILogger.log('[ToolApprovalGate] awaiting approval', toolName, requestId, 'listeners(onToolApprovalResponse)=', this.eventEmitter.listenerCount('onToolApprovalResponse'))
           this.eventEmitter.emit('onToolApprovalRequired', request)
@@ -181,10 +197,17 @@ export class ToolApprovalGate {
   }
 
   /**
-   * Clean up resources
+   * Clean up resources. CRITICAL: resolve every still-pending approval as
+   * rejected before clearing — otherwise the awaiting tool promise is orphaned
    */
   dispose() {
+    this.disposed = true
     this.eventEmitter.removeAllListeners('onToolApprovalResponse')
+    const pending = Array.from(this.pendingApprovals.values())
     this.pendingApprovals.clear()
+    for (const p of pending) {
+      if (p.timer) clearTimeout(p.timer)
+      try { p.resolve(false) } catch { /* best-effort */ }
+    }
   }
 }

--- a/libs/remix-ai-core/src/types/humanInTheLoop.ts
+++ b/libs/remix-ai-core/src/types/humanInTheLoop.ts
@@ -24,7 +24,7 @@ export interface ToolApprovalResponse {
 
 export type ToolCategory = 'file_write' | 'file_delete' | 'deployment' | 'transaction' | 'dapp' | 'other'
 export type ToolRisk = 'low' | 'medium' | 'high'
-export type ToolApprovalPolicy = 'always_ask' | 'ask_risky' | 'auto_approve'
+export type ToolApprovalPolicy = 'always_ask' | 'ask_risky' | 'auto_approve' | 'deployment_only'
 
 export interface ToolPolicyConfig {
   defaultPolicy: ToolApprovalPolicy
@@ -126,7 +126,10 @@ export function shouldRequireApproval(toolName: string, policy: ToolApprovalPoli
   if (isSafeTool(toolName)) return false
   if (policy === 'auto_approve') return false
   if (policy === 'always_ask') return true
-  // 'ask_risky': only ask for medium+ risk
   const meta = getToolMetadata(toolName)
+  if (policy === 'deployment_only') {
+    return meta.category === 'deployment' || meta.category === 'transaction'
+  }
+  // 'ask_risky': only ask for medium+ risk
   return meta.risk === 'medium' || meta.risk === 'high'
 }

--- a/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
@@ -284,15 +284,14 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
     })
     setReviewingApprovals(new Set())
 
-    // 2. Cancel the backend request and abort the frontend stream
+    const wasInFlight = !!abortControllerRef.current || !!streamingAssistantIdRef.current
     if (abortControllerRef.current) {
       abortControllerRef.current.abort()
       abortControllerRef.current = null
     }
-    // Use the assistant plugin's stopRequest (engine event) rather than
-    // call('remixAI', 'cancelRequest') so it bypasses remixAI's busy request
-    // queue and aborts the in-flight answer() synchronously.
-    ;(props.plugin as any).stopRequest()
+    if (wasInFlight) {
+      ;(props.plugin as any).stopRequest()
+    }
 
     // 3. Stop the spinner so the new conversation starts clean
     setIsStreaming(false)
@@ -623,7 +622,15 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
                 executingToolUIString: undefined,
                 currentTask: undefined,
                 taskStatus: undefined,
-                isIntermediateContent: false
+                isIntermediateContent: false,
+                // The turn finished — any todo still marked in_progress would
+                // otherwise keep spinning forever. Mark it completed.
+                todos: m.todos?.map(todo =>
+                  todo.status === 'in_progress'
+                    ? { ...todo, status: 'completed' as const }
+                    : todo
+                ),
+                currentTodoIndex: undefined
               }
               : m
           )
@@ -997,8 +1004,12 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
 
     // Human-in-the-loop: listen for tool approval requests (batch processing)
     const handleToolApproval = (request: ToolApprovalRequest) => {
-      // Don't show new approval dialogs if the request has been stopped
-      if (isStoppedRef.current) return
+      if (isStoppedRef.current) {
+        try {
+          ;(props.plugin as any).respondToToolApproval({ requestId: request.requestId, approved: false })
+        } catch { /* best-effort */ }
+        return
+      }
       remixAILogger.log('[Assistant UI] approval requested', request.toolName, request.requestId)
       if (hitlAutoAcceptRef.current) {
         try {


### PR DESCRIPTION
- only deploy_contract/send_transaction
- Add a 180s timeout
- todo tool tightened, was spinning sometimes after request done
- ToolApprovalGate.dispose() now resolves pending approvals as rejected