### PR TITLE
fix(editor): avoid false busy state in code helper

### DIFF
--- a/libs/remix-ui/editor/src/lib/tooltipPopOver.tsx
+++ b/libs/remix-ui/editor/src/lib/tooltipPopOver.tsx
@@ -491,30 +491,7 @@ Risk: critical=severe, high=dangerous, medium=warning, low=minor, info=tip, perf
 For "relatedDocs", ONLY use URLs from these trusted domains: ${trustedUrls}
 Use empty array if no relevant trusted docs.`
 
-        // Wrap API call with timeout to detect if AI is busy
-        const apiCallPromise = plugin.call('remixAI', 'basic_prompt', prompt)
-        const busyTimeoutPromise = new Promise((_, reject) => {
-          setTimeout(() => reject(new Error('AI_BUSY')), 5000) // 5 second timeout to detect busy state
-        })
-
-        let response
-        try {
-          response = await Promise.race([apiCallPromise, busyTimeoutPromise])
-        } catch (error: any) {
-          if (error?.message === 'AI_BUSY') {
-            // API is taking too long, likely processing another request
-            setFromCache(false)
-            setData({
-              title: 'RemixAI Assistant Busy',
-              body: 'The RemixAI assistant is currently processing another request. Please try again once it becomes available.',
-              risk: 'low' as const,
-              riskLabel: 'Busy'
-            })
-            setLoading(false)
-            return
-          }
-          throw error // Re-throw other errors
-        }
+        const response = await plugin.call('remixAI', 'basic_prompt', prompt)
 
         // Parse the JSON response
         let parsedData: KeywordData


### PR DESCRIPTION
The Code Helper treated any analysis request that took longer than five seconds as proof that RemixAI was busy. The request kept running in the background, which is why opening the same analysis in RemixAI could still work.

This removes the synthetic busy timeout and lets `basic_prompt` resolve or reject normally. Actual service failures continue through the existing error path.

Validation:
- bundled `tooltipPopOver.tsx` with esbuild to verify TSX syntax
- `git diff --check`

Closes #7494