### PR TITLE
Audit UI improvments

### DIFF
--- a/apps/remix-ide/src/app/plugins/remix-ai-assistant.tsx
+++ b/apps/remix-ide/src/app/plugins/remix-ai-assistant.tsx
@@ -314,6 +314,40 @@ export class RemixAIAssistant extends ViewPlugin {
         updatedAt: Date.now()
       }).catch(err => remixAILogger.error('Failed to persist conversation title:', err))
     }
+
+    this.generateConversationTitle(conversationId, prompt)
+  }
+
+  private async generateConversationTitle(conversationId: string, prompt: string) {
+    try {
+      const titlePrompt =
+        'Generate a concise, descriptive title (at most 6 words) for a chat that begins with the following user message. ' +
+        'Reply with ONLY the title — no quotes, no punctuation at the end, no preamble.\n\n' +
+        `User message: ${prompt}`
+      const raw = await this.call('remixAI', 'basic_prompt', titlePrompt)
+      if (typeof raw !== 'string') return
+
+      // Keep the first line, strip surrounding quotes/backticks, clamp length.
+      let title = raw.split('\n').map(l => l.trim()).find(Boolean) || ''
+      title = title.replace(/^["'`]+|["'`]+$/g, '').trim()
+      if (!title) return
+      if (title.length > 60) title = title.slice(0, 59).trimEnd() + '…'
+
+      console.log('[RemixAI] Generated conversation title:', title)
+      // Only apply if the conversation still exists.
+      if (!this.conversations.some(c => c.id === conversationId)) return
+
+      this.conversations = this.conversations.map(conv =>
+        conv.id === conversationId ? { ...conv, title, updatedAt: Date.now() } : conv
+      )
+      this.renderComponent()
+
+      if (this.storageManager) {
+        await this.storageManager.updateConversation(conversationId, { title, updatedAt: Date.now() })
+      }
+    } catch (err) {
+      remixAILogger.warn('Failed to generate AI conversation title:', err)
+    }
   }
 
   toggleHistorySidebar() {

--- a/apps/remix-ide/src/app/plugins/remix-ai-assistant.tsx
+++ b/apps/remix-ide/src/app/plugins/remix-ai-assistant.tsx
@@ -20,7 +20,7 @@ const profile = {
   maintainedBy: 'Remix',
   permission: true,
   events: ['toolApprovalResponse', 'stopRequested'],
-  methods: ['chatPipe', 'handleExternalMessage', 'getProfile', 'deleteConversation','loadConversations', 'newConversation', 'archiveConversation', 'respondToToolApproval', 'stopRequest']
+  methods: ['chatPipe', 'handleExternalMessage', 'getProfile', 'deleteConversation','loadConversations', 'newConversation', 'archiveConversation', 'respondToToolApproval', 'stopRequest', 'submitChatInput']
 }
 
 export class RemixAIAssistant extends ViewPlugin {
@@ -463,6 +463,12 @@ export class RemixAIAssistant extends ViewPlugin {
   handleExternalMessage = (message: string) => {
     this.externalMessage = message
     this.renderComponent()
+  }
+
+  async submitChatInput() {
+    if (this.chatRef?.current) {
+      await this.chatRef.current.submitCurrentInput()
+    }
   }
 
   onReady() {

--- a/libs/remix-ai-core/src/inferencers/deepagent/prompts/system/lightPrompts.ts
+++ b/libs/remix-ai-core/src/inferencers/deepagent/prompts/system/lightPrompts.ts
@@ -35,10 +35,10 @@ Handle JSON-RPC, contract events, multi-chain support, NFT APIs, and webhooks.`
 export const GAS_OPTIMIZER_SUBAGENT_PROMPT = `Gas_Optimizer: Analyze and optimize gas consumption with measurable savings estimates.
 Focus on storage ops, loops, function calls, data types, and provide before/after examples.
 You have access to a solidity gas optimization skill. Don't try to use the full skill with all the references (that will blow up the context) but rather ask the user on which topic you should concentrate the effort.
-Your answer MUST only return a concise summary (not more than 100 words): Do NOT include the full report or any additional text in the conversation chat. But save a comprehensive audit in <filename>_gas_audit_report_<topic>.md`
+Your answer MUST only return a concise summary (not more than 100 words): Do NOT include the full report or any additional text in the conversation chat. But save a comprehensive audit in the 'audit_reports' folder as audit_reports/<filename>_gas_audit_report_<topic>.md (the folder is created automatically when you write the report there).`
 
 export const COMPREHENSIVE_AUDITOR_SUBAGENT_PROMPT = `1) Run Slither analysis with slither_scan 2) Be aware that the folder 'audits' may contain checklists as MD files 3) Against each checklist file do an audit and code review. 4) Final report.
-Your answer MUST only return a concise summary (not more than 100 words): Do NOT include the full report or any additional text in the conversation chat. But save a comprehensive audit in <filename>_security_audit_report_<checklist>.md.`
+Your answer MUST only return a concise summary (not more than 100 words): Do NOT include the full report or any additional text in the conversation chat. But save a comprehensive audit in the 'audit_reports' folder as audit_reports/<filename>_security_audit_report_<checklist>.md (the folder is created automatically when you write the report there).`
 
 export const DEBUG_SPECIALIST_SUBAGENT_PROMPT = `Debug_Specialist: Transaction debugging with step-by-step analysis and variable inspection.
 Use debug tools to analyze execution flow, decode variables, examine stack/storage, and map to source.`

--- a/libs/remix-ui/checklist-explorer-modal/src/lib/remix-ui-checklist-explorer-modal.css
+++ b/libs/remix-ui/checklist-explorer-modal/src/lib/remix-ui-checklist-explorer-modal.css
@@ -241,15 +241,6 @@
   }
 }
 
-/* ========== Selection state styling ========== */
-
-.sub-category-header[style*="box-shadow"] {
-  background-color: var(--bs-primary-bg-subtle) !important;
-  border-left: 4px solid var(--bs-primary);
-}
-
-/* ========== Search result highlighting ========== */
-
 .text-highlight {
   background: rgba(var(--bs-warning-rgb), 0.3);
   padding: 0.1rem 0.2rem;

--- a/libs/remix-ui/checklist-explorer-modal/src/lib/remix-ui-checklist-explorer-modal.tsx
+++ b/libs/remix-ui/checklist-explorer-modal/src/lib/remix-ui-checklist-explorer-modal.tsx
@@ -411,25 +411,14 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
               />
             </div>
           )}
-          <div className="d-flex align-items-center gap-2">
-            <button
-              data-id="checklist-explorer-ok-button"
-              className="btn btn-primary btn-sm"
-              onClick={handleOk}
-              disabled={isProcessing}
-              title="Close and start the audit"
-            >
-              OK
-            </button>
-            <button
-              data-id="checklist-explorer-modal-close-button"
-              className="checklist-explorer-modal-close-button"
-              onClick={onClose}
-              disabled={isProcessing}
-            >
-              <i className="fa-solid fa-xmark text-dark"></i>
-            </button>
-          </div>
+          <button
+            data-id="checklist-explorer-modal-close-button"
+            className="checklist-explorer-modal-close-button"
+            onClick={onClose}
+            disabled={isProcessing}
+          >
+            <i className="fa-solid fa-xmark text-dark"></i>
+          </button>
         </div>
 
         <div className="checklist-explorer-container">

--- a/libs/remix-ui/checklist-explorer-modal/src/lib/remix-ui-checklist-explorer-modal.tsx
+++ b/libs/remix-ui/checklist-explorer-modal/src/lib/remix-ui-checklist-explorer-modal.tsx
@@ -486,9 +486,9 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
                           return (
                             <div key={mainCategory.category} className="main-category mb-3">
                               <div
-                                className={`main-category-header p-3 d-flex justify-content-between align-items-center cursor-pointer ${isSelected ? 'bg-primary text-white' : 'bg-secondary text-light'}`}
+                                className={`main-category-header p-3 d-flex justify-content-between align-items-center cursor-pointer bg-secondary text-light`}
                                 onClick={() => toggleCategory(mainCategory.category)}
-                                style={isSelected ? { boxShadow: '0 0 0 2px var(--bs-primary)' } : isLoaded ? { boxShadow: 'inset 4px 0 0 var(--bs-success)' } : {}}
+                                style={isSelected ? { boxShadow: 'inset 4px 0 0 var(--bs-primary)' } : isLoaded ? { boxShadow: 'inset 4px 0 0 var(--bs-success)' } : {}}
                               >
                                 <div className="flex-grow-1">
                                   <div className="d-flex align-items-center mb-1">
@@ -551,9 +551,9 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
                                   return (
                                     <div key={categoryPath} className="sub-category border-bottom">
                                       <div
-                                        className={`sub-category-header p-3 d-flex justify-content-between align-items-center cursor-pointer ${isSelected ? 'bg-light border-primary' : 'bg-light'}`}
+                                        className={`sub-category-header p-3 d-flex justify-content-between align-items-center cursor-pointer bg-light`}
                                         onClick={() => toggleCategory(categoryPath)}
-                                        style={isSelected ? { boxShadow: '0 0 0 2px var(--bs-primary)' } : isLoaded ? { boxShadow: 'inset 4px 0 0 var(--bs-success)' } : {}}
+                                        style={isSelected ? { backgroundColor: 'rgba(var(--bs-primary-rgb), 0.12)', boxShadow: 'inset 4px 0 0 var(--bs-primary)' } : isLoaded ? { boxShadow: 'inset 4px 0 0 var(--bs-success)' } : {}}
                                       >
                                         <div className="flex-grow-1">
                                           <div className="d-flex align-items-center mb-1">

--- a/libs/remix-ui/checklist-explorer-modal/src/lib/remix-ui-checklist-explorer-modal.tsx
+++ b/libs/remix-ui/checklist-explorer-modal/src/lib/remix-ui-checklist-explorer-modal.tsx
@@ -54,6 +54,38 @@ const countTotalItems = (data: (ChecklistItem | ChecklistCategory)[]): number =>
   return collectChecklistItems(data).length
 }
 
+const categoryFileToken = (categoryPath: string): string => {
+  const raw = categoryPath.includes('::') ? categoryPath.split('::').join('-') : categoryPath
+  return raw
+    .replace(/[^a-zA-Z0-9_-]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '')
+}
+
+const enumerateSelectablePaths = (data: ChecklistData[]): string[] => {
+  const paths: string[] = []
+  for (const mainCat of data) {
+    const hasDirectItems = mainCat.data.some(isChecklistItem)
+    const subCats = mainCat.data.filter(item => !isChecklistItem(item)) as ChecklistCategory[]
+    if (hasDirectItems && subCats.length === 0) {
+      paths.push(mainCat.category)
+    } else {
+      subCats.forEach(sub => paths.push(`${mainCat.category}::${sub.category}`))
+    }
+  }
+  return paths
+}
+
+const computeLoadedCategories = (data: ChecklistData[], files: string[]): Set<string> => {
+  const haystack = files.join('\n')
+  const loaded = new Set<string>()
+  enumerateSelectablePaths(data).forEach(path => {
+    const token = categoryFileToken(path)
+    if (token && haystack.includes(token)) loaded.add(path)
+  })
+  return loaded
+}
+
 export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerModalProps) {
   const { isOpen, onClose, plugin } = props
   const [checklistData, setChecklistData] = useState<ChecklistData[]>([])
@@ -62,6 +94,7 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
   const [searchTerm, setSearchTerm] = useState<string>('')
   const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set())
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set())
+  const [loadedCategories, setLoadedCategories] = useState<Set<string>>(new Set())
   const [wizardStep, setWizardStep] = useState<'browse' | 'confirm' | 'saving'>('browse')
   const [saving, setSaving] = useState<boolean>(false)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -86,11 +119,22 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
     }
   }
 
+  const fetchExistingChecklistFiles = async (): Promise<string[]> => {
+    if (!plugin) return []
+    try {
+      const entries = await plugin.call('fileManager', 'readdir', 'audits')
+      return Object.keys(entries || {})
+    } catch (e) {
+      return []
+    }
+  }
+
   useEffect(() => {
     if (isOpen) {
       setWizardStep('browse')
       setSelectedCategories(new Set())
       setExpandedCategories(new Set())
+      setLoadedCategories(new Set())
       setSearchTerm('')
       setError(null)
 
@@ -99,6 +143,9 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
         try {
           const data = await fetchChecklistData()
           setChecklistData(data)
+          // Highlight categories whose checklist is already saved in the workspace
+          const existingFiles = await fetchExistingChecklistFiles()
+          setLoadedCategories(computeLoadedCategories(data, existingFiles))
         } catch (err) {
           setError(err instanceof Error ? err.message : 'Failed to load checklist')
         } finally {
@@ -263,12 +310,19 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
       await plugin.call('fileManager', 'writeFile', `audits/${filename}`, checklistContent)
 
       setSaving(false)
-      onClose()
+      handleOk()
     } catch (err) {
       setSaving(false)
       setError(err instanceof Error ? err.message : 'Failed to save checklist')
       setWizardStep('confirm')
     }
+  }
+
+  const handleOk = () => {
+    onClose()
+    Promise.resolve(plugin?.call('remixaiassistant', 'submitChatInput')).catch(() => {
+      // assistant plugin unavailable — modal is already closed
+    })
   }
 
   const handleBack = () => {
@@ -357,14 +411,25 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
               />
             </div>
           )}
-          <button
-            data-id="checklist-explorer-modal-close-button"
-            className="checklist-explorer-modal-close-button"
-            onClick={onClose}
-            disabled={isProcessing}
-          >
-            <i className="fa-solid fa-xmark text-dark"></i>
-          </button>
+          <div className="d-flex align-items-center gap-2">
+            <button
+              data-id="checklist-explorer-ok-button"
+              className="btn btn-primary btn-sm"
+              onClick={handleOk}
+              disabled={isProcessing}
+              title="Close and start the audit"
+            >
+              OK
+            </button>
+            <button
+              data-id="checklist-explorer-modal-close-button"
+              className="checklist-explorer-modal-close-button"
+              onClick={onClose}
+              disabled={isProcessing}
+            >
+              <i className="fa-solid fa-xmark text-dark"></i>
+            </button>
+          </div>
         </div>
 
         <div className="checklist-explorer-container">
@@ -392,6 +457,12 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
                   <div className="category-title">Audit Checklist Categories</div>
                   <div className="category-description mb-4">
                     Select audit categories to include in your checklist
+                    {loadedCategories.size > 0 && (
+                      <span className="ms-2 badge bg-success text-white small">
+                        <i className="fa-solid fa-check me-1"></i>
+                        already in workspace
+                      </span>
+                    )}
                   </div>
 
                   {filteredData.length === 0 ? (
@@ -410,19 +481,26 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
                           // Category with only direct checklist items
                           const isSelected = selectedCategories.has(mainCategory.category)
                           const isExpanded = expandedCategories.has(mainCategory.category)
+                          const isLoaded = loadedCategories.has(mainCategory.category)
 
                           return (
                             <div key={mainCategory.category} className="main-category mb-3">
                               <div
                                 className={`main-category-header p-3 d-flex justify-content-between align-items-center cursor-pointer ${isSelected ? 'bg-primary text-white' : 'bg-secondary text-light'}`}
                                 onClick={() => toggleCategory(mainCategory.category)}
-                                style={isSelected ? { boxShadow: '0 0 0 2px var(--bs-primary)' } : {}}
+                                style={isSelected ? { boxShadow: '0 0 0 2px var(--bs-primary)' } : isLoaded ? { boxShadow: 'inset 4px 0 0 var(--bs-success)' } : {}}
                               >
                                 <div className="flex-grow-1">
                                   <div className="d-flex align-items-center mb-1">
                                     <h5 className="mb-0">{mainCategory.category}</h5>
                                     {isSelected && (
                                       <i className="fa-solid fa-circle-check ms-2"></i>
+                                    )}
+                                    {isLoaded && (
+                                      <span className="badge bg-success text-white small ms-2" title="A checklist for this category is already saved in audits/">
+                                        <i className="fa-solid fa-check me-1"></i>
+                                        in workspace
+                                      </span>
                                     )}
                                   </div>
                                   <p className="mb-0 small opacity-75">{mainCategory.description}</p>
@@ -468,19 +546,26 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
                                   const categoryPath = `${mainCategory.category}::${subCategory.category}`
                                   const isSelected = selectedCategories.has(categoryPath)
                                   const isExpanded = expandedCategories.has(categoryPath)
+                                  const isLoaded = loadedCategories.has(categoryPath)
 
                                   return (
                                     <div key={categoryPath} className="sub-category border-bottom">
                                       <div
                                         className={`sub-category-header p-3 d-flex justify-content-between align-items-center cursor-pointer ${isSelected ? 'bg-light border-primary' : 'bg-light'}`}
                                         onClick={() => toggleCategory(categoryPath)}
-                                        style={isSelected ? { boxShadow: '0 0 0 2px var(--bs-primary)' } : {}}
+                                        style={isSelected ? { boxShadow: '0 0 0 2px var(--bs-primary)' } : isLoaded ? { boxShadow: 'inset 4px 0 0 var(--bs-success)' } : {}}
                                       >
                                         <div className="flex-grow-1">
                                           <div className="d-flex align-items-center mb-1">
                                             <h6 className="text-dark mb-0">{subCategory.category}</h6>
                                             {isSelected && (
                                               <i className="fa-solid fa-circle-check text-primary ms-2"></i>
+                                            )}
+                                            {isLoaded && (
+                                              <span className="badge bg-success text-white small ms-2" title="A checklist for this category is already saved in audits/">
+                                                <i className="fa-solid fa-check me-1"></i>
+                                                in workspace
+                                              </span>
                                             )}
                                           </div>
                                           <p className="text-muted mb-0 small">{subCategory.description}</p>
@@ -611,6 +696,7 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
               </div>
             </div>
           )}
+
         </div>
 
         {/* Fixed footer */}

--- a/libs/remix-ui/checklist-explorer-modal/src/lib/remix-ui-checklist-explorer-modal.tsx
+++ b/libs/remix-ui/checklist-explorer-modal/src/lib/remix-ui-checklist-explorer-modal.tsx
@@ -309,6 +309,29 @@ export function RemixUiChecklistExplorerModal(props: RemixUiChecklistExplorerMod
 
       await plugin.call('fileManager', 'writeFile', `audits/${filename}`, checklistContent)
 
+      // Post a summary into the chat so completion isn't silent — especially for
+      // /load-audit-checklist, where nothing else is sent after the modal closes.
+      try {
+        let itemCount = 0
+        const categoryLabels: string[] = []
+        Array.from(selectedCategories).forEach(path => {
+          if (path.includes('::')) {
+            const [mainName, subName] = path.split('::')
+            const main = checklistData.find(c => c.category === mainName)
+            const sub = main?.data.find(i => !isChecklistItem(i) && (i as ChecklistCategory).category === subName) as ChecklistCategory | undefined
+            if (sub) { itemCount += countTotalItems(sub.data); categoryLabels.push(subName) }
+          } else {
+            const main = checklistData.find(c => c.category === path)
+            if (main) { itemCount += countTotalItems(main.data); categoryLabels.push(path) }
+          }
+        })
+        const labelText = categoryLabels.join(', ') || 'selected'
+        const summary = `Created \`audits/${filename}\` with the ${labelText} checklist (${itemCount} item${itemCount === 1 ? '' : 's'})`
+        await plugin.call('remixaiassistant', 'handleExternalMessage', summary)
+      } catch (e) {
+        // assistant panel unavailable — the file is still created
+      }
+
       setSaving(false)
       handleOk()
     } catch (err) {

--- a/libs/remix-ui/plan-manager/src/lib/plan-manager-plugin.tsx
+++ b/libs/remix-ui/plan-manager/src/lib/plan-manager-plugin.tsx
@@ -4510,7 +4510,6 @@ function formatMoney(amount: unknown, currency: string = 'USD'): string {
   }
 }
 
-
 function buildUsageRange(days: number): { from: string; to: string } {
   const to = new Date()
   const from = new Date(to.getTime())

--- a/libs/remix-ui/remix-ai-assistant/src/components/AutocompletePanel.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/AutocompletePanel.tsx
@@ -9,6 +9,8 @@ export interface Command {
   action?: () => void
   disabled?: boolean
   requiredFeatures: string[] // List of required features for this command
+  /** Contextual hint shown below the input after the command is inserted (prompt-template commands only) */
+  hint?: string
 }
 
 interface AutocompletePanelProps {
@@ -31,7 +33,7 @@ interface AutocompletePanelProps {
 }
 
 // Available commands - this could be moved to a config file or fetched dynamically
-const AVAILABLE_COMMANDS: Command[] = [
+export const AVAILABLE_COMMANDS: Command[] = [
   // Core commands
   // { name: 'generate', description: 'Generate smart contracts or code', shortcut: '/g', category: 'Generate' },
   // { name: 'workspace', description: 'Generate a new workspace', shortcut: '/w', category: 'Generate' },
@@ -39,13 +41,13 @@ const AVAILABLE_COMMANDS: Command[] = [
   // { name: 'ollama', description: 'Configure Ollama integration', category: 'Settings' },
 
   // Compilation & Analysis
-  { name: 'compile', description: 'Compile contract', category: 'Build', requiredFeatures: [Features.AI_SOLCODER]},
+  { name: 'compile', description: 'Compile contract', category: 'Build', hint: 'optional instructions, or leave blank to compile the current file', requiredFeatures: [Features.AI_SOLCODER] },
   // { name: 'slither', description: 'Run Slither security analysis', category: 'Analysis' },
   // { name: 'mythril', description: 'Run Mythril security scan', category: 'Analysis' },
 
   // Deployment & Verification
-  { name: 'deploy', description: 'Deploy contract to network', category: 'Deploy', requiredFeatures: [Features.AI_SOLCODER]},
-  { name: 'etherscan', description: 'Fetch contract from Etherscan and call the Etherscan service', category: 'Import', requiredFeatures: [Features.MCP_ETHERSCAN]},
+  { name: 'deploy', description: 'Deploy contract to network', category: 'Deploy', hint: 'name the contract and any constructor arguments, or leave blank to deploy the current one', requiredFeatures: [Features.AI_SOLCODER] },
+  { name: 'etherscan', description: 'Fetch contract from Etherscan and call the Etherscan service', category: 'Import', hint: 'paste a contract address (with network) to fetch and analyze it', requiredFeatures: [Features.MCP_ETHERSCAN] },
   // { name: 'verify', description: 'Verify contract on block explorer', category: 'Deploy' },
 
   // Testing & Debugging
@@ -53,9 +55,9 @@ const AVAILABLE_COMMANDS: Command[] = [
   // { name: 'debug', description: 'Debug transaction', category: 'Debug' },
 
   // DeFi & Integrations
-  { name: 'thegraph', description: 'Fetch data from The Graph', category: 'Data', requiredFeatures: [Features.MCP_THEGRAPH]},
-  { name: 'alchemy', description: 'Fetch data from Alchemy', category: 'Data', requiredFeatures: [Features.MCP_ALCHEMY]},
-  { name: 'circle', description: 'Circle integration', category: 'DeFi', requiredFeatures: [Features.MCP_CIRCLE]},
+  { name: 'thegraph', description: 'Fetch data from The Graph', category: 'Data', hint: 'describe the data to query from a subgraph', requiredFeatures: [Features.MCP_THEGRAPH] },
+  { name: 'alchemy', description: 'Fetch data from Alchemy', category: 'Data', hint: 'describe the on-chain data to fetch (address, network, …)', requiredFeatures: [Features.MCP_ALCHEMY] },
+  { name: 'circle', description: 'Circle integration', category: 'DeFi', hint: 'describe the Circle API task', requiredFeatures: [Features.MCP_CIRCLE] },
   // { name: 'uniswap', description: 'Uniswap integration', category: 'DeFi' },
   // { name: 'aave', description: 'Aave integration', category: 'DeFi' },
 
@@ -64,7 +66,7 @@ const AVAILABLE_COMMANDS: Command[] = [
   // { name: 'docs', description: 'Open documentation', category: 'Help' },
 
   // Frontend & UI
-  { name: 'create-dapp', description: 'Create a DApp frontend (QuickDapp agent)', category: 'Frontend', requiredFeatures: [Features.DAPP_QUICKDAPP]},
+  { name: 'create-dapp', description: 'Create a DApp frontend (QuickDapp agent)', category: 'Frontend', hint: 'describe your DApp, or leave blank to build from your deployed contracts', requiredFeatures: [Features.DAPP_QUICKDAPP] },
 ]
 
 export const AutocompletePanel: React.FC<AutocompletePanelProps> = ({

--- a/libs/remix-ui/remix-ai-assistant/src/components/AutocompletePanel.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/AutocompletePanel.tsx
@@ -65,8 +65,6 @@ const AVAILABLE_COMMANDS: Command[] = [
 
   // Frontend & UI
   { name: 'create a dapp [quickdapp agent]', description: 'DApp development', category: 'Frontend', requiredFeatures: [Features.DAPP_QUICKDAPP]},
-
-  { name: 'audit a contract. I am going to give you the actual file name.', description: 'Contract auditing', category: 'Security', requiredFeatures: [Features.AI_AUDITOR]},
 ]
 
 export const AutocompletePanel: React.FC<AutocompletePanelProps> = ({

--- a/libs/remix-ui/remix-ai-assistant/src/components/AutocompletePanel.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/AutocompletePanel.tsx
@@ -64,7 +64,7 @@ const AVAILABLE_COMMANDS: Command[] = [
   // { name: 'docs', description: 'Open documentation', category: 'Help' },
 
   // Frontend & UI
-  { name: 'create a dapp [quickdapp agent]', description: 'DApp development', category: 'Frontend', requiredFeatures: [Features.DAPP_QUICKDAPP]},
+  { name: 'create-dapp', description: 'Create a DApp frontend (QuickDapp agent)', category: 'Frontend', requiredFeatures: [Features.DAPP_QUICKDAPP]},
 ]
 
 export const AutocompletePanel: React.FC<AutocompletePanelProps> = ({

--- a/libs/remix-ui/remix-ai-assistant/src/components/AutocompletePanel.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/AutocompletePanel.tsx
@@ -41,13 +41,13 @@ export const AVAILABLE_COMMANDS: Command[] = [
   // { name: 'ollama', description: 'Configure Ollama integration', category: 'Settings' },
 
   // Compilation & Analysis
-  { name: 'compile', description: 'Compile contract', category: 'Build', hint: 'optional instructions, or leave blank to compile the current file', requiredFeatures: [Features.AI_SOLCODER] },
+  { name: 'compile', description: 'Compile contract', category: 'Build', hint: 'optional instructions, or leave blank to compile the current file', requiredFeatures: [Features.AI_SOLCODER]},
   // { name: 'slither', description: 'Run Slither security analysis', category: 'Analysis' },
   // { name: 'mythril', description: 'Run Mythril security scan', category: 'Analysis' },
 
   // Deployment & Verification
-  { name: 'deploy', description: 'Deploy contract to network', category: 'Deploy', hint: 'name the contract and any constructor arguments, or leave blank to deploy the current one', requiredFeatures: [Features.AI_SOLCODER] },
-  { name: 'etherscan', description: 'Fetch contract from Etherscan and call the Etherscan service', category: 'Import', hint: 'paste a contract address (with network) to fetch and analyze it', requiredFeatures: [Features.MCP_ETHERSCAN] },
+  { name: 'deploy', description: 'Deploy contract to network', category: 'Deploy', hint: 'name the contract and any constructor arguments, or leave blank to deploy the current one', requiredFeatures: [Features.AI_SOLCODER]},
+  { name: 'etherscan', description: 'Fetch contract from Etherscan and call the Etherscan service', category: 'Import', hint: 'paste a contract address (with network) to fetch and analyze it', requiredFeatures: [Features.MCP_ETHERSCAN]},
   // { name: 'verify', description: 'Verify contract on block explorer', category: 'Deploy' },
 
   // Testing & Debugging
@@ -55,9 +55,9 @@ export const AVAILABLE_COMMANDS: Command[] = [
   // { name: 'debug', description: 'Debug transaction', category: 'Debug' },
 
   // DeFi & Integrations
-  { name: 'thegraph', description: 'Fetch data from The Graph', category: 'Data', hint: 'describe the data to query from a subgraph', requiredFeatures: [Features.MCP_THEGRAPH] },
-  { name: 'alchemy', description: 'Fetch data from Alchemy', category: 'Data', hint: 'describe the on-chain data to fetch (address, network, …)', requiredFeatures: [Features.MCP_ALCHEMY] },
-  { name: 'circle', description: 'Circle integration', category: 'DeFi', hint: 'describe the Circle API task', requiredFeatures: [Features.MCP_CIRCLE] },
+  { name: 'thegraph', description: 'Fetch data from The Graph', category: 'Data', hint: 'describe the data to query from a subgraph', requiredFeatures: [Features.MCP_THEGRAPH]},
+  { name: 'alchemy', description: 'Fetch data from Alchemy', category: 'Data', hint: 'describe the on-chain data to fetch (address, network, …)', requiredFeatures: [Features.MCP_ALCHEMY]},
+  { name: 'circle', description: 'Circle integration', category: 'DeFi', hint: 'describe the Circle API task', requiredFeatures: [Features.MCP_CIRCLE]},
   // { name: 'uniswap', description: 'Uniswap integration', category: 'DeFi' },
   // { name: 'aave', description: 'Aave integration', category: 'DeFi' },
 
@@ -66,7 +66,7 @@ export const AVAILABLE_COMMANDS: Command[] = [
   // { name: 'docs', description: 'Open documentation', category: 'Help' },
 
   // Frontend & UI
-  { name: 'create-dapp', description: 'Create a DApp frontend (QuickDapp agent)', category: 'Frontend', hint: 'describe your DApp, or leave blank to build from your deployed contracts', requiredFeatures: [Features.DAPP_QUICKDAPP] },
+  { name: 'create-dapp', description: 'Create a DApp frontend (QuickDapp agent)', category: 'Frontend', hint: 'describe your DApp, or leave blank to build from your deployed contracts', requiredFeatures: [Features.DAPP_QUICKDAPP]},
 ]
 
 export const AutocompletePanel: React.FC<AutocompletePanelProps> = ({

--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -11,8 +11,6 @@ import { AIModel } from '@remix/remix-ai-core'
 import { PromptDefault } from "./promptDefault";
 import { AutocompletePanel, AVAILABLE_COMMANDS, Command } from './AutocompletePanel'
 
-const AUDIT_COMMAND_TEXT = 'audit a contract'
-
 const getActiveCommandName = (text: string): string | null => {
   const lastSpaceSlash = text.lastIndexOf(' /')
   const slashStart = lastSpaceSlash !== -1 ? lastSpaceSlash + 1 : text.startsWith('/') ? 0 : -1
@@ -487,10 +485,14 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
                   data-id={`shortcut-prompt-${i}`}
                 >
                   <span>
-                    <span style={{ color: 'var(--custom-ai-color)', fontWeight: 600 }}>
-                      {promptText.indexOf(' ') === -1 ? promptText : promptText.substring(0, promptText.indexOf(' '))}
-                    </span>
-                    {promptText.indexOf(' ') === -1 ? '' : promptText.substring(promptText.indexOf(' '))}
+                    {promptText.startsWith('/') ? (
+                      <span>
+                        <span style={{ color: 'var(--custom-ai-color)', fontWeight: 600 }}>
+                          {promptText.indexOf(' ') === -1 ? promptText : promptText.substring(0, promptText.indexOf(' '))}
+                        </span>
+                        {promptText.indexOf(' ') === -1 ? '' : promptText.substring(promptText.indexOf(' '))}
+                      </span>
+                    ) : promptText}
                   </span>
                   {isLocked && (
                     <span

--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -171,7 +171,6 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
   aiRouteReady = true,
   isAuthenticated = true,
   onSignIn,
-  isNewChat = false,
   handleLoadSkills,
   handleOpenSettings,
   handleLoadAuditChecklist,
@@ -204,7 +203,6 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
   const promptAreaRef = useRef<HTMLDivElement>(null)
   const shortcutsRef = useRef<HTMLDivElement>(null)
   const [activeShortcut, setActiveShortcut] = useState<string | null>(null)
-  const [shortcutsExpanded, setShortcutsExpanded] = useState(false)
 
   useEffect(() => {
     if (textareaRef?.current) {
@@ -316,7 +314,6 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
   const handleShortcutSelect = useCallback((prompt: string) => {
     setInput(prompt)
     setActiveShortcut(null)
-    setShortcutsExpanded(false)
     textareaRef?.current?.focus()
   }, [setInput])
 
@@ -434,25 +431,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
     <>
       <div ref={shortcutsRef} className="position-relative mx-2 mb-1">
         <div className="d-flex flex-row align-items-center" style={{ gap: '4px' }}>
-          {!isNewChat && (
-            <button
-              onClick={() => { setShortcutsExpanded(prev => !prev); setActiveShortcut(null) }}
-              className="btn btn-sm rounded-pill"
-              style={{
-                fontSize: '0.72rem',
-                padding: '2px 9px',
-                border: `1px solid ${shortcutsExpanded ? 'var(--custom-ai-color)' : 'var(--bs-border-color)'}`,
-                color: shortcutsExpanded ? 'var(--custom-ai-color)' : 'var(--bs-secondary-color)',
-                backgroundColor: shortcutsExpanded ? 'var(--custom-onsurface-layer-1)' : 'var(--bs-body-bg)',
-                transition: 'all 0.15s ease',
-              }}
-              title="Intent shortcuts"
-              data-id="shortcut-toggle"
-            >
-              <i className="fa-solid fa-bolt"></i>
-            </button>
-          )}
-          {(isNewChat || shortcutsExpanded) && [...SHORTCUT_CATEGORIES, ...(toolCommands.length > 0 ? [{ id: 'tools', label: 'Tools' }] : [])].map(cat => (
+          {[...SHORTCUT_CATEGORIES, ...(toolCommands.length > 0 ? [{ id: 'tools', label: 'Tools' }] : [])].map(cat => (
             <button
               key={cat.id}
               onClick={() => setActiveShortcut(prev => prev === cat.id ? null : cat.id)}
@@ -473,7 +452,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
             </button>
           ))}
         </div>
-        {(isNewChat || shortcutsExpanded) && activeShortcut && activeCategory && (
+        {activeShortcut && activeCategory && (
           <div
             className="position-absolute rounded-3 shadow-lg overflow-hidden"
             style={{
@@ -550,7 +529,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
             })}
           </div>
         )}
-        {(isNewChat || shortcutsExpanded) && activeShortcut === 'tools' && (
+        {activeShortcut === 'tools' && (
           <div
             className="position-absolute rounded-3 shadow-lg overflow-hidden"
             style={{

--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -9,9 +9,21 @@ import { TrackingContext } from '@remix-ide/tracking'
 import { CustomTooltip } from '@remix-ui/helper'
 import { AIModel } from '@remix/remix-ai-core'
 import { PromptDefault } from "./promptDefault";
-import { AutocompletePanel, Command } from './AutocompletePanel'
+import { AutocompletePanel, AVAILABLE_COMMANDS, Command } from './AutocompletePanel'
 
 const AUDIT_COMMAND_TEXT = 'audit a contract'
+
+// Extract the name of a completed slash command (text up to the ':') so we can
+// surface a contextual hint for it. Returns null when no command/colon is present.
+const getActiveCommandName = (text: string): string | null => {
+  const lastSpaceSlash = text.lastIndexOf(' /')
+  const slashStart = lastSpaceSlash !== -1 ? lastSpaceSlash + 1 : text.startsWith('/') ? 0 : -1
+  if (slashStart === -1) return null
+  const afterSlash = text.slice(slashStart + 1)
+  const colonIdx = afterSlash.indexOf(':')
+  if (colonIdx === -1) return null
+  return afterSlash.slice(0, colonIdx).trim() || null
+}
 
 const getSlashWord = (text: string): string | null => {
   // Only detect slash commands at the beginning or after a space
@@ -395,12 +407,21 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
 
   const toolCommands = actionCommands.filter(cmd => cmd.category === 'Tools')
 
+  // Contextual hint for a just-inserted command (e.g. "/compile: ") so the user
+  // knows what to type after the colon.
+  const activeCommandHint = useMemo(() => {
+    const name = getActiveCommandName(input)
+    if (!name) return null
+    const cmd = AVAILABLE_COMMANDS.find(c => c.name.toLowerCase() === name.toLowerCase())
+    return cmd?.hint ?? null
+  }, [input])
+
   // Logout doesn't reliably flip `aiRouteReady` (the route was already ready),
   // so authentication is the source of truth for whether the composer is
   // usable. Folding it in here disables the input + send button and surfaces
   // the sign-in CTA the instant the user logs out.
   const composerReady = aiRouteReady && isAuthenticated
-  const needsSignIn = !isAuthenticated && !!onSignIn
+  const needsSignIn = !aiRouteReady && !isAuthenticated && !!onSignIn
   const placeholderText = needsSignIn
     ? 'Sign in to chat with RemixAI…'
     : aiRouteReady
@@ -630,6 +651,16 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
               onKeyDown={handleKeyDown}
               placeholder={placeholderText}
             />
+            {activeCommandHint && (
+              <div
+                className="px-2 pb-1 d-flex align-items-center"
+                style={{ fontSize: '0.72rem', color: 'var(--bs-secondary-color)', fontStyle: 'italic' }}
+                data-id="command-hint"
+              >
+                <i className="fa-regular fa-circle-question me-1" style={{ fontSize: '0.7rem' }}></i>
+                {activeCommandHint}
+              </div>
+            )}
             <div className="d-flex flex-row align-items-center">
               {/* <div className="d-flex flex-row align-items-center"> */}
               <button

--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -204,6 +204,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
   const promptAreaRef = useRef<HTMLDivElement>(null)
   const shortcutsRef = useRef<HTMLDivElement>(null)
   const [activeShortcut, setActiveShortcut] = useState<string | null>(null)
+  const [shortcutsExpanded, setShortcutsExpanded] = useState(false)
 
   useEffect(() => {
     if (textareaRef?.current) {
@@ -315,6 +316,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
   const handleShortcutSelect = useCallback((prompt: string) => {
     setInput(prompt)
     setActiveShortcut(null)
+    setShortcutsExpanded(false)
     textareaRef?.current?.focus()
   }, [setInput])
 
@@ -430,9 +432,27 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
 
   return (
     <>
-      {isNewChat && <div ref={shortcutsRef} className="position-relative mx-2 mb-1">
-        <div className="d-flex flex-row" style={{ gap: '4px' }}>
-          {[...SHORTCUT_CATEGORIES, ...(toolCommands.length > 0 ? [{ id: 'tools', label: 'Tools' }] : [])].map(cat => (
+      <div ref={shortcutsRef} className="position-relative mx-2 mb-1">
+        <div className="d-flex flex-row align-items-center" style={{ gap: '4px' }}>
+          {!isNewChat && (
+            <button
+              onClick={() => { setShortcutsExpanded(prev => !prev); setActiveShortcut(null) }}
+              className="btn btn-sm rounded-pill"
+              style={{
+                fontSize: '0.72rem',
+                padding: '2px 9px',
+                border: `1px solid ${shortcutsExpanded ? 'var(--custom-ai-color)' : 'var(--bs-border-color)'}`,
+                color: shortcutsExpanded ? 'var(--custom-ai-color)' : 'var(--bs-secondary-color)',
+                backgroundColor: shortcutsExpanded ? 'var(--custom-onsurface-layer-1)' : 'var(--bs-body-bg)',
+                transition: 'all 0.15s ease',
+              }}
+              title="Intent shortcuts"
+              data-id="shortcut-toggle"
+            >
+              <i className="fa-solid fa-bolt"></i>
+            </button>
+          )}
+          {(isNewChat || shortcutsExpanded) && [...SHORTCUT_CATEGORIES, ...(toolCommands.length > 0 ? [{ id: 'tools', label: 'Tools' }] : [])].map(cat => (
             <button
               key={cat.id}
               onClick={() => setActiveShortcut(prev => prev === cat.id ? null : cat.id)}
@@ -453,7 +473,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
             </button>
           ))}
         </div>
-        {activeShortcut && activeCategory && (
+        {(isNewChat || shortcutsExpanded) && activeShortcut && activeCategory && (
           <div
             className="position-absolute rounded-3 shadow-lg overflow-hidden"
             style={{
@@ -530,7 +550,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
             })}
           </div>
         )}
-        {activeShortcut === 'tools' && (
+        {(isNewChat || shortcutsExpanded) && activeShortcut === 'tools' && (
           <div
             className="position-absolute rounded-3 shadow-lg overflow-hidden"
             style={{
@@ -591,7 +611,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
             })}
           </div>
         )}
-      </div>}
+      </div>
       <div
         ref={promptAreaRef}
         className="prompt-area d-flex flex-column mx-2 p-1 rounded-3 border border-text position-relative"

--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -13,16 +13,14 @@ import { AutocompletePanel, AVAILABLE_COMMANDS, Command } from './AutocompletePa
 
 const AUDIT_COMMAND_TEXT = 'audit a contract'
 
-// Extract the name of a completed slash command (text up to the ':') so we can
-// surface a contextual hint for it. Returns null when no command/colon is present.
 const getActiveCommandName = (text: string): string | null => {
   const lastSpaceSlash = text.lastIndexOf(' /')
   const slashStart = lastSpaceSlash !== -1 ? lastSpaceSlash + 1 : text.startsWith('/') ? 0 : -1
   if (slashStart === -1) return null
   const afterSlash = text.slice(slashStart + 1)
-  const colonIdx = afterSlash.indexOf(':')
-  if (colonIdx === -1) return null
-  return afterSlash.slice(0, colonIdx).trim() || null
+  const spaceIdx = afterSlash.indexOf(' ')
+  if (spaceIdx === -1) return null
+  return afterSlash.slice(0, spaceIdx).trim() || null
 }
 
 const getSlashWord = (text: string): string | null => {
@@ -32,16 +30,9 @@ const getSlashWord = (text: string): string | null => {
   if (slashStart === -1) return null
 
   const afterSlash = text.slice(slashStart)
+  if (/\s/.test(afterSlash)) return null
 
-  // If there's already a colon, the command is complete
-  if (afterSlash.includes(':')) return null
-
-  // Extract the word after the slash (until space or end)
-  const nextSpace = afterSlash.indexOf(' ')
-  const word = nextSpace === -1 ? afterSlash : afterSlash.slice(0, nextSpace)
-
-  // Return the word to show autocomplete
-  return word
+  return afterSlash
 }
 
 // A shortcut prompt is either a plain prompt string (always available) or an
@@ -213,10 +204,8 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
 
   // Handle autocomplete visibility
   useEffect(() => {
-    // Don't show autocomplete if input ends with ": " (completed command)
-    const endsWithCommandColon = input.trimEnd().endsWith(':')
     const hasSlashWord = !!getSlashWord(input)
-    const shouldShow = hasSlashWord && !isStreaming && !endsWithCommandColon
+    const shouldShow = hasSlashWord && !isStreaming
 
     setShowAutocomplete(shouldShow)
     // Reset selected index when hiding or showing the panel
@@ -306,7 +295,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
     } else {
       const lastSpaceSlash = input.lastIndexOf(' /')
       const slashStart = lastSpaceSlash !== -1 ? lastSpaceSlash + 1 : input.startsWith('/') ? 0 : input.length
-      setInput(input.slice(0, slashStart) + '/' + command.name + ': ')
+      setInput(input.slice(0, slashStart) + '/' + command.name + ' ')
     }
     textareaRef?.current?.focus()
   }, [input, setInput, setShowAutocomplete, getMissingFeature, onUpgradeRequired, handleLoadAuditChecklist, hasAuditorPermission])
@@ -406,8 +395,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
 
   const toolCommands = actionCommands.filter(cmd => cmd.category === 'Tools')
 
-  // Contextual hint for a just-inserted command (e.g. "/compile: ") so the user
-  // knows what to type after the colon.
+  // Contextual hint for a just-inserted command (e.g. "/compile ") so the user
   const activeCommandHint = useMemo(() => {
     const name = getActiveCommandName(input)
     if (!name) return null
@@ -499,14 +487,10 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
                   data-id={`shortcut-prompt-${i}`}
                 >
                   <span>
-                    {promptText.startsWith('/') ? (
-                      <span>
-                        <span style={{ color: 'var(--custom-ai-color)', fontWeight: 600 }}>
-                          {promptText.substring(0, promptText.indexOf(':') + 1)}
-                        </span>
-                        {promptText.substring(promptText.indexOf(':') + 1)}
-                      </span>
-                    ) : promptText}
+                    <span style={{ color: 'var(--custom-ai-color)', fontWeight: 600 }}>
+                      {promptText.indexOf(' ') === -1 ? promptText : promptText.substring(0, promptText.indexOf(' '))}
+                    </span>
+                    {promptText.indexOf(' ') === -1 ? '' : promptText.substring(promptText.indexOf(' '))}
                   </span>
                   {isLocked && (
                     <span

--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -222,7 +222,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
     if (handleOpenSettings) cmds.push({ name: 'settings', description: 'Open RemixAI settings', category: 'Settings', action: handleOpenSettings, requiredFeatures: []})
     if (handleLoadSkills) {
       cmds.push({
-        name: 'Load Skills',
+        name: 'load-skills',
         description: 'Load skills',
         category: 'Tools',
         action: handleLoadSkills,
@@ -232,7 +232,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
     }
     if (handleLoadAuditChecklist) {
       cmds.push({
-        name: 'Audit a contract',
+        name: 'audit',
         description: hasAuditorPermission ? 'Audit a contract' : 'Coming soon',
         requiredFeatures: [Features.AI_AUDITOR],
         category: 'Tools',
@@ -243,14 +243,14 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
         disabled: !hasAuditorPermission
       })
       cmds.push({
-        name: 'Load Security Audit checklist',
+        name: 'load-audit-checklist',
         description: 'Load audit checklist',
         category: 'Tools',
         action: handleLoadAuditChecklist,
         requiredFeatures: [Features.AI_AUDITOR]
       })
     }
-    if (handleGasOptimisationAudit) cmds.push({ name: 'Start Gas Optimisation Audit', description: 'Gas optimisation audit', category: 'Tools', action: handleGasOptimisationAudit, requiredFeatures: [Features.AI_AUDITOR]})
+    if (handleGasOptimisationAudit) cmds.push({ name: 'gas-audit', description: 'Gas optimisation audit', category: 'Tools', action: handleGasOptimisationAudit, requiredFeatures: [Features.AI_AUDITOR] })
     return cmds
   }, [handleSetModel, handleOpenSettings, handleLoadSkills, handleLoadAuditChecklist, handleGasOptimisationAudit, hasAuditorPermission, hasSkillsPermission, setInput])
 
@@ -288,11 +288,6 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
       value: `command_selected_${command.name}`,
       isClick: true
     })
-
-    const isAuditCommand = command.category === 'Security' && command.name.toLowerCase().includes('audit')
-    if (isAuditCommand && hasAuditorPermission && handleLoadAuditChecklist) {
-      handleLoadAuditChecklist()
-    }
 
     if (command.action) {
       setInput('')

--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -276,6 +276,11 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
       isClick: true
     })
 
+    const isAuditCommand = command.category === 'Security' && command.name.toLowerCase().includes('audit')
+    if (isAuditCommand && hasAuditorPermission && handleLoadAuditChecklist) {
+      handleLoadAuditChecklist()
+    }
+
     if (command.action) {
       setInput('')
       setTimeout(() => command.action!(), 0)
@@ -285,7 +290,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
       setInput(input.slice(0, slashStart) + '/' + command.name + ': ')
     }
     textareaRef?.current?.focus()
-  }, [input, setInput, setShowAutocomplete, getMissingFeature, onUpgradeRequired])
+  }, [input, setInput, setShowAutocomplete, getMissingFeature, onUpgradeRequired, handleLoadAuditChecklist, hasAuditorPermission])
 
   const handleShortcutSelect = useCallback((prompt: string) => {
     setInput(prompt)

--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -249,7 +249,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
         disabled: !hasAuditorPermission
       })
     }
-    if (handleGasOptimisationAudit) cmds.push({ name: 'gas-audit', description: 'Gas optimisation audit', category: 'Tools', action: handleGasOptimisationAudit, requiredFeatures: [Features.AI_AUDITOR] })
+    if (handleGasOptimisationAudit) cmds.push({ name: 'gas-audit', description: 'Gas optimisation audit', category: 'Tools', action: handleGasOptimisationAudit, requiredFeatures: [Features.AI_AUDITOR]})
     return cmds
   }, [handleSetModel, handleOpenSettings, handleLoadSkills, handleLoadAuditChecklist, handleGasOptimisationAudit, hasAuditorPermission, hasSkillsPermission, setInput])
 

--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -78,7 +78,7 @@ const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
     id: 'deploy',
     label: 'Deploy',
     prompts: [
-      { text: '/deploy: deploy this contract to Sepolia testnet', requiredFeatures: [Features.AI_SOLCODER]},
+      { text: '/deploy this contract to Sepolia testnet', requiredFeatures: [Features.AI_SOLCODER]},
       { text: 'How do I verify my contract on Etherscan?', requiredFeatures: [Features.AI_SOLCODER]},
       { text: 'What network should I use for testing?', requiredFeatures: [Features.AI_SOLCODER]},
     ],
@@ -231,13 +231,13 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
     if (handleLoadAuditChecklist) {
       cmds.push({
         name: 'audit',
-        description: hasAuditorPermission ? 'Audit a contract' : 'Coming soon',
+        description: 'Audit a contract',
         requiredFeatures: [Features.AI_AUDITOR],
         category: 'Tools',
-        action: hasAuditorPermission ? () => {
+        action: () => {
           handleLoadAuditChecklist()
-          setInput(`/${AUDIT_COMMAND_TEXT}: `)
-        } : undefined,
+          setInput('Audit a contract. Ask me which contract file to audit')
+        },
         disabled: !hasAuditorPermission
       })
       cmds.push({
@@ -245,7 +245,8 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
         description: 'Load audit checklist',
         category: 'Tools',
         action: handleLoadAuditChecklist,
-        requiredFeatures: [Features.AI_AUDITOR]
+        requiredFeatures: [Features.AI_AUDITOR],
+        disabled: !hasAuditorPermission
       })
     }
     if (handleGasOptimisationAudit) cmds.push({ name: 'gas-audit', description: 'Gas optimisation audit', category: 'Tools', action: handleGasOptimisationAudit, requiredFeatures: [Features.AI_AUDITOR] })
@@ -396,6 +397,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
   // Contextual hint for a just-inserted command (e.g. "/compile ") so the user
   const activeCommandHint = useMemo(() => {
     const name = getActiveCommandName(input)
+    console.log(name)
     if (!name) return null
     const cmd = AVAILABLE_COMMANDS.find(c => c.name.toLowerCase() === name.toLowerCase())
     return cmd?.hint ?? null

--- a/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/prompt.tsx
@@ -11,6 +11,8 @@ import { AIModel } from '@remix/remix-ai-core'
 import { PromptDefault } from "./promptDefault";
 import { AutocompletePanel, Command } from './AutocompletePanel'
 
+const AUDIT_COMMAND_TEXT = 'audit a contract'
+
 const getSlashWord = (text: string): string | null => {
   // Only detect slash commands at the beginning or after a space
   const lastSpaceSlash = text.lastIndexOf(' /')
@@ -230,6 +232,17 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
     }
     if (handleLoadAuditChecklist) {
       cmds.push({
+        name: 'Audit a contract',
+        description: hasAuditorPermission ? 'Audit a contract' : 'Coming soon',
+        requiredFeatures: [Features.AI_AUDITOR],
+        category: 'Tools',
+        action: hasAuditorPermission ? () => {
+          handleLoadAuditChecklist()
+          setInput(`/${AUDIT_COMMAND_TEXT}: `)
+        } : undefined,
+        disabled: !hasAuditorPermission
+      })
+      cmds.push({
         name: 'Load Security Audit checklist',
         description: 'Load audit checklist',
         category: 'Tools',
@@ -239,7 +252,7 @@ export const PromptArea: React.FC<PromptAreaProps> = ({
     }
     if (handleGasOptimisationAudit) cmds.push({ name: 'Start Gas Optimisation Audit', description: 'Gas optimisation audit', category: 'Tools', action: handleGasOptimisationAudit, requiredFeatures: [Features.AI_AUDITOR]})
     return cmds
-  }, [handleSetModel, handleOpenSettings, handleLoadSkills, handleLoadAuditChecklist, handleGasOptimisationAudit])
+  }, [handleSetModel, handleOpenSettings, handleLoadSkills, handleLoadAuditChecklist, handleGasOptimisationAudit, hasAuditorPermission, hasSkillsPermission, setInput])
 
   // Returns the first required feature the user is missing for a command,
   // or null when the command is fully unlocked.

--- a/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
@@ -89,6 +89,13 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
   const [messages, setMessages] = useState<ChatMessage[]>(props.initialMessages || [])
   const [input, setInput] = useState('')
   const [isStreaming, setIsStreaming] = useState(false)
+  // sendPrompt is memoized without `messages` / `currentConversationId` in its
+  // deps, so its closure goes stale (e.g. after starting a new chat mid-session).
+  // Mirror the live values in a ref so the first-message detection stays correct.
+  const firstPromptStateRef = useRef({ count: (props.initialMessages || []).length, conversationId: props.currentConversationId })
+  useEffect(() => {
+    firstPromptStateRef.current = { count: messages.length, conversationId: props.currentConversationId }
+  }, [messages, props.currentConversationId])
   const [isThinking, setIsThinking] = useState(false)
   const [showModelSelector, setShowModelSelector] = useState(false)
   const [assistantChoice, setAssistantChoice] = useState<'openai' | 'mistralai' | 'anthropic' | 'ollama'>(
@@ -1649,9 +1656,9 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
       }
       setMessages(prev => [...prev, userMsg])
 
-      // If this is the first message in the conversation, optimistically show it in the sidebar
-      if (messages.length === 0 && props.currentConversationId) {
-        props.plugin.onFirstPromptSent(props.currentConversationId, trimmed)
+      const { count: priorMessageCount, conversationId: activeConversationId } = firstPromptStateRef.current
+      if (priorMessageCount === 0 && activeConversationId) {
+        props.plugin.onFirstPromptSent(activeConversationId, trimmed)
       }
 
       /** append streaming chunks helper - clears tool status when content arrives */
@@ -2554,6 +2561,11 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
     </div>
   )
 
+  const currentConversationTitle = props.conversations?.find(c => c.id === props.currentConversationId)?.title
+  const headerChatTitle = (currentConversationTitle && currentConversationTitle !== 'New Conversation')
+    ? currentConversationTitle
+    : messages.find(m => m.role === 'user')?.content
+
   return (
     props.isInitializing ? (
       <div
@@ -2612,7 +2624,7 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
                 showButton={showButton}
                 setShowButton={setShowButton}
                 theme={themeTracker?.name}
-                chatTitle={messages.find(m => m.role === 'user')?.content}
+                chatTitle={headerChatTitle}
                 isAiChatMaximized={isAiChatMaximized}
                 setIsAiChatMaximized={setIsAiChatMaximized}
               />
@@ -2731,7 +2743,7 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
                   showButton={showButton}
                   setShowButton={setShowButton}
                   theme={themeTracker?.name}
-                  chatTitle={messages.find(m => m.role === 'user')?.content}
+                  chatTitle={headerChatTitle}
                   isAiChatMaximized={isAiChatMaximized}
                   setIsAiChatMaximized={setIsAiChatMaximized}
                 />

--- a/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
+++ b/libs/remix-ui/remix-ai-assistant/src/components/remix-ui-remix-ai-assistant.tsx
@@ -51,6 +51,8 @@ export interface RemixUiRemixAiAssistantProps {
 export interface RemixUiRemixAiAssistantHandle {
   /** Programmatically send a prompt to the chat (returns after processing starts) */
   sendChat: (prompt: string, isEditorCodeAnalysis?: boolean) => Promise<void>
+  /** Sends whatever text is currently in the prompt input (no-op if empty) */
+  submitCurrentInput: () => Promise<void>
   /** Clears local chat history (parent receives onMessagesChange([])) */
   clearChat: () => void
   /** Returns current chat history array */
@@ -2369,12 +2371,15 @@ export const RemixUiRemixAiAssistant = React.forwardRef<
       sendChat: async (prompt: string, isEditorCodeAnalysis?: boolean) => {
         await sendPrompt(prompt, isEditorCodeAnalysis)
       },
+      submitCurrentInput: async () => {
+        await handleSend()
+      },
       clearChat: () => {
         setMessages([])
       },
       getHistory: () => messages
     }),
-    [sendPrompt, messages]
+    [sendPrompt, handleSend, messages]
   )
   const chatHistoryRef = useRef<HTMLElement | null>(null)
 

--- a/libs/remix-ui/skills-explorer-modal/src/lib/remix-ui-skills-explorer-modal.tsx
+++ b/libs/remix-ui/skills-explorer-modal/src/lib/remix-ui-skills-explorer-modal.tsx
@@ -222,6 +222,12 @@ export function RemixUiSkillsExplorerModal(props: RemixUiSkillsExplorerModalProp
       }
 
       setUploading(false)
+      try {
+        const summary = `Added the **${parsedSkill.folderName}** skill to \`skills/${parsedSkill.folderName}/\`. I'll apply it automatically when a task matches — or mention its name in your prompt.`
+        await plugin.call('remixaiassistant', 'handleExternalMessage', summary)
+      } catch (e) {
+        // assistant panel unavailable — skill is still added
+      }
       onClose()
     } catch (err) {
       setUploading(false)
@@ -357,6 +363,15 @@ export function RemixUiSkillsExplorerModal(props: RemixUiSkillsExplorerModalProp
       setError(errors.join('\n'))
       setWizardStep('confirm')
     } else {
+      try {
+        const names = skills.filter(s => selectedSkills.has(s.id)).map(s => s.name)
+        const list = names.length ? names.map(n => `**${n}**`).join(', ') : `${selectedSkills.size} skill(s)`
+        const single = names.length === 1
+        const summary = `Added ${list} to \`skills/\`. I'll apply ${single ? 'it' : 'them'} automatically when a task matches — or mention ${single ? 'its name' : 'a skill by name'} in your prompt.`
+        await plugin.call('remixaiassistant', 'handleExternalMessage', summary)
+      } catch (e) {
+        // assistant panel unavailable — skills are still added
+      }
       onClose()
     }
   }

--- a/libs/remix-ui/workspace/src/lib/actions/workspace.ts
+++ b/libs/remix-ui/workspace/src/lib/actions/workspace.ts
@@ -750,19 +750,23 @@ export const loadWorkspacePreset = async (template: WorkspaceTemplate = 'remixDe
           try {
             const uniqueFileName = await createNonClashingNameAsync(file, plugin.fileManager)
             if (file === 'remix.config.json') {
-              const remixConfig = JSON.parse(files[file])
-
+              let remixConfig = JSON.parse(files[file])
+              if (uniqueFileName !== file) {
+                try {
+                  remixConfig = { ...JSON.parse(await plugin.fileManager.readFile(file)), ...remixConfig }
+                } catch (_) { /* existing config unreadable — fall back to the template config */ }
+              }
               remixConfig.project = template
               remixConfig.version = projectVersion
               remixConfig.IDE = window.location.hostname
-              await writeToTargetWorkspace(uniqueFileName, JSON.stringify(remixConfig, null, 2))
+              await writeToTargetWorkspace(file, JSON.stringify(remixConfig, null, 2))
             } else {
               await writeToTargetWorkspace(uniqueFileName, files[file])
-            }
-            if ((uniqueFileName.indexOf('contracts/') >= 0 || uniqueFileName.indexOf('src/') >= 0) && !openPath) {
-              openPath = uniqueFileName
-            } else if (isReadme(uniqueFileName)) {
-              openPath = uniqueFileName
+              if ((uniqueFileName.indexOf('contracts/') >= 0 || uniqueFileName.indexOf('src/') >= 0) && !openPath) {
+                openPath = uniqueFileName
+              } else if (isReadme(uniqueFileName)) {
+                openPath = uniqueFileName
+              }
             }
           } catch (error) {
             console.error(error)


### PR DESCRIPTION
Improved modal for selecting audit checklist
  - Save audit reports into a dedicated audit_reports/ folder
  - Highlight checklists already in the workspace in the Checklist Explorer
  - Add an OK button to the checklist modal that closes it and starts the audit
  - Soften the checklist selection highlight so text stays readable
  - Standardize slash-command names (lowercase/hyphenated) and remove the duplicate /audit
  - Add "Audit a contract" to the new-conversation Tools list
  - Show a contextual hint under the input after inserting a /command:
  - Keep the Code/Explain/Learn/Deploy/Tools shortcuts available mid-conversation via a toggle
  - Generate conversation titles with the AI and show them in the header/history
  - Fix first-message detection so titles generate on first send, not only after refresh
  - Fix duplicate remix.config.json race between MCP and workspace creation