### PR TITLE
fix(doc-viewer): improve line spacing for wrapped headings

### DIFF
--- a/apps/doc-viewer/src/app/App.tsx
+++ b/apps/doc-viewer/src/app/App.tsx
@@ -21,7 +21,13 @@ export default function App() {
     <>
       <div className="bg-light p-5">
         <button className="btn btn-sm border mb-2" onClick={edit}>EDIT</button>
-        <ReactMarkdown children={contents} remarkPlugins={[remarkGfm]} />
+        <ReactMarkdown
+          children={contents}
+          remarkPlugins={[remarkGfm]}
+          components={{
+            h1: ({node, ...props}) => <h1 className="lh-sm" {...props} />
+          }}
+        />
       </div>
     </>
   )


### PR DESCRIPTION
## Summary

- apply an explicit line height to level-one Markdown headings
- prevent long wrapped titles from overlapping in the document viewer
- keep the change scoped to rendered Markdown `h1` elements

## Root cause

The Remix theme uses a responsive font size for `h1` elements while also setting a fixed 24px line height. In narrow document viewer panels, long headings wrap onto multiple lines and the fixed line height causes those lines to overlap.

Using the existing Bootstrap `lh-sm` utility gives wrapped headings a line height relative to their font size.

## Testing

- verified that Markdown `h1` elements receive the `lh-sm` class
- ran `git diff --check`

Fixes #7493