### PR TITLE
[remix_live] Fix QuickDApp routing false positives for non-DApp files

### DIFF
--- a/libs/remix-ai-core/src/inferencers/deepagent/RemixFilesystemBackend.ts
+++ b/libs/remix-ai-core/src/inferencers/deepagent/RemixFilesystemBackend.ts
@@ -260,15 +260,15 @@ export class RemixFilesystemBackend {
       const isQuickDappCandidatePath = this.isQuickDappCandidatePath(normalizedPath)
       const hasWeb3DappContent = this.hasQuickDappWeb3Content(content)
       const shouldEnforceQuickDappRouting =
-        hasWeb3DappContent ||
+        (isQuickDappCandidatePath && hasWeb3DappContent) ||
         normalizedPath.startsWith('/frontend/') ||
         normalizedPath.startsWith('/dapp/') ||
         /[-_.]dapp\.(html|jsx?|tsx?|css)$/i.test(normalizedPath)
-      const workspaceMismatch = await this.getQuickDappWorkspaceMismatch(normalizedPath, isQuickDappCandidatePath || hasWeb3DappContent)
+      const workspaceMismatch = await this.getQuickDappWorkspaceMismatch(normalizedPath, isQuickDappCandidatePath)
       if (workspaceMismatch) return workspaceMismatch
       const pathMismatch = this.getQuickDappPathMismatch(normalizedPath, shouldEnforceQuickDappRouting)
       if (pathMismatch) return pathMismatch
-      if (isQuickDappCandidatePath || hasWeb3DappContent) {
+      if (isQuickDappCandidatePath) {
         const activeQuickDappContext = currentWorkspaceName
           ? getQuickDappGenerationContext(currentWorkspaceName)
           : undefined

--- a/libs/remix-ai-core/src/remix-mcp-server/prompts/quickDappTheGraphPrompts.ts
+++ b/libs/remix-ai-core/src/remix-mcp-server/prompts/quickDappTheGraphPrompts.ts
@@ -33,6 +33,9 @@ export interface QuickDappContractHandoffPromptContext {
   mode: 'none' | 'single' | 'multiple'
 }
 
+const QUICKDAPP_SCOPE_NOTICE = 'Before listing setup options, briefly state this scope once: "QuickDApp publishes a browser-based static frontend. It does not provide a server runtime or secret storage, and selected contract bindings are fixed after creation."'
+const QUICKDAPP_GRAPH_ONLY_SCOPE_NOTICE = 'Before listing setup options, briefly state this scope once: "QuickDApp publishes a browser-based static frontend. It does not provide a server runtime or secret storage. This Graph-only DApp is read-only."'
+
 const formatContractCandidatesForPrompt = (candidates: QuickDappContractPromptCandidate[]): string[] =>
   candidates.map((contract, index) =>
     `${index + 1}. ${contract.name} at ${contract.address} on chain ${contract.chainId}`
@@ -58,6 +61,7 @@ const buildContractHandoffPrompt = (
       ...contractLines,
       '',
       'STEP 1 - ASK FOR SETUP OPTIONS:',
+      QUICKDAPP_SCOPE_NOTICE,
       `Use ${contract.name} at ${contract.address} on chain ${contract.chainId} unless I explicitly ask to choose another contract.`,
       'Ask me once: "How should I create your DApp?"',
       getLocationLine(isDesktop, false),
@@ -79,6 +83,7 @@ const buildContractHandoffPrompt = (
       ...contractLines,
       '',
       'STEP 1 - ASK FOR SETUP OPTIONS AND CONTRACT:',
+      QUICKDAPP_SCOPE_NOTICE,
       'Ask me once: "How should I create your DApp?"',
       getLocationLine(isDesktop, false),
       '- Base mini-app: No (default) or Yes',
@@ -99,6 +104,7 @@ const buildContractHandoffPrompt = (
     '- none found',
     '',
     'STEP 1 - ASK FOR GRAPH-ONLY SETUP OPTIONS:',
+    QUICKDAPP_GRAPH_ONLY_SCOPE_NOTICE,
     'Ask me once: "How should I create your DApp?"',
     getLocationLine(isDesktop, true),
     '- Base mini-app: No (default) or Yes',

--- a/libs/remix-ui/run-tab-deployed-contracts/src/lib/components/DeployedContractItem.tsx
+++ b/libs/remix-ui/run-tab-deployed-contracts/src/lib/components/DeployedContractItem.tsx
@@ -25,6 +25,7 @@ const highlightedContracts = new Set<string>()
 const QUICKDAPP_SUBGRAPH_SETUP_OPTION = '- Subgraph: None (default) or a .subgraph file path/name'
 const QUICKDAPP_SUBGRAPH_SETUP_RULE = 'Subgraph defaults to None. If I choose to use a .subgraph, ask me for the .subgraph file path/name and pass it to generate_dapp as subgraphFilePath. Do not redirect me to the .subgraph context menu and do not invent graphContext.'
 const QUICKDAPP_GRAPH_CONTEXT_TOOL_ARG = '- subgraphFilePath: include only if I chose a .subgraph file path/name; graphContext: include only if a validated graphContext was already provided by The Graph handoff'
+const QUICKDAPP_SCOPE_NOTICE = 'Before listing setup options, briefly state this scope once: "QuickDApp publishes a browser-based static frontend. It does not provide a server runtime or secret storage, and selected contract bindings are fixed after creation."'
 
 interface DeployedContractItemProps {
   contract: DeployedContract
@@ -423,6 +424,7 @@ export function DeployedContractItem({ contract, index, registerRef, isKebabMenu
         ? `I want to create a DApp frontend inline in the /frontend folder of my current workspace. Follow these steps exactly:
 
 STEP 1 - ASK FOR SETUP OPTIONS:
+${QUICKDAPP_SCOPE_NOTICE}
 Location is fixed to Inline in /frontend for this request. Ask me once for:
 - Base mini-app: No (default) or Yes
 - Design: defaults, style notes, or a Figma URL
@@ -454,6 +456,7 @@ IMPORTANT: In this turn, only ask STEP 1 and then STOP. After my next reply, con
         : `I want to create a DApp frontend. Follow these steps exactly:
 
 STEP 1 - ASK FOR SETUP OPTIONS:
+${QUICKDAPP_SCOPE_NOTICE}
 Ask me once: "How should I create your DApp?"
 - Location: Workspace (default, new dedicated workspace) or Inline (in /frontend folder of current workspace)
 - Base mini-app: No (default) or Yes

--- a/libs/remix-ui/tabs/src/lib/remix-ui-tabs.tsx
+++ b/libs/remix-ui/tabs/src/lib/remix-ui-tabs.tsx
@@ -69,6 +69,7 @@ const initialTabsState: ITabsState = {
 const QUICKDAPP_SUBGRAPH_SETUP_OPTION = '- Subgraph: None (default) or a .subgraph file path/name'
 const QUICKDAPP_SUBGRAPH_SETUP_RULE = 'Subgraph defaults to None. If I choose to use a .subgraph, ask me for the .subgraph file path/name and pass it to generate_dapp as subgraphFilePath. Do not redirect me to the .subgraph context menu and do not invent graphContext.'
 const QUICKDAPP_GRAPH_CONTEXT_TOOL_ARG = '- subgraphFilePath: include only if I chose a .subgraph file path/name; graphContext: include only if a validated graphContext was already provided by The Graph handoff'
+const QUICKDAPP_SCOPE_NOTICE = 'When asking setup options, briefly state this scope once: "QuickDApp publishes a browser-based static frontend. It does not provide a server runtime or secret storage, and selected contract bindings are fixed after creation."'
 
 const tabsReducer = (state: ITabsState, action: ITabsAction) => {
   switch (action.type) {
@@ -664,7 +665,7 @@ export const TabsUI = (props: TabsUIProps) => {
     const isDesktop = isElectron()
 
     // Build the richest context we can — silently, no modals
-    const contextParts: string[] = []
+    const contextParts: string[] = [QUICKDAPP_SCOPE_NOTICE, '']
     let instances: any[] = []
 
     // 1. Gather deployed contracts silently


### PR DESCRIPTION
- Restrict Web3-based QuickDapp routing checks to QuickDApp candidate paths.
- Allow Web3 files under non-QuickDApp paths such as `/backend` and `/scripts`.
- Preserve existing routing and source-root protections for `/src`, `/frontend`, and other QuickDApp paths.
- Add a brief QuickDApp scope notice to all three creation entry points.